### PR TITLE
test: add shared pytest manifest fixtures

### DIFF
--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from typing import Any
 from unittest import mock
 
 from base_cli_adapters.history import build_finished_record
@@ -209,6 +210,8 @@ def run_engine_with_home(args: list[str], base_home: Path, home: Path) -> tuple[
 
 
 class ProjectDiscoveryTests(unittest.TestCase):
+    manifest_factory: Any
+
     # pylint: disable=too-many-statements
     def test_command_protocol_covers_project_command_bridge_records(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -16,48 +16,6 @@ from base_cli_adapters.protocol import loads_records
 from base_projects import engine, project_discovery
 
 
-def write_manifest(project_root: Path, name: str) -> None:
-    project_root.mkdir(parents=True)
-    (project_root / "base_manifest.yaml").write_text(
-        f"project:\n  name: {name}\npython: {{}}\nartifacts: []\n",
-        encoding="utf-8",
-    )
-
-
-def write_shell_manifest(project_root: Path, name: str) -> None:
-    project_root.mkdir(parents=True)
-    (project_root / "base_manifest.yaml").write_text(
-        f"project:\n  name: {name}\nartifacts: []\n",
-        encoding="utf-8",
-    )
-
-
-def write_uv_manifest(project_root: Path, name: str) -> None:
-    project_root.mkdir(parents=True)
-    (project_root / "base_manifest.yaml").write_text(
-        f"project:\n  name: {name}\npython:\n  manager: uv\n",
-        encoding="utf-8",
-    )
-    python_bin = project_root / ".venv" / "bin" / "python"
-    write_ready_python_bin(python_bin)
-
-
-def write_inline_uv_manifest(project_root: Path, name: str) -> None:
-    project_root.mkdir(parents=True)
-    (project_root / "base_manifest.yaml").write_text(
-        f"project:\n  name: {name}\npython: {{manager: uv}}\nartifacts: []\n",
-        encoding="utf-8",
-    )
-    python_bin = project_root / ".venv" / "bin" / "python"
-    write_ready_python_bin(python_bin)
-
-
-def write_ready_python_bin(python_bin: Path) -> None:
-    python_bin.parent.mkdir(parents=True)
-    python_bin.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-    python_bin.chmod(0o755)
-
-
 def write_versioned_python_bin(python_bin: Path, version: str) -> None:
     python_bin.parent.mkdir(parents=True, exist_ok=True)
     python_bin.write_text(f"#!/bin/sh\nprintf '{version}\\n'\n", encoding="utf-8")
@@ -390,8 +348,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
     def test_cached_project_discovery_sorts_projects(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)
-            write_manifest(workspace / "zeta", "zeta")
-            write_manifest(workspace / "alpha", "alpha")
+            self.manifest_factory.write_project(workspace / "zeta", "zeta")
+            self.manifest_factory.write_project(workspace / "alpha", "alpha")
             (workspace / "notes").mkdir()
 
             ctx = mock.Mock()
@@ -404,8 +362,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)
             base_home = workspace / "base"
-            write_manifest(base_home, "base")
-            write_manifest(workspace / "demo", "demo")
+            self.manifest_factory.write_project(base_home, "base")
+            self.manifest_factory.write_project(workspace / "demo", "demo")
 
             status, stdout, stderr = run_engine(["list"], base_home)
 
@@ -419,7 +377,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             workspace = Path(tmpdir) / "custom"
             base_home = Path(tmpdir) / "base"
             base_home.mkdir()
-            write_manifest(workspace / "demo", "demo")
+            self.manifest_factory.write_project(workspace / "demo", "demo")
 
             status, stdout, stderr = run_engine(["list", "--workspace", str(workspace)], base_home)
 
@@ -433,7 +391,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             workspace = root / "configured-workspace"
             base_home = root / "homebrew" / "base" / "libexec"
             base_home.mkdir(parents=True)
-            write_manifest(workspace / "demo", "demo")
+            self.manifest_factory.write_project(workspace / "demo", "demo")
 
             status, stdout, stderr = run_engine(
                 ["list"],
@@ -452,8 +410,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
             explicit_workspace = root / "explicit"
             base_home = root / "homebrew" / "base" / "libexec"
             base_home.mkdir(parents=True)
-            write_manifest(configured_workspace / "configured-demo", "configured-demo")
-            write_manifest(explicit_workspace / "explicit-demo", "explicit-demo")
+            self.manifest_factory.write_project(configured_workspace / "configured-demo", "configured-demo")
+            self.manifest_factory.write_project(explicit_workspace / "explicit-demo", "explicit-demo")
 
             status, stdout, stderr = run_engine(
                 ["list", "--workspace", str(explicit_workspace)],
@@ -470,7 +428,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             workspace = Path(tmpdir) / "custom"
             base_home = Path(tmpdir) / "base"
             base_home.mkdir()
-            write_manifest(workspace / "demo", "demo")
+            self.manifest_factory.write_project(workspace / "demo", "demo")
 
             status, stdout, stderr = run_engine(
                 ["list", "--workspace", str(workspace), "--format", "json"],
@@ -486,7 +444,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             workspace = Path(tmpdir) / "custom"
             base_home = Path(tmpdir) / "base"
             base_home.mkdir()
-            write_manifest(workspace / "demo", "demo")
+            self.manifest_factory.write_project(workspace / "demo", "demo")
 
             status, stdout, stderr = run_engine(
                 ["list", "--workspace", str(workspace), "--format", "csv"],
@@ -504,7 +462,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             workspace = Path(tmpdir) / "custom"
             base_home = Path(tmpdir) / "base"
             base_home.mkdir()
-            write_manifest(workspace / "demo", "demo")
+            self.manifest_factory.write_project(workspace / "demo", "demo")
 
             status, stdout, stderr = run_engine(
                 ["list", "--workspace", str(workspace), "--format", "yaml"],
@@ -523,10 +481,10 @@ class ProjectDiscoveryTests(unittest.TestCase):
             base_home = root / "base"
             home.mkdir()
             base_home.mkdir()
-            write_manifest(workspace / "base", "base")
-            write_manifest(workspace / "demo", "demo")
+            self.manifest_factory.write_project(workspace / "base", "base")
+            self.manifest_factory.write_project(workspace / "demo", "demo")
             python_bin = home / ".base.d" / "base" / ".venv" / "bin" / "python"
-            write_ready_python_bin(python_bin)
+            self.manifest_factory.write_ready_python_bin(python_bin)
             write_last_check(home, "base", "2026-06-17T14:30:00Z")
 
             status, stdout, stderr = invoke_engine(["status", "--workspace", str(workspace)], base_home, home)
@@ -546,7 +504,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             base_home = root / "base"
             home.mkdir()
             base_home.mkdir()
-            write_uv_manifest(workspace / "bankbuddy", "bankbuddy")
+            self.manifest_factory.write_python(workspace / "bankbuddy", "bankbuddy")
 
             status, stdout, stderr = invoke_engine(["status", "--workspace", str(workspace)], base_home, home)
 
@@ -564,7 +522,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             home.mkdir()
             base_home.mkdir()
             project_root = workspace / "shell-only"
-            write_shell_manifest(project_root, "shell-only")
+            self.manifest_factory.write_shell(project_root, "shell-only")
 
             status, stdout, stderr = invoke_engine(
                 ["status", "--workspace", str(workspace), "--format", "json"],
@@ -589,7 +547,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             home.mkdir()
             base_home.mkdir()
             project_root = workspace / "shell-only"
-            write_shell_manifest(project_root, "shell-only")
+            self.manifest_factory.write_shell(project_root, "shell-only")
 
             status, stdout, stderr = invoke_engine(["status", "--workspace", str(workspace)], base_home, home)
 
@@ -615,7 +573,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             base_home = root / "base"
             home.mkdir()
             base_home.mkdir()
-            write_manifest(workspace / "demo", "demo")
+            self.manifest_factory.write_project(workspace / "demo", "demo")
             write_last_check(home, "demo", "2026-06-17T14:30:00Z", status="error")
 
             status, stdout, stderr = invoke_engine(
@@ -651,8 +609,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
             workspace = root / "workspace"
             base_home = workspace / "base"
             home.mkdir()
-            write_manifest(base_home, "base")
-            write_manifest(workspace / "demo", "demo")
+            self.manifest_factory.write_project(base_home, "base")
+            self.manifest_factory.write_project(workspace / "demo", "demo")
 
             status, stdout, stderr = invoke_engine(
                 ["--debug", "status", "--format", "json"],
@@ -679,7 +637,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             project_root = workspace / "bankbuddy"
             home.mkdir()
             base_home.mkdir()
-            write_uv_manifest(project_root, "bankbuddy")
+            self.manifest_factory.write_python(project_root, "bankbuddy")
             python_bin = project_root / ".venv" / "bin" / "python"
             write_versioned_python_bin(python_bin, "3.12")
 
@@ -706,7 +664,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             base_home = root / "base"
             home.mkdir()
             base_home.mkdir()
-            write_manifest(workspace / "demo", "demo")
+            self.manifest_factory.write_project(workspace / "demo", "demo")
             broken_root = workspace / "broken"
             broken_root.mkdir(parents=True)
             (broken_root / "base_manifest.yaml").write_text("project: [", encoding="utf-8")
@@ -727,7 +685,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             base_home = root / "base"
             home.mkdir()
             base_home.mkdir()
-            write_manifest(workspace / "demo", "demo")
+            self.manifest_factory.write_project(workspace / "demo", "demo")
 
             with mock.patch(
                 "base_projects.project_discovery.read_project", wraps=project_discovery.read_project
@@ -753,7 +711,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             home.mkdir()
             base_home.mkdir()
             project_root = workspace / "demo"
-            write_manifest(project_root, "demo")
+            self.manifest_factory.write_project(project_root, "demo")
 
             with mock.patch(
                 "base_projects.project_discovery.read_project", wraps=project_discovery.read_project
@@ -779,7 +737,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             workspace = Path(tmpdir)
             base_home = workspace / "base"
             base_home.mkdir()
-            write_manifest(workspace / "demo", "demo")
+            self.manifest_factory.write_project(workspace / "demo", "demo")
 
             with mock.patch("base_projects.project_discovery.write_project_cache") as write_cache:
                 status, stdout, stderr = run_engine(
@@ -808,7 +766,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             base_home = workspace / "base"
             base_home.mkdir()
             project_root = workspace / "demo"
-            write_manifest(project_root, "demo")
+            self.manifest_factory.write_project(project_root, "demo")
 
             status, stdout, stderr = run_engine(["resolve", "demo"], base_home)
 
@@ -826,7 +784,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             base_home = workspace / "base"
             base_home.mkdir()
             project_root = workspace / "demo"
-            write_manifest(project_root, "demo")
+            self.manifest_factory.write_project(project_root, "demo")
             outside = workspace / "outside"
             outside.mkdir()
             captured: list[tuple[object, ...]] = []
@@ -854,7 +812,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             base_home = workspace / "base"
             base_home.mkdir()
             project_root = workspace / "demo"
-            write_inline_uv_manifest(project_root, "demo")
+            self.manifest_factory.write_inline_python(project_root, "demo")
 
             status, stdout, stderr = run_engine(["resolve", "demo"], base_home)
 
@@ -873,7 +831,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             base_home.mkdir()
             project_root = root / "active" / "demo"
             manifest_path = project_root / "base_manifest.yaml"
-            write_manifest(project_root, "demo")
+            self.manifest_factory.write_project(project_root, "demo")
 
             with mock.patch(
                 "base_projects.engine.discover_projects_cached",
@@ -910,8 +868,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
             active_root = root / "active" / "demo"
             explicit_workspace = root / "explicit"
             explicit_root = explicit_workspace / "demo"
-            write_manifest(active_root, "demo")
-            write_manifest(explicit_root, "demo")
+            self.manifest_factory.write_project(active_root, "demo")
+            self.manifest_factory.write_project(explicit_root, "demo")
 
             status, stdout, stderr = run_engine(
                 ["resolve", "demo", "--workspace", str(explicit_workspace)],
@@ -942,7 +900,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             base_home = root / "base"
             base_home.mkdir()
             project_root = root / "active" / "demo"
-            write_manifest(project_root, "other")
+            self.manifest_factory.write_project(project_root, "other")
 
             status, _stdout, stderr = run_engine(
                 ["resolve", "demo"],
@@ -963,7 +921,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             base_home = root / "homebrew" / "base" / "libexec"
             base_home.mkdir(parents=True)
             project_root = workspace / "demo"
-            write_manifest(project_root, "demo")
+            self.manifest_factory.write_project(project_root, "demo")
 
             status, stdout, stderr = run_engine(
                 ["resolve", "demo"],
@@ -990,8 +948,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
             workspace = Path(tmpdir)
             base_home = workspace / "base"
             other_base = workspace / "base-worktree"
-            write_manifest(base_home, "base")
-            write_manifest(other_base, "base")
+            self.manifest_factory.write_project(base_home, "base")
+            self.manifest_factory.write_project(other_base, "base")
 
             status, stdout, stderr = run_engine(["resolve", "base"], base_home)
 
@@ -1009,8 +967,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
             workspace = root / "configured-workspace"
             base_home = root / "homebrew" / "base" / "libexec"
             other_base = workspace / "base"
-            write_manifest(base_home, "base")
-            write_manifest(other_base, "base")
+            self.manifest_factory.write_project(base_home, "base")
+            self.manifest_factory.write_project(other_base, "base")
 
             status, stdout, stderr = run_engine(
                 ["resolve", "base"],
@@ -1180,7 +1138,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             workspace = Path(tmpdir)
             base_home = workspace / "base"
             base_home.mkdir()
-            write_manifest(workspace / "demo", "demo")
+            self.manifest_factory.write_project(workspace / "demo", "demo")
 
             status, stdout, stderr = run_engine(["activation-sources", "demo"], base_home)
 
@@ -1209,7 +1167,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             workspace = Path(tmpdir)
             base_home = workspace / "base"
             base_home.mkdir()
-            write_manifest(workspace / "demo", "demo")
+            self.manifest_factory.write_project(workspace / "demo", "demo")
 
             status, stdout, stderr = run_engine(["resolve", "demo"], base_home)
 
@@ -1284,7 +1242,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             workspace = Path(tmpdir)
             base_home = workspace / "base"
             base_home.mkdir()
-            write_manifest(workspace / "demo", "demo")
+            self.manifest_factory.write_project(workspace / "demo", "demo")
 
             status, _stdout, stderr = run_engine(["test-command", "demo"], base_home)
 
@@ -1523,7 +1481,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             workspace = Path(tmpdir)
             base_home = workspace / "base"
             base_home.mkdir()
-            write_manifest(workspace / "demo", "demo")
+            self.manifest_factory.write_project(workspace / "demo", "demo")
 
             status, _stdout, stderr = run_engine(["demo-script", "demo"], base_home)
 
@@ -1748,7 +1706,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             workspace = Path(tmpdir)
             base_home = workspace / "base"
             base_home.mkdir()
-            write_manifest(workspace / "demo", "demo")
+            self.manifest_factory.write_project(workspace / "demo", "demo")
 
             status, _stdout, stderr = run_engine(["run-commands", "demo"], base_home)
 
@@ -1762,7 +1720,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             base_home.mkdir()
             project_root = workspace / "demo"
             manifest_path = project_root / "base_manifest.yaml"
-            write_manifest(project_root, "demo")
+            self.manifest_factory.write_project(project_root, "demo")
 
             status, stdout, stderr = run_engine(["manifest", str(manifest_path)], base_home)
 
@@ -1787,7 +1745,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             base_home.mkdir()
             project_root = workspace / "demo"
             nested = project_root / "docs" / "notes"
-            write_manifest(project_root, "demo")
+            self.manifest_factory.write_project(project_root, "demo")
             nested.mkdir(parents=True)
 
             old_cwd = Path.cwd()
@@ -1847,8 +1805,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
     def test_cached_project_discovery_rejects_duplicate_project_names(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)
-            write_manifest(workspace / "one", "demo")
-            write_manifest(workspace / "two", "demo")
+            self.manifest_factory.write_project(workspace / "one", "demo")
+            self.manifest_factory.write_project(workspace / "two", "demo")
 
             with self.assertRaisesRegex(engine.ProjectDiscoveryError, "Duplicate project names"):
                 ctx = mock.Mock()

--- a/cli/python/base_trust/tests/test_engine.py
+++ b/cli/python/base_trust/tests/test_engine.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from typing import Any
 from unittest import mock
 
 from base_cli_adapters.history import build_finished_record
@@ -52,6 +53,8 @@ def init_git_repo(project_root: Path, origin: str) -> str:
 
 
 class ManifestCommandTrustTests(unittest.TestCase):
+    manifest_factory: Any
+
     def test_require_explicit_manifest_populates_history_project_metadata(self) -> None:
         from base_trust import engine
 

--- a/cli/python/base_trust/tests/test_engine.py
+++ b/cli/python/base_trust/tests/test_engine.py
@@ -15,50 +15,6 @@ from base_cli_adapters.history import build_finished_record
 from base_cli.testing import invoke
 
 
-def write_manifest(project_root: Path, name: str = "demo", command: str | None = "pytest tests/") -> Path:
-    project_root.mkdir(parents=True, exist_ok=True)
-    manifest_path = project_root / "base_manifest.yaml"
-    lines = ["project:", f"  name: {name}"]
-    if command is not None:
-        lines.extend(["test:", f"  command: {command}"])
-    lines.append("artifacts: []")
-    manifest_path.write_text(
-        "\n".join(lines) + "\n",
-        encoding="utf-8",
-    )
-    return manifest_path
-
-
-def write_all_command_surfaces_manifest(project_root: Path, name: str = "demo") -> Path:
-    project_root.mkdir(parents=True, exist_ok=True)
-    manifest_path = project_root / "base_manifest.yaml"
-    manifest_path.write_text(
-        "\n".join(
-            [
-                "project:",
-                f"  name: {name}",
-                "test:",
-                "  command: pytest tests/",
-                "commands:",
-                "  lint: ruff check .",
-                "build:",
-                "  targets:",
-                "    api:",
-                "      command: go build ./...",
-                "demo:",
-                "  script: demo.sh",
-                "activate:",
-                "  source:",
-                "    - .base/activate.sh",
-                "artifacts: []",
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-    return manifest_path
-
-
 def init_git_repo(project_root: Path, origin: str) -> str:
     subprocess.run(["git", "init"], cwd=project_root, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     subprocess.run(
@@ -103,7 +59,7 @@ class ManifestCommandTrustTests(unittest.TestCase):
             root = Path(tmpdir)
             home = root / "home"
             project_root = root / "work" / "demo"
-            manifest_path = write_manifest(project_root)
+            manifest_path = self.manifest_factory.write(project_root)
             outside = root / "outside"
             outside.mkdir()
             captured: list[tuple[object, ...]] = []
@@ -159,7 +115,7 @@ class ManifestCommandTrustTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "work" / "demo"
-            manifest_path = write_manifest(project_root)
+            manifest_path = self.manifest_factory.write(project_root)
             head = init_git_repo(project_root, "https://user:secret@github.com/example/demo.git")
             expected_digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
 
@@ -179,8 +135,8 @@ class ManifestCommandTrustTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            all_surfaces = write_all_command_surfaces_manifest(root / "all")
-            no_surfaces = write_manifest(root / "none", name="none", command=None)
+            all_surfaces = self.manifest_factory.write_command_surfaces(root / "all")
+            no_surfaces = self.manifest_factory.write(root / "none", name="none", test_command=None)
 
             self.assertEqual(
                 engine.manifest_command_surfaces(all_surfaces),
@@ -195,7 +151,7 @@ class ManifestCommandTrustTests(unittest.TestCase):
             root = Path(tmpdir)
             home = root / "home"
             project_root = root / "work" / "demo"
-            manifest_path = write_manifest(project_root)
+            manifest_path = self.manifest_factory.write(project_root)
             identity = engine.compute_trust_identity_for_manifest(manifest_path)
             store = engine.ManifestCommandTrustStore(home=home)
 
@@ -223,7 +179,7 @@ class ManifestCommandTrustTests(unittest.TestCase):
             root = Path(tmpdir)
             home = root / "home"
             workspace = root / "work"
-            manifest_path = write_manifest(workspace / "demo")
+            manifest_path = self.manifest_factory.write(workspace / "demo")
             expected_digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
 
             result = invoke(
@@ -252,10 +208,10 @@ class ManifestCommandTrustTests(unittest.TestCase):
             root = Path(tmpdir)
             home = root / "home"
             workspace = root / "work"
-            write_manifest(workspace / "fresh", name="fresh")
-            allowed_manifest = write_manifest(workspace / "allowed", name="allowed")
-            changed_manifest = write_manifest(workspace / "changed", name="changed")
-            write_manifest(workspace / "metadata-only", name="metadata-only", command=None)
+            self.manifest_factory.write(workspace / "fresh", name="fresh")
+            allowed_manifest = self.manifest_factory.write(workspace / "allowed", name="allowed")
+            changed_manifest = self.manifest_factory.write(workspace / "changed", name="changed")
+            self.manifest_factory.write(workspace / "metadata-only", name="metadata-only", test_command=None)
             store = engine.ManifestCommandTrustStore(home=home)
             store.allow(
                 engine.compute_trust_identity_for_manifest(allowed_manifest),
@@ -311,7 +267,7 @@ class ManifestCommandTrustTests(unittest.TestCase):
             root = Path(tmpdir)
             home = root / "home"
             workspace = root / "work"
-            write_manifest(workspace / "docs", name="docs", command=None)
+            self.manifest_factory.write(workspace / "docs", name="docs", test_command=None)
 
             result = invoke(
                 engine.app,
@@ -344,9 +300,9 @@ class ManifestCommandTrustTests(unittest.TestCase):
             workspace = root / "configured-workspace"
             base_home = root / "installed-base"
             active_root = root / "active"
-            write_manifest(workspace / "scoped", name="scoped")
-            write_manifest(base_home, name="base")
-            active_manifest = write_manifest(active_root, name="active")
+            self.manifest_factory.write(workspace / "scoped", name="scoped")
+            self.manifest_factory.write(base_home, name="base")
+            active_manifest = self.manifest_factory.write(active_root, name="active")
             config_path = home / ".base.d" / "config.yaml"
             config_path.parent.mkdir(parents=True)
             config_path.write_text(f"workspace:\n  root: {workspace}\n", encoding="utf-8")
@@ -396,7 +352,7 @@ class ManifestCommandTrustTests(unittest.TestCase):
             root = Path(tmpdir)
             home = root / "home"
             workspace = root / "work"
-            manifest_path = write_manifest(workspace / "demo")
+            manifest_path = self.manifest_factory.write(workspace / "demo")
             expected_digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
 
             stdout = io.StringIO()
@@ -429,7 +385,7 @@ class ManifestCommandTrustTests(unittest.TestCase):
             root = Path(tmpdir)
             home = root / "home"
             workspace = root / "work"
-            manifest_path = write_all_command_surfaces_manifest(workspace / "demo")
+            manifest_path = self.manifest_factory.write_command_surfaces(workspace / "demo")
 
             with mock.patch("base_cli.is_terminal", return_value=True):
                 result = invoke(
@@ -455,7 +411,7 @@ class ManifestCommandTrustTests(unittest.TestCase):
             root = Path(tmpdir)
             home = root / "home"
             workspace = root / "work"
-            manifest_path = write_manifest(workspace / "demo")
+            manifest_path = self.manifest_factory.write(workspace / "demo")
             identity = engine.compute_trust_identity_for_manifest(manifest_path)
             engine.ManifestCommandTrustStore(home=home).allow(identity, base_version="9.9.9")
             manifest_path.write_text(
@@ -489,7 +445,7 @@ class ManifestCommandTrustTests(unittest.TestCase):
             root = Path(tmpdir)
             home = root / "home"
             workspace = root / "work"
-            manifest_path = write_manifest(workspace / "demo")
+            manifest_path = self.manifest_factory.write(workspace / "demo")
             identity = engine.compute_trust_identity_for_manifest(manifest_path)
             engine.ManifestCommandTrustStore(home=home).allow(identity, base_version="9.9.9")
 
@@ -511,7 +467,7 @@ class ManifestCommandTrustTests(unittest.TestCase):
             root = Path(tmpdir)
             home = root / "home"
             workspace = root / "work"
-            write_manifest(workspace / "demo")
+            self.manifest_factory.write(workspace / "demo")
 
             stdout = io.StringIO()
             stderr = io.StringIO()
@@ -549,7 +505,7 @@ class ManifestCommandTrustTests(unittest.TestCase):
             root = Path(tmpdir)
             home = root / "home"
             workspace = root / "work"
-            manifest_path = write_manifest(workspace / "demo")
+            manifest_path = self.manifest_factory.write(workspace / "demo")
             expected_digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
             env = {"BASE_HOME": str(workspace / "base")}
 

--- a/conftest.py
+++ b/conftest.py
@@ -11,15 +11,15 @@ class ManifestFactory:
     """Build the small manifest variants used by package-level tests."""
 
     @staticmethod
-    def _write(project_root: Path, lines: list[str]) -> Path:
-        project_root.mkdir(parents=True, exist_ok=True)
-        manifest_path = project_root / "base_manifest.yaml"
+    def _write(root: Path, lines: list[str]) -> Path:
+        root.mkdir(parents=True, exist_ok=True)
+        manifest_path = root / "base_manifest.yaml"
         manifest_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
         return manifest_path
 
     def write(
         self,
-        project_root: Path,
+        root: Path,
         name: str = "demo",
         *,
         test_command: str | None = "pytest tests/",
@@ -30,46 +30,46 @@ class ManifestFactory:
         if test_command is not None:
             lines.extend(["test:", f"  command: {test_command}"])
         lines.append("artifacts: []")
-        return self._write(project_root, lines)
+        return self._write(root, lines)
 
-    def write_project(self, project_root: Path, name: str = "demo") -> Path:
+    def write_project(self, root: Path, name: str = "demo") -> Path:
         """Write a minimal Python-project manifest."""
 
         return self._write(
-            project_root,
+            root,
             ["project:", f"  name: {name}", "python: {}", "artifacts: []"],
         )
 
-    def write_shell(self, project_root: Path, name: str = "demo") -> Path:
+    def write_shell(self, root: Path, name: str = "demo") -> Path:
         """Write a minimal shell-project manifest."""
 
-        return self._write(project_root, ["project:", f"  name: {name}", "artifacts: []"])
+        return self._write(root, ["project:", f"  name: {name}", "artifacts: []"])
 
-    def write_python(self, project_root: Path, name: str = "demo") -> Path:
+    def write_python(self, root: Path, name: str = "demo") -> Path:
         """Write a uv-managed Python-project manifest with a ready venv."""
 
         manifest_path = self._write(
-            project_root,
+            root,
             ["project:", f"  name: {name}", "python:", "  manager: uv"],
         )
-        self.write_ready_python_bin(project_root / ".venv" / "bin" / "python")
+        self.write_ready_python_bin(root / ".venv" / "bin" / "python")
         return manifest_path
 
-    def write_inline_python(self, project_root: Path, name: str = "demo") -> Path:
+    def write_inline_python(self, root: Path, name: str = "demo") -> Path:
         """Write an inline-uv Python-project manifest with a ready venv."""
 
         manifest_path = self._write(
-            project_root,
+            root,
             ["project:", f"  name: {name}", "python: {manager: uv}", "artifacts: []"],
         )
-        self.write_ready_python_bin(project_root / ".venv" / "bin" / "python")
+        self.write_ready_python_bin(root / ".venv" / "bin" / "python")
         return manifest_path
 
-    def write_command_surfaces(self, project_root: Path, name: str = "demo") -> Path:
+    def write_command_surfaces(self, root: Path, name: str = "demo") -> Path:
         """Write a manifest containing every executable command surface."""
 
         return self._write(
-            project_root,
+            root,
             [
                 "project:",
                 f"  name: {name}",
@@ -97,15 +97,15 @@ class ManifestFactory:
         python_bin.chmod(0o755)
 
 
-@pytest.fixture
-def manifest_factory() -> ManifestFactory:
+@pytest.fixture(name="manifest_factory")
+def manifest_factory_fixture() -> ManifestFactory:
     """Return shared manifest writers for pytest-style tests."""
 
     return ManifestFactory()
 
 
-@pytest.fixture
-def project_root(tmp_path: Path) -> Path:
+@pytest.fixture(name="project_root")
+def project_root_fixture(tmp_path: Path) -> Path:
     """Return an isolated project root for tests that need one project."""
 
     return tmp_path / "project"

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,120 @@
+"""Shared pytest setup helpers for Base's Python tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class ManifestFactory:
+    """Build the small manifest variants used by package-level tests."""
+
+    @staticmethod
+    def _write(project_root: Path, lines: list[str]) -> Path:
+        project_root.mkdir(parents=True, exist_ok=True)
+        manifest_path = project_root / "base_manifest.yaml"
+        manifest_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return manifest_path
+
+    def write(
+        self,
+        project_root: Path,
+        name: str = "demo",
+        *,
+        test_command: str | None = "pytest tests/",
+    ) -> Path:
+        """Write the standard manifest used by command-trust tests."""
+
+        lines = ["project:", f"  name: {name}"]
+        if test_command is not None:
+            lines.extend(["test:", f"  command: {test_command}"])
+        lines.append("artifacts: []")
+        return self._write(project_root, lines)
+
+    def write_project(self, project_root: Path, name: str = "demo") -> Path:
+        """Write a minimal Python-project manifest."""
+
+        return self._write(
+            project_root,
+            ["project:", f"  name: {name}", "python: {}", "artifacts: []"],
+        )
+
+    def write_shell(self, project_root: Path, name: str = "demo") -> Path:
+        """Write a minimal shell-project manifest."""
+
+        return self._write(project_root, ["project:", f"  name: {name}", "artifacts: []"])
+
+    def write_python(self, project_root: Path, name: str = "demo") -> Path:
+        """Write a uv-managed Python-project manifest with a ready venv."""
+
+        manifest_path = self._write(
+            project_root,
+            ["project:", f"  name: {name}", "python:", "  manager: uv"],
+        )
+        self.write_ready_python_bin(project_root / ".venv" / "bin" / "python")
+        return manifest_path
+
+    def write_inline_python(self, project_root: Path, name: str = "demo") -> Path:
+        """Write an inline-uv Python-project manifest with a ready venv."""
+
+        manifest_path = self._write(
+            project_root,
+            ["project:", f"  name: {name}", "python: {manager: uv}", "artifacts: []"],
+        )
+        self.write_ready_python_bin(project_root / ".venv" / "bin" / "python")
+        return manifest_path
+
+    def write_command_surfaces(self, project_root: Path, name: str = "demo") -> Path:
+        """Write a manifest containing every executable command surface."""
+
+        return self._write(
+            project_root,
+            [
+                "project:",
+                f"  name: {name}",
+                "test:",
+                "  command: pytest tests/",
+                "commands:",
+                "  lint: ruff check .",
+                "build:",
+                "  targets:",
+                "    api:",
+                "      command: go build ./...",
+                "demo:",
+                "  script: demo.sh",
+                "activate:",
+                "  source:",
+                "    - .base/activate.sh",
+                "artifacts: []",
+            ],
+        )
+
+    @staticmethod
+    def write_ready_python_bin(python_bin: Path) -> None:
+        python_bin.parent.mkdir(parents=True, exist_ok=True)
+        python_bin.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        python_bin.chmod(0o755)
+
+
+@pytest.fixture
+def manifest_factory() -> ManifestFactory:
+    """Return shared manifest writers for pytest-style tests."""
+
+    return ManifestFactory()
+
+
+@pytest.fixture
+def project_root(tmp_path: Path) -> Path:
+    """Return an isolated project root for tests that need one project."""
+
+    return tmp_path / "project"
+
+
+@pytest.fixture(autouse=True)
+def attach_shared_test_fixtures(request: pytest.FixtureRequest, manifest_factory: ManifestFactory) -> None:
+    """Expose fixture values on legacy unittest test cases during migration."""
+
+    instance = getattr(request.node, "instance", None)
+    if instance is not None:
+        instance.manifest_factory = manifest_factory

--- a/tests/test_shared_fixtures.py
+++ b/tests/test_shared_fixtures.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+def test_project_root_fixture_is_isolated(project_root: Path) -> None:
+    assert project_root.name == "project"
+    assert not project_root.exists()
+
+
+def test_manifest_factory_writes_standard_manifest(project_root: Path, manifest_factory) -> None:
+    manifest_path = manifest_factory.write(project_root)
+
+    assert manifest_path == project_root / "base_manifest.yaml"
+    assert manifest_path.read_text(encoding="utf-8") == (
+        "project:\n  name: demo\ntest:\n  command: pytest tests/\nartifacts: []\n"
+    )
+
+
+def test_manifest_factory_writes_command_surfaces(project_root: Path, manifest_factory) -> None:
+    manifest_path = manifest_factory.write_command_surfaces(project_root)
+
+    manifest = manifest_path.read_text(encoding="utf-8")
+    assert "commands:" in manifest
+    assert "build:" in manifest
+    assert "demo:" in manifest
+    assert "activate:" in manifest


### PR DESCRIPTION
## Summary

- add repository-wide pytest fixtures for isolated project roots and common manifest variants
- migrate duplicated manifest setup in base_trust and base_projects engine tests
- add direct fixture smoke coverage

This is the first incremental slice of #1912. The remaining base_pr_policy and base_release migrations are intentionally left for follow-up work.

## Validation

- `BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python PYTHONPATH=/Users/rameshhp/work/base-cli/lib/python:lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q tests/test_shared_fixtures.py cli/python/base_trust/tests/test_engine.py cli/python/base_projects/tests/test_engine.py`
- `TZ=UTC BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python env -u BASE_HOME ./bin/base-test`
- `git diff --check`

The default local timezone is Asia/Kolkata, while the existing host-timezone history test assumes UTC; the full harness passes with `TZ=UTC`.

## AI context

No update needed: this is test-only infrastructure with no product behavior or architecture change.

## Demo Impact

None.