### PR TITLE
Suppress redundant pyproject dependency warning for uv-managed projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and Base versions are tracked in the repo-root `VERSION` file.
 - Batched branch and worktree GitHub PR-state verification through one
   paginated REST read per prune invocation, avoiding one GraphQL query per
   branch and failing the scan closed when that read is unavailable.
+- Suppressed the redundant `BASE-P142` `pyproject.toml` dependency warning for
+  projects that explicitly delegate Python dependency synchronization to uv.
 
 ## [1.8.0] - 2026-08-15
 

--- a/cli/python/base_setup/pyproject.py
+++ b/cli/python/base_setup/pyproject.py
@@ -30,7 +30,7 @@ def check_pyproject(manifest: BaseManifest) -> tuple[ArtifactCheck, ...]:
         return (pyproject_readability_warning(pyproject_path, error),)
 
     checks: list[ArtifactCheck] = [pyproject_metadata_check(data)]
-    if has_dependency_metadata(data):
+    if has_dependency_metadata(data) and manifest.python.manager != "uv":
         checks.append(pyproject_dependency_warning())
     if has_tool_base(data):
         checks.append(pyproject_tool_base_warning())

--- a/cli/python/base_setup/tests/test_diagnostics.py
+++ b/cli/python/base_setup/tests/test_diagnostics.py
@@ -813,3 +813,38 @@ class IdeDiagnosticsTests(unittest.TestCase):
         self.assertIn("github.copilot", error_output)
         self.assertIn("Cursor setting: editor.formatOnSave", error_output)
         self.assertIn("Fix:", error_output)
+
+
+def test_check_json_omits_redundant_pyproject_warning_for_uv_project() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        manifest_path = root / "base_manifest.yaml"
+        manifest_path.write_text(
+            "project:\n  name: demo\npython:\n  manager: uv\nartifacts: []\n",
+            encoding="utf-8",
+        )
+        (root / "pyproject.toml").write_text(
+            "[project]\nname = \"demo-python\"\ndependencies = [\"requests\"]\n",
+            encoding="utf-8",
+        )
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = read_manifest(manifest_path)
+
+        with redirect_stdout(io.StringIO()) as stdout:
+            status = engine.check_manifest(
+                fake_context(),
+                default_manifest,
+                manifest,
+                output_format="json",
+            )
+
+    payload = json.loads(stdout.getvalue())
+    finding_ids = [check["id"] for check in payload["checks"]]
+    assert status == 0
+    assert "BASE-P142" not in finding_ids
+    assert "BASE-P150" in finding_ids

--- a/cli/python/base_setup/tests/test_pyproject.py
+++ b/cli/python/base_setup/tests/test_pyproject.py
@@ -5,15 +5,17 @@ import unittest
 from pathlib import Path
 
 from base_setup.manifest import BaseManifest
+from base_setup.manifest_model import PythonConfig
 from base_setup.pyproject import check_pyproject
 
 
-def manifest_at(path: Path) -> BaseManifest:
+def manifest_at(path: Path, *, python_manager: str | None = None) -> BaseManifest:
     return BaseManifest(
         path=path,
         project_name="demo",
         brewfile=None,
         artifacts=(),
+        python=PythonConfig(manager=python_manager),
     )
 
 
@@ -94,6 +96,20 @@ class PyprojectDiagnosticsTests(unittest.TestCase):
         self.assertIn("dependency metadata", dependency_check.message)
         self.assertNotIn("secret", dependency_check.message)
         self.assertNotIn("example.invalid", dependency_check.message)
