### PR TITLE
fix(runtime): discard rejected usage artifacts

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -167,7 +167,10 @@ are documented in `docs/inspection-json.md`.
 - `basectl history` - list recent structured Base command runs from the local
   history index, with comma-separated OR filters such as
   `--command check,doctor`, `--format json` for scripts, and `--report` for a
-  privacy-conscious Markdown or JSON activity report.
+  privacy-conscious Markdown or JSON activity report. Rejected usage
+  invocations (status `2`), including an explicitly named nonexistent project,
+  leave no persistent run bundle, log, or history row. Failures after command
+  usage is accepted remain observable.
 - `basectl config <path|show|doctor>` - inspect Base's machine-local user
   config.
 - `basectl onboard` - guide a user through the first Base setup checklist.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and Base versions are tracked in the repo-root `VERSION` file.
 
 ### Fixed
 
+- Prevented rejected `basectl` usage invocations from retaining run bundles,
+  logs, or history rows; an explicitly named nonexistent `basectl test` project
+  now returns usage status `2`, while accepted-command failures remain
+  observable and inherited parent bundles remain untouched.
 - Batched branch and worktree GitHub PR-state verification through one
   paginated REST read per prune invocation, avoiding one GraphQL query per
   branch and failing the scan closed when that read is unavailable.

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -617,6 +617,7 @@ basectl_initialize_run_bundle() {
     local command="${1:-run}" cache_root run_id run_root label
     shift || true
 
+    _basectl_run_bundle_created=0
     if [[ -n "${BASE_CLI_RUN_ROOT:-}" ]]; then
         export BASE_CLI_RUNTIME_OWNER=base
         if [[ -z "${BASE_CLI_RUN_ID:-}" ]]; then
@@ -650,6 +651,7 @@ basectl_initialize_run_bundle() {
         basectl_error "Unable to secure Base run bundle '$run_root'. Check file permissions."
         return 1
     }
+    _basectl_run_bundle_created=1
 }
 
 basectl_finalize_run_bundle() {
@@ -666,6 +668,28 @@ basectl_finalize_run_bundle() {
     chmod 600 "$run_root/run.json" "${BASE_BASH_LIBS_PRIMARY_LOG:-$run_root/logs/primary.log}" || return 1
     if [[ "${BASE_CLI_KEEP_TEMP:-}" != true ]]; then
         rm -rf -- "$run_root/tmp"
+    fi
+}
+
+basectl_discard_invocation_run_bundle() {
+    local run_root="${BASE_CLI_RUN_ROOT:-}" runs_root wrapper
+
+    [[ "${_basectl_run_bundle_created:-0}" == 1 ]] || return 0
+    [[ -n "$run_root" && -d "$run_root" && ! -L "$run_root" ]] || return 1
+    runs_root="${run_root%/*}"
+    [[ -n "$runs_root" && "$runs_root" != "$run_root" ]] || return 1
+    rm -rf -- "$run_root" || return 1
+
+    # Delegated base-cli children may have indexed the inherited outer bundle
+    # before the leaf command rejected its usage. Refresh that cache after the
+    # outer bundle is gone so it cannot retain a stale pointer.
+    wrapper="$BASE_HOME/bin/base-wrapper"
+    if [[ -x "$wrapper" ]]; then
+        (
+            unset BASE_CLI_RUN_ROOT BASE_CLI_RUN_ID BASE_BASH_LIBS_PRIMARY_LOG
+            unset BASE_CLI_PRIMARY_LOG BASE_CLI_HISTORY_PARENT_RUN_ID BASE_CLI_HISTORY_SCOPE
+            "$wrapper" --project base base_cli_adapters.run_index "$runs_root"
+        ) >/dev/null 2>&1 || true
     fi
 }
 
@@ -855,8 +879,14 @@ basectl_main() {
     esac
 
     if ((run_bundle_enabled)); then
-        basectl_finalize_run_bundle "$command_status"
-        basectl_history_record "$command" "$command_status" "$history_scope" "${history_args[@]}"
+        if ((command_status == 2)); then
+            basectl_discard_invocation_run_bundle || {
+                base_std_log_warn "Unable to discard rejected invocation run bundle."
+            }
+        else
+            basectl_finalize_run_bundle "$command_status"
+            basectl_history_record "$command" "$command_status" "$history_scope" "${history_args[@]}"
+        fi
     fi
     return "$command_status"
 }

--- a/cli/bash/commands/basectl/tests/runtime-dispatch.bats
+++ b/cli/bash/commands/basectl/tests/runtime-dispatch.bats
@@ -45,6 +45,64 @@ load ./basectl_helpers.bash
 }
 
 
