### PR TITLE
Avoid duplicate Tests workflow runs

### DIFF
--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -39,6 +39,11 @@ closure procedure](../docs/github-workflow.md#superseded-pull-requests).
 Prefer the narrowest check that proves the change, then broaden when shared
 behavior is touched.
 
+The `Tests` workflow validates pull requests and pushes to `main`; it does not
+run a duplicate push workflow for feature branches. Its concurrency group uses
+the pull-request number, or the Git ref for default-branch runs, so superseded
+commits cancel without affecting unrelated pull requests.
+
 Common commands:
 
 ```bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,13 +2,15 @@ name: Tests
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,6 +3,12 @@
 Base uses three test layers. Prefer the narrowest layer that proves the behavior,
 then broaden when a change crosses command or runtime boundaries.
 
+The `Tests` GitHub Actions workflow runs for every pull request and for pushes
+to `main`. Feature-branch pushes do not start a second copy of the pull-request
+workflow. Concurrency is scoped to the pull-request number, or to the Git ref
+for default-branch runs, so a newer commit cancels only the superseded run for
+the same change.
+
 ## Regression And Completion Evidence
 
 Bug fixes should start with a failing test, fixture, or reproduction whenever

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -19,6 +19,7 @@ COPILOT_INSTRUCTIONS = REPO_ROOT / ".github" / "copilot-instructions.md"
 COPILOT_SETUP_WORKFLOW = WORKFLOW_DIR / "copilot-setup-steps.yml"
 BASE_CHECK_WORKFLOW = WORKFLOW_DIR / "base-check.yml"
 BASE_DEMO_E2E_WORKFLOW = WORKFLOW_DIR / "base-demo-e2e.yml"
+TESTS_WORKFLOW = WORKFLOW_DIR / "tests.yml"
 BASE_PROJECT_CONFIG = REPO_ROOT / ".github" / "base-project.yml"
 ISSUE_BRANCH_POLICY_WORKFLOW = WORKFLOW_DIR / "issue-branch-policy.yml"
 ISSUE_BRANCH_POLICY_TEMPLATE = REPO_ROOT / "templates" / "issue-branch-policy.yml"
@@ -123,6 +124,31 @@ def test_all_workflow_action_uses_are_pinned_to_full_commit_sha() -> None:
     unpinned = workflow_action_references_without_full_sha()
 
     assert not unpinned, unpinned
+
+
+def test_tests_workflow_runs_once_per_pr_commit_and_on_main() -> None:
+    workflow = load_workflow(TESTS_WORKFLOW)
+    triggers = workflow.get("on") or workflow.get(True)
+
+    assert triggers == {
+        "push": {"branches": ["main"]},
+        "pull_request": None,
+    }
+    assert workflow["concurrency"] == {
+        "group": "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}",
+        "cancel-in-progress": True,
+    }
+    assert {
+        job["name"]
+        for job in workflow["jobs"].values()
+    } == {
+        "Python tests (${{ matrix.python-version }})",
+        "BATS tests",
+        "macOS smoke tests",
+        "Integration tests",
+        "Ubuntu source-checkout suite",
+        "Security scanners",
+    }
 
 
 def test_issue_branch_policy_workflow_is_trusted_and_template_backed() -> None:


### PR DESCRIPTION
## Summary

- restrict the `Tests` workflow push trigger to `main`, preserving pull-request and post-merge/default-branch validation without a second feature-branch push run
- scope concurrency to the pull-request number, or the Git ref for non-PR runs, so superseded commits cancel without affecting unrelated pull requests
- lock the trigger, concurrency, and existing job display names with workflow contract tests and document the policy

## Issue

Fixes #1980

## Validation

- `python -m pytest -q tests/test_github_workflows.py` — 45 passed
- full Python suite — 975 passed, 254 subtests passed
- focused Pylint and `git diff --check` passed
- head `147553660f00b17cc4d16a6a0d8db318abbee665` produced no `Tests` run for its feature-branch push, then exactly one `Tests` run (`32692045954`) for the pull-request event
- repository ruleset still requires the unchanged `base/issue-branch-policy` context; all Tests job display names remain unchanged

## Docs Impact

`docs/testing.md` now documents PR/default-branch trigger ownership and superseded-run cancellation behavior.

## AI Context Impact

`.ai-context/WORKFLOWS.md` now records the same durable Tests trigger and concurrency contract for agents.
