### PR TITLE
Add Python branch coverage ratchet

### DIFF
--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -54,6 +54,12 @@ PYTHONPATH=../base-cli/lib/python:lib/python:cli/python \
 python -m pytest
 ```
 
+Python CI also enables branch coverage, writes `coverage.json`, and runs
+`python -m tests.coverage_gate coverage.json`. The gate keeps separate 85%
+statement, 76% branch, and 84% combined floors; see
+[`docs/testing.md`](../docs/testing.md) for the reproducible command and Bash
+coverage policy.
+
 The shared `base_cli` framework is maintained in the standalone `base-cli`
 repository. Source-checkout tests resolve it from `BASE_CLI_SOURCE_DIR`, a
 sibling `../base-cli/lib/python` checkout, or the installed `base-cli`

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+branch = True
 source =
     cli/python
 omit =

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,8 @@ jobs:
           python -m pytest \
             --cov=cli/python \
             --cov-report=term-missing \
-            --cov-fail-under=85
+            --cov-report=json:coverage.json
+          python -m tests.coverage_gate coverage.json
 
   bats:
     name: BATS tests

--- a/cli/python/base_history/tests/test_record.py
+++ b/cli/python/base_history/tests/test_record.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from base_history import record
+
+
+def test_main_writes_history_and_bundle_metadata(tmp_path: Path) -> None:
+    bundle_path = tmp_path / "base" / "runs" / "run-123"
+    bundle_path.mkdir(parents=True)
+    argv = [
+        "--command",
+        "export-context",
+        "--run-id",
+        "run-123",
+        "--exit-code",
+        "7",
+        "--scope",
+        "primary",
+        "--started-at",
+        "2026-08-24T01:02:03Z",
+        "--project",
+        "base-demo",
+        "--project-root",
+        str(tmp_path / "base-demo"),
+        "--manifest",
+        str(tmp_path / "base-demo" / "base_manifest.yaml"),
+        "--owner",
+        "base",
+        "--bundle-path",
+        str(bundle_path),
+        "--raw-command",
+        "basectl",
+        "--",
+        "export-context",
+        "base-demo",
+    ]
+
+    with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(tmp_path)}):
+        assert record.main(argv) == 0
+
+    history_path = tmp_path / "base" / "history" / "runs.jsonl"
+    history_record = json.loads(history_path.read_text(encoding="utf-8"))
+    assert history_record["run_id"] == "run-123"
+    assert history_record["command"] == "export-context"
+    assert history_record["raw_command"] == "basectl"
+    assert history_record["argv"] == ["export-context", "base-demo"]
+    assert history_record["project"] == "base-demo"
+    assert history_record["owner"] == "base"
+    assert history_record["scope"] == "primary"
+    assert history_record["status"] == "error"
+    assert history_record["exit_code"] == 7
+    assert history_record["started_at"] == "2026-08-24T01:02:03Z"
+
+    metadata = json.loads((bundle_path / "run.json").read_text(encoding="utf-8"))
+    assert metadata["run_id"] == "run-123"
+    assert metadata["command"] == "export-context"
+    assert metadata["raw_command"] == "basectl"
+    assert metadata["argv"] == ["export-context", "base-demo"]
+    assert metadata["project"] == "base-demo"
+    assert metadata["owner"] == "base"
+    assert metadata["status"] == "error"
+    assert metadata["exit_code"] == 7
+
+
+def test_main_rejects_an_invalid_start_timestamp_without_writing_history(
+    tmp_path: Path,
+) -> None:
+    with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(tmp_path)}):
+        with pytest.raises(SystemExit, match="Invalid --started-at timestamp: yesterday"):
+            record.main(
+                [
+                    "--command",
+                    "check",
+                    "--run-id",
+                    "run-invalid",
+                    "--exit-code",
+                    "0",
+                    "--started-at",
+                    "yesterday",
+                ]
+            )
+
+    assert not (tmp_path / "base" / "history" / "runs.jsonl").exists()
+
+
+def test_main_propagates_history_write_failures() -> None:
+    with mock.patch.object(
+        record,
+        "write_primary_record",
+        side_effect=OSError("history is read-only"),
+    ):
+        with pytest.raises(OSError, match="history is read-only"):
+            record.main(
+                [
+                    "--command",
+                    "check",
+                    "--run-id",
+                    "run-write-failure",
+                    "--exit-code",
+                    "0",
+                ]
+            )

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -88,15 +88,24 @@ PYTHONPATH=../base-cli/lib/python:lib/python:cli/python \
 python -m pytest \
   --cov=cli/python \
   --cov-report=term-missing \
-  --cov-fail-under=85
+  --cov-report=json:coverage.json
+python -m tests.coverage_gate coverage.json
 ```
 
 The shared [coverage configuration](../.coveragerc) excludes Python test
 modules, package initializers, and `__main__.py` entrypoints from the measured