+@test "basectl discards locally created run artifacts for leaf usage errors" {
+    local cache_root="$TEST_TMPDIR/cache"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_CACHE_DIR="$cache_root" \
+        BASE_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        bash -c '
+            source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
+            base_std_log_debug() { :; }
+            basectl_do_setup() { return 2; }
+            basectl_history_record() { touch "$BASE_TEST_STATE_DIR/history-recorded"; }
+            basectl_main setup
+        '
+
+    [ "$status" -eq 2 ]
+    [ -d "$cache_root/base/runs" ]
+    [ -z "$(find "$cache_root/base/runs" -mindepth 1 -maxdepth 1 -print -quit)" ]
+    [ ! -e "$cache_root/base/history/runs.jsonl" ]
+    [ ! -e "$TEST_STATE_DIR/history-recorded" ]
+}
+
+
+@test "basectl preserves an inherited parent run bundle after a leaf usage error" {
+    local cache_root="$TEST_TMPDIR/cache"
+    local inherited_root="$cache_root/base/runs/parent-run__setup"
+
+    mkdir -p "$inherited_root/logs" "$inherited_root/tmp/parent"
+    touch "$inherited_root/logs/primary.log" "$inherited_root/tmp/parent/proof.txt"
+    printf '%s\n' '{"run_id":"parent-run","owner":"base","status":"running"}' > "$inherited_root/run.json"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_CACHE_DIR="$cache_root" \
+        BASE_CLI_RUNTIME_OWNER=base \
+        BASE_CLI_RUN_ID=parent-run \
+        BASE_CLI_RUN_ROOT="$inherited_root" \
+        BASE_BASH_LIBS_PRIMARY_LOG="$inherited_root/logs/primary.log" \
+        BASE_CLI_HISTORY_PARENT_RUN_ID=parent-run \
+        BASE_CLI_HISTORY_SCOPE=internal \
+        BASE_TEST_STATE_DIR="$TEST_STATE_DIR" \
+        bash -c '
+            source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
+            base_std_log_debug() { :; }
+            basectl_do_setup() { return 2; }
+            basectl_history_record() { touch "$BASE_TEST_STATE_DIR/history-recorded"; }
+            basectl_main setup
+        '
+
+    [ "$status" -eq 2 ]
+    grep -Fq '"status":"running"' "$inherited_root/run.json"
+    [ -f "$inherited_root/tmp/parent/proof.txt" ]
+    [ ! -e "$TEST_STATE_DIR/history-recorded" ]
+}
+
+
 @test "basectl keeps a run bundle for a recognized command failure" {
     local cache_root="$TEST_TMPDIR/cache"
     local run_root
@@ -53,11 +111,12 @@ load ./basectl_helpers.bash
         HOME="$TEST_HOME" \
         BASE_HOME="$BASE_REPO_ROOT" \
         BASE_CACHE_DIR="$cache_root" \
+        BASE_TEST_STATE_DIR="$TEST_STATE_DIR" \
         bash -c '
             source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
             base_std_log_debug() { :; }
             basectl_do_setup() { return 7; }
-            basectl_history_record() { :; }
+            basectl_history_record() { touch "$BASE_TEST_STATE_DIR/history-recorded"; }
             basectl_main setup
         '
 
@@ -66,6 +125,7 @@ load ./basectl_helpers.bash
     [ -n "$run_root" ]
     [ -f "$run_root/run.json" ]
     [ -f "$run_root/logs/primary.log" ]
+    [ -f "$TEST_STATE_DIR/history-recorded" ]
 }
 
 

