### PR TITLE
Fix export-context history attribution

### DIFF
--- a/cli/bash/commands/basectl/subcommands/export_context.sh
+++ b/cli/bash/commands/basectl/subcommands/export_context.sh
@@ -6,6 +6,10 @@ readonly _base_export_context_subcommand_sourced
 
 import_base_lib arg/lib_arg.sh
 
+_base_project_command_helpers_path="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/project_command_helpers.sh"
+# shellcheck source=/dev/null
+source "$_base_project_command_helpers_path"
+
 base_export_context_subcommand_usage() {
     cat <<'EOF'
 Usage:
@@ -126,11 +130,11 @@ base_export_context_subcommand_main() {
     resolved_name="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
     project_root="${BASE_COMMAND_PROTOCOL_FIELDS[project_root]}"
     manifest_path="${BASE_COMMAND_PROTOCOL_FIELDS[manifest_path]}"
-    base_project_set_history_context "$resolved_name" "$project_root" "$manifest_path"
 
     [[ -n "$resolved_name" && -n "$project_root" && -n "$manifest_path" ]] || {
         base_std_fatal_error "Unable to resolve project for export-context."
     }
+    base_project_set_history_context "$resolved_name" "$project_root" "$manifest_path"
 
     exporter_args+=(
         --project-name "$resolved_name"

--- a/cli/bash/commands/basectl/tests/export-context.bats
+++ b/cli/bash/commands/basectl/tests/export-context.bats
@@ -39,6 +39,8 @@ load ./basectl_helpers.bash
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
     local workspace="$TEST_TMPDIR/workspace"
     local state_file="$TEST_TMPDIR/export-state"
+    local history_state="$TEST_TMPDIR/history-state"
+    local history_call
 
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
     cat > "$python_bin" <<'EOF'
@@ -54,6 +56,10 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "base_export_context" ]]; then
     printf 'exported current\n'
     exit 0
 fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_history.record" ]]; then
+    printf '%s\n' "$*" > "${BASE_TEST_HISTORY_STATE:?}"
+    exit 0
+fi
 printf 'unexpected export-context python args: %s\n' "$*" >&2
 exit 1
 EOF
@@ -66,6 +72,7 @@ EOF
         PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
         BASE_TEST_PROJECT_ROOT="$workspace/demo" \
         BASE_TEST_EXPORT_STATE="$state_file" \
+        BASE_TEST_HISTORY_STATE="$history_state" \
         bash -c '
             cd "$1"
             shift
@@ -73,8 +80,52 @@ EOF
         ' bash "$workspace/demo" "$BASE_REPO_ROOT/bin/basectl" export-context --print
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"exported current"* ]]
+    [ "$output" = "exported current" ]
     [ "$(cat "$state_file")" = "--project-name demo --project-root $workspace/demo --format markdown --print" ]
+    history_call="$(cat "$history_state")"
+    [[ "$history_call" == *"-m base_history.record --command export-context "* ]]
+    [[ "$history_call" == *" --project demo --project-root $workspace/demo "* ]]
+    [[ "$history_call" == *" --manifest $workspace/demo/base_manifest.yaml "* ]]
+}
+
+@test "basectl export-context rejects incomplete project context before setting history attribution" {
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+    local workspace="$TEST_TMPDIR/workspace"
+    local history_state="$TEST_TMPDIR/history-state"
+
+    mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "current" ]]; then
+    base_test_protocol_project_reference demo "${BASE_TEST_PROJECT_ROOT:?}" ""
+    exit 0
+fi
+printf 'unexpected export-context python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+    workspace="$(cd "$workspace" && pwd -P)"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_BASH_LIBS_DIR="${BASE_BASH_LIBS_DIR:-}" \
+        BASE_TEST_PROJECT_ROOT="$workspace/demo" \
+        BASE_TEST_HISTORY_STATE="$history_state" \
+        "$TEST_BASH_BIN_DIR/bash" -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/export_context.sh"
+            base_project_set_history_context() {
+                printf "%s\n" "$*" > "${BASE_TEST_HISTORY_STATE:?}"
+            }
+            cd "$1"
+            base_export_context_subcommand_main --print
+        ' bash "$workspace/demo"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unable to resolve project for export-context."* ]]
+    [ ! -e "$history_state" ]
 }
 
 @test "basectl export-context resolves named project and forwards output options" {


### PR DESCRIPTION
## Summary

- Load the shared project-command helpers before `export-context` sets history attribution.
- Validate the resolved project name, root, and manifest before exporting them into the history environment.
- Strengthen BATS coverage for clean output, complete history metadata, and incomplete resolver results.

## Issue

Fixes #1978

## Validation

- `BASE_BASH_LIBS_DIR="$HOME/work/base-bash-libs/lib/bash" bats cli/bash/commands/basectl/tests/export-context.bats` (6 passed)
- `shellcheck cli/bash/commands/basectl/subcommands/export_context.sh`
- Real `basectl export-context base --list-files` smoke test with isolated cache; stderr was clean and the history record contained `project`, `project_root`, and `manifest`.
- `env -u BASE_HOME TZ=UTC BASE_BASH_LIBS_DIR="$HOME/work/base-bash-libs/lib/bash" BASE_CLI_SOURCE_DIR="$HOME/work/base-cli/lib/python" BASE_CACHE_DIR=/private/tmp/base-1978-full-utc ./bin/base-test` (968 Python tests and 871 BATS tests passed)
- `git diff --check`

## Demo Impact

None.

## Notes

`.ai-context/` is unchanged because this restores the existing documented command and history contracts without changing the public command surface or product architecture.