-source set. The initial floor is 85%, based on an 87% baseline from the full
-Python suite across 11,428 production statements. This is a regression guard,
-not a claim that every module has ideal behavioral coverage; ratchet it upward
-as lower-covered areas gain focused tests.
+source set and enables branch measurement. The ratchet checks the JSON report
+separately at 85% statements, 76% branches, and 84% combined coverage. These
+whole-point floors preserve the existing statement gate and leave a small
+cross-version margin below the measured 87.51%, 76.99%, and 84.94% baseline.
+The terminal report keeps per-file missing lines and partial branches visible,
+while the ratchet prints every metric and names any failed threshold.
+
+This is a regression guard, not a claim that every module has ideal behavioral
+coverage. Raise a floor deliberately as lower-covered areas gain focused tests;
+do not lower one merely to make a change pass. To prove the failure behavior
+locally without changing production code, run
+`python -m pytest tests/test_coverage_gate.py -k fails`.
 
 ## Bash Command And Runtime Tests
 
@@ -143,10 +152,19 @@ resolves to a source checkout. In a packaged install such as Homebrew,
 skips source-checkout-only BATS and integration tests with a message pointing
 back to the source checkout command above.
 
-There is not yet an equivalent Bash/BATS line-coverage floor. The BATS suite
-continues to provide behavior and contract coverage, while a lightweight Bash
-coverage tool (such as `kcov` or `bashcov`) is evaluated separately so it can
-be introduced without making the shell test job platform-dependent.
+Base deliberately uses command-focused BATS regression coverage plus ShellCheck
+as the Bash equivalent instead of a line percentage. Contributors changing a
+public command or runtime branch must add or update a focused BATS assertion,
+then run that test and the full `bin/base-test` suite. Linux CI runs the complete
+BATS command matrix and ShellCheck on tracked shell files, so missing behavioral
+coverage or unsafe shell changes block the pull request.
+
+This policy avoids adding `kcov` or `bashcov`, whose tracing and platform
+requirements would make the macOS/Linux signal inconsistent and whose sourced
+shell-line percentages do not establish command behavior. Revisit the decision
+if a portable tool can report command-path coverage without changing Base's
+runtime behavior; until then, command-focused tests are the reviewed coverage
+unit and the required CI signal.
 
 ## Integration Tests
 