--- a/cli/bash/commands/basectl/tests/test.bats
+++ b/cli/bash/commands/basectl/tests/test.bats
@@ -343,3 +343,56 @@ EOF
     [ "$status" -ne 2 ]
     [[ "$output" != *"ERROR: Unknown test option '--unknown'."* ]]
 }
+
+@test "basectl test discards artifacts after a leaf parser rejection" {
+    local cache_root="$TEST_TMPDIR/cache"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_CACHE_DIR="$cache_root" \
+        "$BASE_REPO_ROOT/bin/basectl" test --unknown
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"ERROR: Unknown test option '--unknown'."* ]]
+    [ -d "$cache_root/base/runs" ]
+    [ -z "$(find "$cache_root/base/runs" -mindepth 1 -maxdepth 1 -type d -print -quit)" ]
+    [ ! -e "$cache_root/base/history/runs.jsonl" ]
+}
+
+@test "basectl test discards artifacts when an explicit project does not exist" {
+    local cache_root="$TEST_TMPDIR/cache"
+    local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
+
+    mkdir -p "$(dirname "$python_bin")"
+    cat > "$python_bin" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "base-dmo" ]]; then
+    printf '{"version":1,"bundles":[{"path":"%s","run_id":"stale","status":"running","started_at":1,"size":1,"preserve":false}]}\n' \
+        "${BASE_CLI_RUN_ROOT:?}" > "${BASE_CLI_RUN_ROOT%/*}/.base-cli-run-index.json"
+    printf "Project 'base-dmo' was not found in workspace '/workspace'.\n" >&2
+    exit 2
+fi
+if [[ "${1:-}" == "-m" && "${2:-}" == "base_cli_adapters.run_index" ]]; then
+    printf '{"version":1,"bundles":[]}\n' > "${3:?}/.base-cli-run-index.json"
+    exit 0
+fi
+printf 'unexpected test python args: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$python_bin"
+
+    run env \
+        HOME="$TEST_HOME" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        BASE_CACHE_DIR="$cache_root" \
+        "$BASE_REPO_ROOT/bin/basectl" test base-dmo
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Project 'base-dmo' was not found"* ]]
+    [ -d "$cache_root/base/runs" ]
+    [ -z "$(find "$cache_root/base/runs" -mindepth 1 -maxdepth 1 -type d -print -quit)" ]
+    [ ! -e "$cache_root/base/history/runs.jsonl" ]
+    run grep -Fq 'base-dmo' "$cache_root/base/runs/.base-cli-run-index.json"
+    [ "$status" -eq 1 ]
+}