+
+    def test_dependency_metadata_is_managed_by_explicit_uv_project_manager(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "pyproject.toml").write_text(
+                "[project]\nname = \"demo\"\ndependencies = [\"requests\"]\n",
+                encoding="utf-8",
+            )
+            manifest = manifest_at(root / "base_manifest.yaml", python_manager="uv")
+
+            checks = check_pyproject(manifest)
+
+        self.assertEqual([check.finding_id for check in checks], ["BASE-P140"])
+        self.assertTrue(checks[0].ok)
 
     def test_tool_base_warns_as_unsupported(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -173,7 +173,7 @@ Doctor commands use the same diagnostic item fields. The top-level
 | `BASE-P132` | IDE CLI PATH status |
 | `BASE-P140` | `pyproject.toml` presence and metadata summary |
 | `BASE-P141` | `pyproject.toml` readability |
-| `BASE-P142` | `pyproject.toml` dependency metadata observed but not reconciled |
+| `BASE-P142` | `pyproject.toml` dependency metadata observed without an explicit supported Python manager |
 | `BASE-P143` | Unsupported `[tool.base]` configuration |
 | `BASE-P150` | uv CLI availability for uv-managed projects or uv command runners |
 | `BASE-P151` | uv-managed project `pyproject.toml` presence |
@@ -198,8 +198,11 @@ as a guarantee that every project dependency import succeeds.
 Base only inspects the `pyproject.toml` file beside the active
 `base_manifest.yaml`. These findings do not make `pyproject.toml` a Base
 configuration source and do not cause Base to install Python dependencies.
-Warnings in this range should guide users toward a valid Python project file
-without failing the Base manifest check by themselves.
+`BASE-P142` applies when dependency metadata is present without an explicit
+supported Python manager; projects declaring `python.manager: uv` use the
+dedicated uv diagnostics instead. Warnings in this range should guide users
+toward a valid Python project file without failing the Base manifest check by
+themselves.
 
 `BASE-P150` through `BASE-P155` are uv support diagnostics. They are warnings
 when uv tooling or expected uv project files are missing, because check/doctor

--- a/docs/python-manifest.md
+++ b/docs/python-manifest.md
@@ -238,8 +238,11 @@ when you only need to inspect the resolved invocation.
 
 `pyproject.toml` remains the Python project's packaging contract. Base observes
 a same-directory `pyproject.toml` during diagnostics, reports whether it is
-readable, summarizes standard `[project]` metadata, and warns when dependency
-metadata or unsupported `[tool.base]` configuration is present.
+readable, and summarizes standard `[project]` metadata. For projects without
+an explicit supported Python manager, Base warns when dependency metadata or
+unsupported `[tool.base]` configuration is present. When `python.manager: uv`
+is declared, uv owns Python dependency synchronization and the dedicated uv
+diagnostics report project-file, environment, and lockfile readiness instead.
 
 Base does not treat `pyproject.toml` as an alternate Base manifest. It does not
 solve dependencies, execute build backend hooks, generate lockfiles, or install


### PR DESCRIPTION
## Summary

- Suppress `BASE-P142` when a project explicitly declares `python.manager: uv`.
- Preserve the warning for dependency metadata without an explicit supported Python manager.
- Add direct and JSON diagnostic regression coverage plus documentation and changelog updates.

## Root Cause

The read-only `pyproject.toml` diagnostic classified all dependency metadata as unmanaged. That check ran independently of the manifest's explicit uv manager, even though Base delegates uv dependency synchronization and already reports uv readiness and drift through `BASE-P150` through `BASE-P155`.

## User Impact

Healthy uv-managed projects no longer look incomplete because of a redundant warning. Missing uv project files, environments, or synchronization drift remain visible through the dedicated uv findings.

## Validation

- Focused pyproject and diagnostics tests: 28 passed, 1 skipped, 1 subtest passed.
- Full Python suite with `TZ=UTC`: 962 passed, 1 skipped, 254 subtests passed.
- Full source-checkout BATS suite: 870 passed.
- `git diff --check` passed.
- Pylint was unavailable because it is not installed in the environment.

## Demo Impact

None. This is a diagnostics-only behavior fix.

## AI Context

No `.ai-context/` update is needed; the change refines an existing diagnostic boundary without changing Base's product shape, command surface, or manifest model.

Fixes #1968