--- a/tests/coverage_gate.py
+++ b/tests/coverage_gate.py
@@ -1,0 +1,79 @@
+"""Enforce Base's separate Python coverage ratchets from coverage.py JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+METRICS = (
+    ("statements", "Statements", "percent_statements_covered", 85.0),
+    ("branches", "Branches", "percent_branches_covered", 76.0),
+    ("combined", "Combined", "percent_covered", 84.0),
+)
+
+
+class CoverageReportError(ValueError):
+    """Raised when a coverage report cannot provide the required metrics."""
+
+
+def load_percentages(report_path: Path) -> dict[str, float]:
+    """Load the separate statement, branch, and combined percentages."""
+    try:
+        payload: Any = json.loads(report_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CoverageReportError(f"cannot read coverage report {report_path}: {exc}") from exc
+
+    totals = payload.get("totals") if isinstance(payload, dict) else None
+    if not isinstance(totals, dict):
+        raise CoverageReportError("coverage report is missing numeric totals")
+
+    percentages: dict[str, float] = {}
+    missing: list[str] = []
+    for metric, _label, json_key, _floor in METRICS:
+        value = totals.get(json_key)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            missing.append(json_key)
+            continue
+        percentages[metric] = float(value)
+
+    if missing:
+        raise CoverageReportError(
+            "coverage report is missing numeric totals: " + ", ".join(missing)
+        )
+    return percentages
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", type=Path, help="coverage.py JSON report")
+    options = parser.parse_args(argv)
+
+    try:
+        percentages = load_percentages(options.report)
+    except CoverageReportError as exc:
+        print(f"Coverage report error: {exc}", file=sys.stderr)
+        return 2
+
+    failed: list[str] = []
+    for metric, label, _json_key, floor in METRICS:
+        percentage = percentages[metric]
+        result = "PASS" if percentage >= floor else "FAIL"
+        print(f"{label}: {percentage:.2f}% (minimum {floor:.2f}%) {result}")
+        if percentage < floor:
+            failed.append(metric)
+
+    if failed:
+        print(
+            "Coverage ratchet failed for: " + ", ".join(failed),
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_contract_hardening.py
+++ b/tests/test_contract_hardening.py
@@ -17,6 +17,8 @@ DEV_REQUIREMENTS = REPO_ROOT / "requirements-dev.txt"
 TESTS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "tests.yml"
 TESTING_DOC = REPO_ROOT / "docs" / "testing.md"
 PYTHON_COVERAGE_FLOOR = 85
+PYTHON_BRANCH_COVERAGE_FLOOR = 76
+PYTHON_COMBINED_COVERAGE_FLOOR = 84
 CANONICAL_POSITIONING_DOCS = tuple(
     REPO_ROOT / relative_path
     for relative_path in (
@@ -99,12 +101,16 @@ def test_python_coverage_policy_is_wired_and_documented() -> None:
     assert "pytest-cov==7.1.0" in requirements
     assert "--cov=cli/python" in workflow
     assert "--cov-report=term-missing" in workflow
-    assert f"--cov-fail-under={PYTHON_COVERAGE_FLOOR}" in workflow
+    assert "--cov-report=json:coverage.json" in workflow
+    assert "python -m tests.coverage_gate coverage.json" in workflow
+    assert "branch = True" in coverage_config
     assert "source =\n    cli/python" in coverage_config
     assert "cli/python/**/tests/*" in coverage_config
-    assert f"--cov-fail-under={PYTHON_COVERAGE_FLOOR}" in testing_doc
-    assert f"{PYTHON_COVERAGE_FLOOR}%" in testing_doc
-    assert "Bash/BATS" in testing_doc
+    assert f"{PYTHON_COVERAGE_FLOOR}% statements" in testing_doc
+    assert f"{PYTHON_BRANCH_COVERAGE_FLOOR}% branches" in testing_doc
+    assert f"{PYTHON_COMBINED_COVERAGE_FLOOR}% combined" in testing_doc
+    assert "python -m tests.coverage_gate coverage.json" in testing_doc
+    assert "command-focused BATS regression coverage" in testing_doc
 
 
 def test_python_test_docs_and_ci_use_the_standalone_base_cli_source_contract() -> None:

--- a/tests/test_coverage_gate.py
+++ b/tests/test_coverage_gate.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+
+from tests import coverage_gate
+
+
+def write_report(tmp_path, *, statements: float, branches: float, combined: float):
+    report_path = tmp_path / "coverage.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "totals": {
+                    "percent_statements_covered": statements,
+                    "percent_branches_covered": branches,
+                    "percent_covered": combined,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return report_path
+
+
+def test_coverage_gate_reports_each_metric_separately(tmp_path, capsys) -> None:
+    report_path = write_report(
+        tmp_path,
+        statements=87.51,
+        branches=76.99,
+        combined=84.94,
+    )
+
+    assert coverage_gate.main([str(report_path)]) == 0
+
+    output = capsys.readouterr().out
+    assert "Statements: 87.51% (minimum 85.00%) PASS" in output
+    assert "Branches: 76.99% (minimum 76.00%) PASS" in output
+    assert "Combined: 84.94% (minimum 84.00%) PASS" in output
+
+
+def test_coverage_gate_fails_with_actionable_metric_output(tmp_path, capsys) -> None:
+    report_path = write_report(
+        tmp_path,
+        statements=84.99,
+        branches=75.99,
+        combined=83.99,
+    )
+
+    assert coverage_gate.main([str(report_path)]) == 1
+
+    captured = capsys.readouterr()
+    assert "Statements: 84.99% (minimum 85.00%) FAIL" in captured.out
+    assert "Branches: 75.99% (minimum 76.00%) FAIL" in captured.out
+    assert "Combined: 83.99% (minimum 84.00%) FAIL" in captured.out
+    assert "Coverage ratchet failed for: statements, branches, combined" in captured.err
+
+
+def test_coverage_gate_rejects_incomplete_coverage_json(tmp_path, capsys) -> None:
+    report_path = tmp_path / "coverage.json"
+    report_path.write_text('{"totals": {}}', encoding="utf-8")
+
+    assert coverage_gate.main([str(report_path)]) == 2
+
+    assert "missing numeric totals" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- enable coverage.py branch measurement and enforce separate 85% statement, 76% branch, and 84% combined ratchets from JSON output
- add direct history-record success, metadata, invalid-input, and write-failure tests
- document the reproducible Python coverage command and the command-focused BATS plus ShellCheck policy used instead of platform-dependent Bash line coverage

## Issue

Fixes #1979

## Validation

- `python -m pytest -q tests/test_coverage_gate.py cli/python/base_history/tests/test_record.py tests/test_contract_hardening.py::test_python_coverage_policy_is_wired_and_documented` — 7 passed
- full Python coverage run — 974 passed, 254 subtests passed; 87.87% statements, 77.07% branches, 85.23% combined
- `python -m tests.coverage_gate /private/tmp/base-1979-final.json` — all three ratchets passed
- below-floor coverage fixture — exits 1 and identifies statements, branches, and combined as failures
- `env -u BASE_HOME TZ=UTC BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python BASE_CACHE_DIR=/private/tmp/base-1979-full ./bin/base-test` — 974 Python tests and 871 BATS tests passed
- focused Pylint and `git diff --check` passed

## Docs Impact

`docs/testing.md` now records the coverage floors, local reproduction commands, failure proof, and the reviewed Bash coverage equivalent.

## AI Context Impact

`.ai-context/WORKFLOWS.md` now points agents to the branch-aware coverage gate, its thresholds, and the canonical testing policy.