--- a/cli/python/base_cli_adapters/run_index.py
+++ b/cli/python/base_cli_adapters/run_index.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Sequence
+
+import base_cli
+
+# The outer Bash lifecycle owns Base's inherited bundle. base-cli owns the
+# retention index that its delegated Python children update, so use its single
+# lock-aware refresh implementation instead of editing that index in Bash.
+from base_cli._runtime import refresh_run_bundle_index
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 1:
+        print("Usage: python -m base_cli_adapters.run_index <runs-root>", file=sys.stderr)
+        return base_cli.ExitCode.USAGE_ERROR
+    refresh_run_bundle_index(Path(args[0]))
+    return base_cli.ExitCode.SUCCESS
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/python/base_cli_adapters/tests/test_run_index.py
+++ b/cli/python/base_cli_adapters/tests/test_run_index.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from base_cli_adapters import run_index
+
+
+class RunIndexTests(unittest.TestCase):
+    def test_main_refreshes_stale_bundle_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runs_root = Path(tmpdir)
+            stale_path = runs_root / "missing-run"
+            (runs_root / ".base-cli-run-index.json").write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "bundles": [
+                            {
+                                "path": str(stale_path),
+                                "run_id": stale_path.name,
+                                "status": "running",
+                                "started_at": 1,
+                                "size": 1,
+                                "preserve": False,
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            status = run_index.main([str(runs_root)])
+            payload = json.loads(
+                (runs_root / ".base-cli-run-index.json").read_text(encoding="utf-8")
+            )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(payload, {"version": 1, "bundles": []})
+
+    def test_main_rejects_invalid_arguments(self) -> None:
+        self.assertEqual(run_index.main([]), 2)

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -65,6 +65,7 @@ from base_projects.workspace_report_text import print_workspace_agent_brief
 from base_projects.workspace_report_text import print_workspace_onboarding
 from base_projects.workspace_report_text import print_workspace_status
 from base_projects.workspace_scanner import ProjectDiscoveryError
+from base_projects.workspace_scanner import ProjectNotFoundError
 from base_projects.workspace_statuses import workspace_project_statuses
 from base_setup.demo import resolve_demo_script_path
 from base_setup.errors import ArtifactError
@@ -557,6 +558,9 @@ def test_command_project_command(
         else:
             project = current_project()
         manifest = read_manifest(project.manifest_path)
+    except ProjectNotFoundError as exc:
+        ctx.log.error(str(exc))
+        return base_cli.ExitCode.USAGE_ERROR
     except (ProjectDiscoveryError, ManifestError) as exc:
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
@@ -875,7 +879,7 @@ def resolve_named_project(ctx: base_cli.Context, project_name: str, workspace: s
         return bind_project_context(ctx, project)
 
     workspace_root = resolve_workspace_root(ctx, workspace)
-    raise ProjectDiscoveryError(f"Project '{project_name}' was not found in workspace '{workspace_root}'.")
+    raise ProjectNotFoundError(f"Project '{project_name}' was not found in workspace '{workspace_root}'.")
 
 
 def bind_project_context(ctx: base_cli.Context, project: Project) -> Project:

--- a/cli/python/base_projects/project_discovery.py
+++ b/cli/python/base_projects/project_discovery.py
@@ -12,6 +12,7 @@ import base_cli
 from base_cli_adapters.paths import base_cache_root, discover_manifest
 from base_projects.workspace_scanner import ManifestEntry
 from base_projects.workspace_scanner import ProjectDiscoveryError
+from base_projects.workspace_scanner import ProjectNotFoundError
 from base_projects.workspace_scanner import workspace_manifest_entries
 from base_setup.manifest import read_manifest
 from base_setup.manifest_loader import ManifestError
@@ -63,7 +64,7 @@ def find_project_in_projects(projects: tuple[Project, ...], workspace_root: Path
     for project in projects:
         if project.name == project_name:
             return project
-    raise ProjectDiscoveryError(f"Project '{project_name}' was not found in workspace '{workspace_root}'.")
+    raise ProjectNotFoundError(f"Project '{project_name}' was not found in workspace '{workspace_root}'.")
 
 
 def resolve_active_project(project_name: str) -> Project | None:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -1005,6 +1005,18 @@ class ProjectDiscoveryTests(unittest.TestCase):
             f"{base_route_fields(base_home, 'demo')}\n",
         )
 
+    def test_projects_test_command_treats_unknown_named_project_as_usage_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+
+            status, stdout, stderr = run_engine(["test-command", "base-dmo"], base_home)
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn(f"Project 'base-dmo' was not found in workspace '{workspace.resolve()}'.", stderr)
+
     def test_projects_test_command_marks_manifest_command_trust_required(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)

--- a/cli/python/base_projects/workspace_scanner.py
+++ b/cli/python/base_projects/workspace_scanner.py
@@ -8,6 +8,10 @@ class ProjectDiscoveryError(RuntimeError):
     pass
 
 
+class ProjectNotFoundError(ProjectDiscoveryError):
+    pass
+
+
 @dataclass(frozen=True)
 class ManifestEntry:
     path: Path

--- a/docs/cache-ownership-and-layout.md
+++ b/docs/cache-ownership-and-layout.md
@@ -108,13 +108,17 @@ by individual Base components. This state is not tied to one diagnostic run.
 
 ### `base/runs/`
 
-One directory per Base control-plane invocation. The directory name starts
-with the canonical run ID and adds sanitized command/project labels for manual
-inspection, for example `20260719T052536_37996_8494__setup__base`. The labels
-are filesystem display context only; `run.json`, history, and CLI output retain
-the canonical run ID without the suffix. `run.json` is written at the
-start with `status: running` and finalized with timestamps, exit status,
-project metadata, command arguments, and parent/child references when known.
+One directory per accepted Base control-plane invocation. The directory name
+starts with the canonical run ID and adds sanitized command/project labels for
+manual inspection, for example
+`20260719T052536_37996_8494__setup__base`. The labels are filesystem display
+context only; `run.json`, history, and CLI output retain the canonical run ID
+without the suffix. `run.json` is written at the start with `status: running`
+and finalized with timestamps, exit status, project metadata, command
+arguments, and parent/child references when known. A recognized command may
+create this directory temporarily while validating leaf arguments or a named
+project, but a usage rejection removes the invocation-owned directory and does
+not write history. An inherited parent run directory is outside that cleanup.
 Run metadata and the primary log are private (`0600`). `primary.log` is the
 single diagnostic stream for the invocation. Bash and Python children append
 to this same file, which always captures DEBUG-level diagnostics even when the
@@ -174,7 +178,8 @@ the ownership boundary described above.
 
 ## Runtime invariants
 
-1. Every public invocation has one owner and one top-level run bundle.
+1. Every accepted public invocation has one owner and one top-level run bundle;
+   rejected usage invocations leave no persistent run bundle or history row.
 2. Base-owned processes always resolve the `base/` owner explicitly.
 3. Project-owned processes resolve their project ID and checkout ID from the
    validated manifest and canonical project root.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -81,11 +81,14 @@ History writes are best-effort:
 - ignore malformed history lines while warning in debug output
 
 `basectl history` shows one record per accepted public command invocation.
-Top-level command and wrapper-syntax errors are rejected before persistent
-runtime state is initialized, so they do not create a run bundle or history
-record. Once a recognized command is accepted, its run remains observable even
-if leaf-level argument validation, environment checks, or execution later
-fails. Legacy internal rows are ignored so old caches do not reintroduce
+Top-level command, wrapper-syntax, and leaf-level usage errors are rejected
+without persistent run evidence, so they do not create a retained run bundle
+or history record. A recognized command may initialize a temporary bundle
+before its leaf parser or project selector rejects the invocation; `basectl`
+discards that invocation-owned bundle before returning usage status `2`.
+Inherited parent bundles are never discarded. Once command usage is accepted,
+environment, manifest, trust, discovery, and execution failures remain
+observable. Legacy internal rows are ignored so old caches do not reintroduce
 duplicate command entries.
 
 ## Record Shape


### PR DESCRIPTION
## Summary

- classify an explicitly missing basectl test project as a usage error
- discard only invocation-owned bundles, logs, history, and stale run-index entries for status 2
- preserve inherited parents and accepted-command failure observability

## Issue

Fixes #1986

## Validation

- focused Python: 13 passed
- runtime-dispatch BATS: 33 passed
- basectl test BATS: 13 passed
- ShellCheck and Pylint passed
- full harness Python phase: 989 passed
- full harness BATS phase: 874 of 875 passed; the unrelated finding-order overlap case passed immediately when rerun alone
- live isolated-cache basectl test base-dmo proof: exit 2, no retained bundle, log, history, or stale index reference
- git diff --check

## Docs Impact

Updated the changelog and observability/cache lifecycle documentation to define the rejected-usage persistence boundary.

## AI Context Impact

Updated .ai-context/COMMANDS.md with the same public command contract.

## Demo Impact

None.