### PR TITLE
Harden cleanup cache containment

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -160,7 +160,9 @@ Pass `--format json`; text remains the default. Completed inspections keep
 findings in `data` with `error: null`, while controlled usage or upstream
 failures use an `error` object. The canonical field contract and exit semantics
 are documented in `docs/inspection-json.md`.
-- `basectl clean` - remove old Base runtime logs, temp files, and cache entries.
+- `basectl clean` - remove old Base runtime logs, temp files, and cache entries;
+  it rejects symlinked paths below the resolved Base cache root and never
+  follows them during deletion.
 - `basectl logs` - list, print, open, or tail recent Base CLI runtime logs.
 - `basectl history` - list recent structured Base command runs from the local
   history index, with comma-separated OR filters such as

--- a/cli/python/base_clean/engine.py
+++ b/cli/python/base_clean/engine.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-import shutil
-import time
 import json
+import os
+import stat
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -64,16 +65,25 @@ def run(ctx: base_cli.Context, older_than: str | None, keep_last: str | None, dr
         ctx.log.info("No Base runtime artifacts matched the clean criteria.")
         return base_cli.ExitCode.SUCCESS
 
+    acted_count = 0
     for candidate in unique_candidates:
-        action = "Would remove" if dry_run else "Removing"
-        print(f"{action}\t{candidate.category}\t{candidate.path}")
-        if not dry_run:
-            remove_path(candidate.path)
+        if dry_run:
+            if not clean_path_is_safe(cache_root, candidate.path, "candidate", ctx.log):
+                continue
+            print(f"Would remove\t{candidate.category}\t{candidate.path}")
+            acted_count += 1
+        elif remove_path(cache_root, candidate.path, ctx.log):
+            print(f"Removing\t{candidate.category}\t{candidate.path}")
+            acted_count += 1
+
+    if not acted_count:
+        ctx.log.info("No safe Base runtime artifacts matched the clean criteria.")
+        return base_cli.ExitCode.SUCCESS
 
     ctx.log.info(
         "%s %s Base runtime artifact(s).",
         "Would remove" if dry_run else "Removed",
-        len(unique_candidates),
+        acted_count,
     )
     return base_cli.ExitCode.SUCCESS
 
@@ -110,11 +120,27 @@ def parse_keep_last(value: str) -> int:
 
 def find_clean_candidates(cache_root: Path, cutoff: float, logger: object | None = None) -> list[CleanCandidate]:
     candidates: list[CleanCandidate] = []
-    for owner_root in runtime_owner_roots(cache_root):
+    for owner_root in runtime_owner_roots(cache_root, logger):
         if logger is not None:
             logger.debug("Scanning runtime owner root '%s'.", owner_root)
-        candidates.extend(find_category_candidates(owner_root / "runs", "run", cutoff, logger))
-        candidates.extend(find_category_candidates(owner_root / "cache" / "components", "cache", cutoff, logger))
+        candidates.extend(
+            find_category_candidates(
+                cache_root,
+                owner_root / "runs",
+                "run",
+                cutoff,
+                logger,
+            )
+        )
+        candidates.extend(
+            find_category_candidates(
+                cache_root,
+                owner_root / "cache" / "components",
+                "cache",
+                cutoff,
+                logger,
+            )
+        )
     return sorted(candidates, key=lambda candidate: str(candidate.path))
 
 
@@ -124,19 +150,32 @@ def find_log_retention_candidates(
     logger: object | None = None,
 ) -> list[CleanCandidate]:
     candidates: list[CleanCandidate] = []
-    for owner_root in runtime_owner_roots(cache_root):
+    for owner_root in runtime_owner_roots(cache_root, logger):
         runs_root = owner_root / "runs"
         if logger is not None:
             logger.debug("Scanning run retention artifacts in '%s'.", runs_root)
-        if not runs_root.is_dir():
+        if not clean_path_is_safe(
+            cache_root,
+            runs_root,
+            "category root",
+            logger,
+            require_directory=True,
+        ):
             continue
         run_dirs = []
-        for path in sorted(runs_root.iterdir(), key=lambda item: item.name):
-            if not path.is_dir() or run_is_running(path):
+        for path in safe_directory_entries(runs_root, "category root", logger):
+            if not clean_path_is_safe(
+                cache_root,
+                path,
+                "candidate",
+                logger,
+                require_directory=True,
+            ) or run_is_running(path):
                 continue
             try:
                 run_dirs.append((path, run_metadata_mtime(path)))
-            except OSError:
+            except OSError as exc:
+                warn_unsafe_path(logger, "candidate", path, f"could not read metadata: {exc}")
                 continue
         retained = {
             path
@@ -154,13 +193,143 @@ def find_log_retention_candidates(
     return sorted(candidates, key=lambda candidate: str(candidate.path))
 
 
-def runtime_owner_roots(cache_root: Path) -> list[Path]:
-    roots = []
+def runtime_owner_roots(cache_root: Path, logger: object | None = None) -> list[Path]:
+    roots: list[Path] = []
     base_root = cache_root / "base"
-    if base_root.is_dir():
+    if clean_path_is_safe(
+        cache_root,
+        base_root,
+        "owner root",
+        logger,
+        require_directory=True,
+    ):
         roots.append(base_root)
-    roots.extend(path for path in sorted((cache_root / "projects").glob("*/*"), key=str) if path.is_dir())
+
+    projects_root = cache_root / "projects"
+    if not clean_path_is_safe(
+        cache_root,
+        projects_root,
+        "projects root",
+        logger,
+        require_directory=True,
+    ):
+        return roots
+
+    for namespace_root in safe_directory_entries(projects_root, "projects root", logger):
+        if not clean_path_is_safe(
+            cache_root,
+            namespace_root,
+            "project namespace",
+            logger,
+            require_directory=True,
+        ):
+            continue
+        for owner_root in safe_directory_entries(namespace_root, "project namespace", logger):
+            if clean_path_is_safe(
+                cache_root,
+                owner_root,
+                "owner root",
+                logger,
+                require_directory=True,
+            ):
+                roots.append(owner_root)
     return roots
+
+
+def safe_directory_entries(
+    directory: Path,
+    path_kind: str,
+    logger: object | None = None,
+) -> list[Path]:
+    try:
+        return sorted(directory.iterdir(), key=lambda item: item.name)
+    except OSError as exc:
+        warn_unsafe_path(logger, path_kind, directory, f"could not list directory: {exc}")
+        return []
+
+
+def clean_path_is_safe(  # pylint: disable=too-many-return-statements
+    cache_root: Path,
+    path: Path,
+    path_kind: str,
+    logger: object | None = None,
+    *,
+    require_directory: bool = False,
+) -> bool:
+    lexical_root = cache_root.absolute()
+    lexical_path = path.absolute()
+    try:
+        relative_path = lexical_path.relative_to(lexical_root)
+    except ValueError:
+        warn_unsafe_path(logger, path_kind, path, "path is outside the Base cache root")
+        return False
+
+    try:
+        resolved_root = lexical_root.resolve(strict=True)
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        warn_unsafe_path(logger, path_kind, path, f"could not resolve the Base cache root: {exc}")
+        return False
+
+    current = lexical_root
+    final_stat = None
+    for index, part in enumerate(relative_path.parts):
+        current /= part
+        try:
+            current_stat = current.lstat()
+        except FileNotFoundError:
+            return False
+        except OSError as exc:
+            warn_unsafe_path(logger, path_kind, path, f"could not inspect '{current}': {exc}")
+            return False
+        if stat.S_ISLNK(current_stat.st_mode):
+            warn_unsafe_path(
+                logger,
+                path_kind,
+                path,
+                f"path component '{current}' is a symlink; replace it with a real directory before retrying",
+            )
+            return False
+        if index < len(relative_path.parts) - 1 and not stat.S_ISDIR(current_stat.st_mode):
+            warn_unsafe_path(
+                logger,
+                path_kind,
+                path,
+                f"parent component '{current}' is not a directory",
+            )
+            return False
+        final_stat = current_stat
+
+    if final_stat is None:
+        return False
+    if require_directory and not stat.S_ISDIR(final_stat.st_mode):
+        return False
+
+    try:
+        resolved_path = lexical_path.resolve(strict=True)
+    except (FileNotFoundError, OSError) as exc:
+        warn_unsafe_path(logger, path_kind, path, f"could not resolve path: {exc}")
+        return False
+    if not resolved_path.is_relative_to(resolved_root):
+        warn_unsafe_path(logger, path_kind, path, "resolved path is outside the Base cache root")
+        return False
+    return True
+
+
+def warn_unsafe_path(
+    logger: object | None,
+    path_kind: str,
+    path: Path,
+    reason: str,
+) -> None:
+    if logger is not None:
+        logger.warning(
+            "Skipping unsafe Base cleanup %s '%s': %s.",
+            path_kind,
+            path,
+            reason,
+        )
 
 
 def run_is_running(run_root: Path) -> bool:
@@ -189,10 +358,10 @@ def find_log_retention_candidates_for_dir(
         if not path.is_file():
             continue
         try:
-            stat = path.stat()
+            path_stat = path.stat()
         except OSError:
             continue
-        log_files.append((path, stat.st_mtime))
+        log_files.append((path, path_stat.st_mtime))
 
     retained = sorted(log_files, key=lambda item: (item[1], item[0].name), reverse=True)[:keep_count]
     retained_paths = {path for path, _mtime in retained}
@@ -209,6 +378,7 @@ def deduplicate_candidates(candidates: list[CleanCandidate]) -> list[CleanCandid
 
 
 def find_category_candidates(
+    cache_root: Path,
     category_root: Path,
     category: str,
     cutoff: float,
@@ -216,14 +386,23 @@ def find_category_candidates(
 ) -> list[CleanCandidate]:
     if logger is not None:
         logger.debug("Scanning %s runtime artifacts in '%s'.", category, category_root)
-    if not category_root.is_dir():
+    if not clean_path_is_safe(
+        cache_root,
+        category_root,
+        "category root",
+        logger,
+        require_directory=True,
+    ):
         return []
 
     candidates = []
-    for path in sorted(category_root.iterdir(), key=lambda item: item.name):
+    for path in safe_directory_entries(category_root, "category root", logger):
+        if not clean_path_is_safe(cache_root, path, "candidate", logger):
+            continue
         try:
             mtime = run_metadata_mtime(path) if category == "run" else path.stat().st_mtime
-        except OSError:
+        except OSError as exc:
+            warn_unsafe_path(logger, "candidate", path, f"could not read metadata: {exc}")
             continue
         if mtime < cutoff:
             candidates.append(CleanCandidate(path=path, category=category, age_seconds=int(time.time() - mtime)))
@@ -240,8 +419,83 @@ def run_metadata_mtime(path: Path) -> float:
         return path.stat().st_mtime
 
 
-def remove_path(path: Path) -> None:
-    if path.is_dir() and not path.is_symlink():
-        shutil.rmtree(path)
-    else:
-        path.unlink()
+def remove_path(
+    cache_root: Path,
+    path: Path,
+    logger: object | None = None,
+) -> bool:
+    if not clean_path_is_safe(cache_root, path, "candidate", logger):
+        return False
+    if not descriptor_safe_removal_supported():
+        warn_unsafe_path(
+            logger,
+            "candidate",
+            path,
+            "secure descriptor-relative deletion is unavailable on this platform",
+        )
+        return False
+
+    lexical_root = cache_root.absolute()
+    relative_path = path.absolute().relative_to(lexical_root)
+    if not relative_path.parts:
+        warn_unsafe_path(logger, "candidate", path, "refusing to remove the Base cache root")
+        return False
+
+    opened_fds: list[int] = []
+    directory_flags = (
+        os.O_RDONLY
+        | os.O_DIRECTORY
+        | os.O_NOFOLLOW
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    try:
+        root_fd = os.open(lexical_root.resolve(strict=True), directory_flags)
+        opened_fds.append(root_fd)
+        parent_fd = root_fd
+        for component in relative_path.parts[:-1]:
+            parent_fd = os.open(component, directory_flags, dir_fd=parent_fd)
+            opened_fds.append(parent_fd)
+        secure_remove_entry(parent_fd, relative_path.parts[-1], directory_flags)
+    except OSError as exc:
+        warn_unsafe_path(
+            logger,
+            "candidate",
+            path,
+            f"could not open cache path without following symlinks: {exc}",
+        )
+        return False
+    finally:
+        for descriptor in reversed(opened_fds):
+            os.close(descriptor)
+    return True
+
+
+def descriptor_safe_removal_supported() -> bool:
+    return (
+        hasattr(os, "O_DIRECTORY")
+        and hasattr(os, "O_NOFOLLOW")
+        and os.open in os.supports_dir_fd
+        and os.stat in os.supports_dir_fd
+        and os.stat in os.supports_follow_symlinks
+        and os.unlink in os.supports_dir_fd
+        and os.rmdir in os.supports_dir_fd
+        and os.listdir in os.supports_fd
+    )
+
+
+def secure_remove_entry(parent_fd: int, name: str, directory_flags: int) -> None:
+    entry_stat = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    if not stat.S_ISDIR(entry_stat.st_mode):
+        os.unlink(name, dir_fd=parent_fd)
+        return
+
+    child_fd = os.open(name, directory_flags, dir_fd=parent_fd)
+    try:
+        opened_stat = os.fstat(child_fd)
+        if (opened_stat.st_dev, opened_stat.st_ino) != (entry_stat.st_dev, entry_stat.st_ino):
+            raise OSError("cleanup candidate changed while it was being opened")
+        for child_name in os.listdir(child_fd):
+            secure_remove_entry(child_fd, child_name, directory_flags)
+    finally:
+        os.close(child_fd)
+    os.rmdir(name, dir_fd=parent_fd)

--- a/cli/python/base_clean/tests/test_engine.py
+++ b/cli/python/base_clean/tests/test_engine.py
@@ -10,7 +10,27 @@ from unittest import mock
 from base_clean import engine
 
 
-class BaseCleanTests(unittest.TestCase):
+def create_old_run(root: Path) -> Path:
+    run_root = root / "old-run"
+    (run_root / "logs").mkdir(parents=True)
+    (run_root / "logs" / "proof.log").write_text("outside\n", encoding="utf-8")
+    metadata = run_root / "run.json"
+    metadata.write_text('{"status":"ok"}\n', encoding="utf-8")
+    old_time = time.time() - 40 * 24 * 60 * 60
+    os.utime(metadata, (old_time, old_time))
+    return run_root
+
+
+def create_old_cache(root: Path) -> Path:
+    cache_path = root / "old-cache"
+    cache_path.mkdir(parents=True)
+    (cache_path / "proof.txt").write_text("outside\n", encoding="utf-8")
+    old_time = time.time() - 40 * 24 * 60 * 60
+    os.utime(cache_path, (old_time, old_time))
+    return cache_path
+
+
+class BaseCleanTests(unittest.TestCase):  # pylint: disable=too-many-public-methods
     def test_parse_age_accepts_supported_units(self) -> None:
         self.assertEqual(engine.parse_age("30d"), 30 * 24 * 60 * 60)
         self.assertEqual(engine.parse_age("12h"), 12 * 60 * 60)
@@ -111,11 +131,228 @@ class BaseCleanTests(unittest.TestCase):
             dir_path.mkdir()
             (dir_path / "temp.txt").write_text("x", encoding="utf-8")
 
-            engine.remove_path(file_path)
-            engine.remove_path(dir_path)
+            self.assertTrue(engine.remove_path(root, file_path))
+            self.assertTrue(engine.remove_path(root, dir_path))
 
             self.assertFalse(file_path.exists())
             self.assertFalse(dir_path.exists())
+
+    def test_remove_path_rejects_an_external_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            cache_root = root / "cache"
+            outside_path = root / "outside" / "run"
+            outside_path.mkdir(parents=True)
+            logger = mock.Mock()
+
+            self.assertFalse(engine.remove_path(cache_root, outside_path, logger))
+
+            self.assertTrue(outside_path.exists())
+            warning = logger.warning.call_args.args[0] % logger.warning.call_args.args[1:]
+            self.assertIn("Skipping unsafe Base cleanup candidate", warning)
+            self.assertIn("outside the Base cache root", warning)
+
+    def test_remove_path_fails_closed_if_a_parent_becomes_a_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            cache_root = root / "cache"
+            outside_root = root / "outside"
+            external_run = create_old_run(outside_root)
+            owner_link = cache_root / "base"
+            owner_link.parent.mkdir(parents=True)
+            owner_link.symlink_to(outside_root, target_is_directory=True)
+            candidate = owner_link / external_run.name
+            logger = mock.Mock()
+
+            with mock.patch.object(engine, "clean_path_is_safe", return_value=True):
+                self.assertFalse(engine.remove_path(cache_root, candidate, logger))
+
+            self.assertTrue(external_run.is_dir())
+            warning = logger.warning.call_args.args[0] % logger.warning.call_args.args[1:]
+            self.assertIn("could not open cache path without following symlinks", warning)
+
+    def test_remove_path_fails_closed_without_secure_descriptor_operations(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            candidate = cache_root / "run"
+            candidate.mkdir()
+            logger = mock.Mock()
+
+            with mock.patch.object(engine, "descriptor_safe_removal_supported", return_value=False):
+                self.assertFalse(engine.remove_path(cache_root, candidate, logger))
+
+            self.assertTrue(candidate.is_dir())
+            warning = logger.warning.call_args.args[0] % logger.warning.call_args.args[1:]
+            self.assertIn("secure descriptor-relative deletion is unavailable", warning)
+
+    def test_clean_path_validation_fails_closed_on_metadata_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            candidate = cache_root / "run"
+            candidate.mkdir()
+            logger = mock.Mock()
+            original_lstat = Path.lstat
+
+            def failing_lstat(path: Path):
+                if path == candidate:
+                    raise PermissionError("metadata denied")
+                return original_lstat(path)
+
+            with mock.patch.object(Path, "lstat", new=failing_lstat):
+                self.assertFalse(
+                    engine.clean_path_is_safe(cache_root, candidate, "candidate", logger)
+                )
+
+            self.assertTrue(candidate.is_dir())
+            warning = logger.warning.call_args.args[0] % logger.warning.call_args.args[1:]
+            self.assertIn("could not inspect", warning)
+            self.assertIn("metadata denied", warning)
+
+    def test_clean_rejects_symlinked_owner_roots(self) -> None:
+        for owner_kind in ("base", "project"):
+            with self.subTest(owner_kind=owner_kind), tempfile.TemporaryDirectory() as tmpdir:
+                root = Path(tmpdir)
+                cache_root = root / "cache"
+                outside_owner = root / "outside-owner"
+                external_run = create_old_run(outside_owner / "runs")
+                if owner_kind == "base":
+                    owner_link = cache_root / "base"
+                else:
+                    owner_link = cache_root / "projects" / "workspace" / "project"
+                owner_link.parent.mkdir(parents=True)
+                owner_link.symlink_to(outside_owner, target_is_directory=True)
+
+                with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
+                    result = engine.main(["--older-than", "1s"])
+
+                self.assertEqual(result, 0)
+                self.assertTrue(owner_link.is_symlink())
+                self.assertTrue(external_run.is_dir())
+                self.assertTrue((external_run / "logs" / "proof.log").is_file())
+
+    def test_clean_rejects_symlinked_project_parent_roots(self) -> None:
+        cases = (
+            (Path("projects"), Path("workspace/project/runs"), "projects-root"),
+            (Path("projects/workspace"), Path("project/runs"), "project-namespace"),
+        )
+        for relative_link, outside_runs, path_kind in cases:
+            with self.subTest(path_kind=path_kind), tempfile.TemporaryDirectory() as tmpdir:
+                root = Path(tmpdir)
+                cache_root = root / "cache-root"
+                outside_root = root / "outside"
+                external_run = create_old_run(outside_root / outside_runs)
+                parent_link = cache_root / relative_link
+                parent_link.parent.mkdir(parents=True)
+                parent_link.symlink_to(outside_root, target_is_directory=True)
+
+                with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
+                    result = engine.main(["--older-than", "1s"])
+
+                self.assertEqual(result, 0)
+                self.assertTrue(parent_link.is_symlink())
+                self.assertTrue(external_run.is_dir())
+
+    def test_clean_keep_last_rejects_a_symlinked_owner_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            cache_root = root / "cache-root"
+            outside_owner = root / "outside-owner"
+            old_run = create_old_run(outside_owner / "runs")
+            new_run = outside_owner / "runs" / "new-run"
+            new_run.mkdir(parents=True)
+            (new_run / "run.json").write_text('{"status":"ok"}\n', encoding="utf-8")
+            owner_link = cache_root / "base"
+            owner_link.parent.mkdir(parents=True)
+            owner_link.symlink_to(outside_owner, target_is_directory=True)
+
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
+                result = engine.main(["--keep-last", "1"])
+
+            self.assertEqual(result, 0)
+            self.assertTrue(owner_link.is_symlink())
+            self.assertTrue(old_run.is_dir())
+            self.assertTrue(new_run.is_dir())
+
+    def test_clean_rejects_symlinked_category_roots(self) -> None:
+        cases = (
+            (Path("runs"), Path("outside-runs"), "run"),
+            (Path("cache"), Path("outside-cache"), "cache-parent"),
+            (Path("cache/components"), Path("outside-components"), "components"),
+        )
+        for relative_link, outside_relative, category_kind in cases:
+            with self.subTest(category_kind=category_kind), tempfile.TemporaryDirectory() as tmpdir:
+                root = Path(tmpdir)
+                cache_root = root / "cache-root"
+                owner_root = cache_root / "base"
+                outside_root = root / outside_relative
+                if category_kind == "run":
+                    external_artifact = create_old_run(outside_root)
+                elif category_kind == "cache-parent":
+                    external_artifact = create_old_cache(outside_root / "components")
+                else:
+                    external_artifact = create_old_cache(outside_root)
+
+                category_link = owner_root / relative_link
+                category_link.parent.mkdir(parents=True)
+                category_link.symlink_to(outside_root, target_is_directory=True)
+
+                with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
+                    result = engine.main(["--older-than", "1s"])
+
+                self.assertEqual(result, 0)
+                self.assertTrue(category_link.is_symlink())
+                self.assertTrue(external_artifact.is_dir())
+                self.assertTrue(any(external_artifact.iterdir()))
+
+    def test_clean_rejects_symlinked_candidates(self) -> None:
+        for category_kind in ("run", "cache"):
+            with self.subTest(category_kind=category_kind), tempfile.TemporaryDirectory() as tmpdir:
+                root = Path(tmpdir)
+                cache_root = root / "cache-root"
+                if category_kind == "run":
+                    category_root = cache_root / "base" / "runs"
+                    external_artifact = create_old_run(root / "outside")
+                else:
+                    category_root = cache_root / "base" / "cache" / "components"
+                    external_artifact = create_old_cache(root / "outside")
+                category_root.mkdir(parents=True)
+                candidate_link = category_root / external_artifact.name
+                candidate_link.symlink_to(external_artifact, target_is_directory=True)
+
+                with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
+                    result = engine.main(["--older-than", "1s"])
+
+                self.assertEqual(result, 0)
+                self.assertTrue(candidate_link.is_symlink())
+                self.assertTrue(external_artifact.is_dir())
+                self.assertTrue(any(external_artifact.iterdir()))
+
+    def test_candidate_scan_warns_when_a_parent_is_a_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            cache_root = root / "cache-root"
+            outside_owner = root / "outside-owner"
+            create_old_run(outside_owner / "runs")
+            owner_link = cache_root / "projects" / "workspace" / "project"
+            owner_link.parent.mkdir(parents=True)
+            owner_link.symlink_to(outside_owner, target_is_directory=True)
+            logger = mock.Mock()
+
+            candidates = engine.find_clean_candidates(cache_root, time.time(), logger)
+
+        self.assertEqual(candidates, [])
+        warnings = [
+            call.args[0] % call.args[1:]
+            for call in logger.warning.call_args_list
+        ]
+        self.assertTrue(
+            any(
+                "Skipping unsafe Base cleanup owner root" in warning
+                and "symlink" in warning
+                for warning in warnings
+            ),
+            warnings,
+        )
 
     def test_clean_dry_run_reports_without_removing(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/docs/cache-ownership-and-layout.md
+++ b/docs/cache-ownership-and-layout.md
@@ -189,9 +189,11 @@ the ownership boundary described above.
 
 `basectl clean` operates on completed run bundles, with optional project and
 owner filters. It never removes an active run, durable `~/.base.d` state, or
-another application's cache root. Persistent component caches may be pruned by
-age, while history metadata is retained until an explicit history-retention
-policy is applied.
+another application's cache root. Cleanup rejects symlinks below the resolved
+Base cache root and performs deletion relative to trusted directory descriptors
+so an owner, category, or candidate path cannot redirect removal elsewhere.
+Persistent component caches may be pruned by age, while history metadata is
+retained until an explicit history-retention policy is applied.
 
 ## Implementation boundary
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -166,6 +166,10 @@ The retention contract should be:
   caches older than the age.
 - `basectl clean --keep-last <count>` retains the newest completed bundles per
   owner namespace.
+- Cleanup resolves its Base cache boundary before scanning, rejects symlinked
+  owner, category, and candidate path components, and reopens deletion targets
+  relative to trusted directory descriptors. Unsafe or unverifiable paths are
+  left untouched with a warning rather than followed.
 - Per-run temporary data is diagnostic-only: `basectl` removes the complete
   `tmp/` tree after every recognized command, regardless of success or failure,
   unless `basectl --keep-temp <command>` (or the documented Python retention

--- a/tests/test_observability_docs.py
+++ b/tests/test_observability_docs.py
@@ -19,3 +19,16 @@ def test_unscheduled_observability_work_is_not_numbered_as_active_steps() -> Non
     assert "2. Add `basectl explain last-error`" not in section
     assert "3. Add `basectl report`" not in section
     assert "4. Extend `basectl clean`" not in section
+
+
+def test_cleanup_docs_define_the_symlink_containment_boundary() -> None:
+    observability = OBSERVABILITY_DOC.read_text(encoding="utf-8")
+    cache_layout = (REPO_ROOT / "docs" / "cache-ownership-and-layout.md").read_text(
+        encoding="utf-8"
+    )
+    commands = (REPO_ROOT / ".ai-context" / "COMMANDS.md").read_text(encoding="utf-8")
+
+    assert "rejects symlinked" in observability
+    assert "relative to trusted directory descriptors" in observability
+    assert "Cleanup rejects symlinks below the resolved" in cache_layout
+    assert "never follows them during deletion" in " ".join(commands.split())


### PR DESCRIPTION
## Summary

- constrain cleanup discovery to real directories beneath the resolved Base cache boundary
- reject symlinked or unverifiable owner, namespace, category, and candidate paths with actionable warnings
- delete recursively through trusted directory descriptors with no-follow semantics to close scan/delete races
- document the containment contract and add regression coverage for age and keep-last cleanup

## Issue

Fixes #1969

## Validation

- `env TZ=UTC BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python PYTHONPATH=cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q cli/python/base_clean/tests/test_engine.py tests/test_observability_docs.py` (28 passed, 20 subtests passed)
- `env PYTHONPATH=cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pylint --rcfile=.pylintrc cli/python/base_clean/engine.py cli/python/base_clean/tests/test_engine.py tests/test_observability_docs.py`
- isolated public `basectl clean --older-than 1s --dry-run` and real-clean proof
- isolated public symlink-escape proof (external artifact preserved and warning emitted)
- `env -u BASE_HOME TZ=UTC BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python BASE_CACHE_DIR=/private/tmp/base-1969-full ./bin/base-test` (986 Python tests and 871 BATS tests passed)
- `git diff --check`

## Security Notes

Cleanup now fails closed when cache paths contain symlinks, cannot be verified, or the platform cannot provide descriptor-relative no-follow deletion. Recursive removal operates from opened directory descriptors and never follows nested symlinks outside the trusted cache tree.

## Docs Impact

Updated `docs/observability.md` and `docs/cache-ownership-and-layout.md` with the resolved-cache containment and warning contract.

## AI Context Impact

Updated `.ai-context/COMMANDS.md` because the public `basectl clean` safety contract changed.
