### PR TITLE
Validate inherited run bundle context

### DIFF
--- a/.ai-context/ARCHITECTURE.md
+++ b/.ai-context/ARCHITECTURE.md
@@ -60,6 +60,13 @@ with the selected project virtual environment and a `PYTHONPATH` that includes
 Base's `lib/python` and `cli/python`; the `base_cli` provider is selected by
 `lib/base/base_cli_runtime.sh` and is not copied into this repository.
 
+Run-bundle propagation is an internal capability, not user configuration.
+`basectl` reuses inherited bundle state only when the physical path is a real
+direct child of the active Base cache owner root and the owner, run ID, parent
+ID, primary log, and running metadata all agree. Invalid state is scrubbed and
+replaced with a fresh bundle, and finalization repeats the validation before
+writing metadata or removing temporary data.
+
 Project Python ownership is explicit. A top-level `python:` mapping (including
 `python: {}`) or a `python-package` artifact requires a project runtime.
 Shell-only manifests use Base's own venv for setup/check/doctor control-plane

--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -613,24 +613,78 @@ basectl_run_bundle_label() {
     fi
 }
 
+basectl_scrub_inherited_run_context() {
+    unset \
+        BASE_CLI_RUNTIME_OWNER \
+        BASE_CLI_RUN_ID \
+        BASE_CLI_RUN_ROOT \
+        BASE_CLI_PRIMARY_LOG \
+        BASE_BASH_LIBS_PRIMARY_LOG \
+        BASE_CLI_HISTORY_PARENT_RUN_ID \
+        BASE_CLI_HISTORY_STARTED_AT \
+        BASE_CLI_HISTORY_SCOPE \
+        BASE_CLI_HISTORY_PROJECT \
+        BASE_CLI_HISTORY_PROJECT_ROOT \
+        BASE_CLI_HISTORY_MANIFEST
+}
+
+basectl_run_bundle_context_is_valid() {
+    local cache_root="$1"
+    local require_internal="${2:-true}"
+    local require_running="${3:-true}"
+    local run_root="${BASE_CLI_RUN_ROOT:-}"
+    local run_id="${BASE_CLI_RUN_ID:-}"
+    local runs_root physical_runs_root physical_run_root run_name metadata expected_log
+
+    [[ "${BASE_CLI_RUNTIME_OWNER:-}" == base ]] || return 1
+    [[ "$require_internal" != true || "${BASE_CLI_HISTORY_SCOPE:-}" == internal ]] || return 1
+    [[ -n "$run_id" && "$run_id" =~ ^[a-zA-Z0-9][a-zA-Z0-9_-]*$ ]] || return 1
+    [[ "$run_id" != *"__"* && "$run_id" != *".."* ]] || return 1
+    [[ "${BASE_CLI_HISTORY_PARENT_RUN_ID:-}" == "$run_id" ]] || return 1
+    [[ -n "$run_root" && -d "$run_root" && ! -L "$run_root" ]] || return 1
+
+    runs_root="$cache_root/base/runs"
+    [[ -d "$runs_root" && ! -L "$cache_root/base" && ! -L "$runs_root" ]] || return 1
+    physical_runs_root="$(cd -- "$runs_root" 2>/dev/null && pwd -P)" || return 1
+    physical_run_root="$(cd -- "$run_root" 2>/dev/null && pwd -P)" || return 1
+    [[ "$(dirname -- "$physical_run_root")" == "$physical_runs_root" ]] || return 1
+
+    run_name="$(basename -- "$physical_run_root")"
+    [[ "$run_name" == "$run_id" || "$run_name" == "$run_id"__* ]] || return 1
+    [[ -d "$run_root/logs" && ! -L "$run_root/logs" ]] || return 1
+    [[ -f "$run_root/run.json" && ! -L "$run_root/run.json" ]] || return 1
+    expected_log="$run_root/logs/primary.log"
+    [[ "${BASE_BASH_LIBS_PRIMARY_LOG:-}" == "$expected_log" ]] || return 1
+    [[ -f "$expected_log" && ! -L "$expected_log" ]] || return 1
+    [[ ! -L "$run_root/run.json.tmp" ]] || return 1
+    [[ ! -e "$run_root/tmp" || (-d "$run_root/tmp" && ! -L "$run_root/tmp") ]] || return 1
+
+    metadata="$(<"$run_root/run.json")" || return 1
+    [[ "$metadata" != *$'\n'* ]] || return 1
+    [[ "$metadata" =~ \"run_id\"[[:space:]]*:[[:space:]]*\"$run_id\" ]] || return 1
+    [[ "$metadata" =~ \"owner\"[[:space:]]*:[[:space:]]*\"base\" ]] || return 1
+    if [[ "$require_running" == true ]]; then
+        [[ "$metadata" =~ \"status\"[[:space:]]*:[[:space:]]*\"running\" ]] || return 1
+    else
+        [[ "$metadata" =~ \"status\"[[:space:]]*:[[:space:]]*\"(running|ok|error)\" ]] || return 1
+    fi
+}
+
 basectl_initialize_run_bundle() {
     local command="${1:-run}" cache_root run_id run_root label
     shift || true
 
     _basectl_run_bundle_created=0
+    cache_root="$(basectl_cache_root)"
+    _BASECTL_ACTIVE_RUN_CACHE_ROOT="$cache_root"
     if [[ -n "${BASE_CLI_RUN_ROOT:-}" ]]; then
-        export BASE_CLI_RUNTIME_OWNER=base
-        if [[ -z "${BASE_CLI_RUN_ID:-}" ]]; then
-            BASE_CLI_RUN_ID="$(basename -- "$BASE_CLI_RUN_ROOT")"
-            BASE_CLI_RUN_ID="${BASE_CLI_RUN_ID%%__*}"
-            export BASE_CLI_RUN_ID
+        if basectl_run_bundle_context_is_valid "$cache_root"; then
+            return 0
         fi
-        export BASE_BASH_LIBS_PRIMARY_LOG="${BASE_BASH_LIBS_PRIMARY_LOG:-$BASE_CLI_RUN_ROOT/logs/primary.log}"
-        export BASE_CLI_HISTORY_PARENT_RUN_ID="${BASE_CLI_HISTORY_PARENT_RUN_ID:-$BASE_CLI_RUN_ID}"
-        return 0
+        basectl_scrub_inherited_run_context
+        base_std_log_warn "Ignoring invalid inherited Base run context; creating a fresh run bundle."
     fi
 
-    cache_root="$(basectl_cache_root)"
     run_id="$(date -u +%Y%m%dT%H%M%S 2>/dev/null || true)_${BASHPID:-$$}_${RANDOM}"
     label="$(basectl_run_bundle_label "$command" "$@")"
     run_root="$cache_root/base/runs/${run_id}__${label}"
@@ -655,29 +709,35 @@ basectl_initialize_run_bundle() {
 }
 
 basectl_finalize_run_bundle() {
-    local exit_code="$1" run_root tmp_file
+    local exit_code="$1" cache_root run_root tmp_file
 
     run_root="${BASE_CLI_RUN_ROOT:-}"
     [[ -n "$run_root" && -d "$run_root" ]] || return 0
-    tmp_file="$run_root/run.json.tmp"
+    cache_root="${_BASECTL_ACTIVE_RUN_CACHE_ROOT:-$(basectl_cache_root)}"
+    if ! basectl_run_bundle_context_is_valid "$cache_root" false false; then
+        base_std_log_warn "Skipping finalization for an invalid Base run context."
+        return 1
+    fi
+    tmp_file="$(mktemp "$run_root/.run.json.XXXXXX")" || return 1
     printf '{"run_id":"%s","owner":"base","status":"%s","exit_code":%s,"started_at":"%s","ended_at":"%s"}\n' \
         "${BASE_CLI_RUN_ID:-$(basename -- "$run_root")}" \
         "$([[ "$exit_code" == 0 ]] && printf ok || printf error)" "$exit_code" \
         "${BASE_CLI_HISTORY_STARTED_AT:-}" \
-        "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" >"$tmp_file" && mv -f "$tmp_file" "$run_root/run.json"
-    chmod 600 "$run_root/run.json" "${BASE_BASH_LIBS_PRIMARY_LOG:-$run_root/logs/primary.log}" || return 1
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" >"$tmp_file" || return 1
+    chmod 600 "$tmp_file" || return 1
+    mv -f "$tmp_file" "$run_root/run.json" || return 1
     if [[ "${BASE_CLI_KEEP_TEMP:-}" != true ]]; then
         rm -rf -- "$run_root/tmp"
     fi
 }
 
 basectl_discard_invocation_run_bundle() {
-    local run_root="${BASE_CLI_RUN_ROOT:-}" runs_root wrapper
+    local run_root="${BASE_CLI_RUN_ROOT:-}" cache_root runs_root wrapper
 
     [[ "${_basectl_run_bundle_created:-0}" == 1 ]] || return 0
-    [[ -n "$run_root" && -d "$run_root" && ! -L "$run_root" ]] || return 1
-    runs_root="${run_root%/*}"
-    [[ -n "$runs_root" && "$runs_root" != "$run_root" ]] || return 1
+    cache_root="${_BASECTL_ACTIVE_RUN_CACHE_ROOT:-$(basectl_cache_root)}"
+    basectl_run_bundle_context_is_valid "$cache_root" false false || return 1
+    runs_root="$cache_root/base/runs"
     rm -rf -- "$run_root" || return 1
 
     # Delegated base-cli children may have indexed the inherited outer bundle
@@ -736,7 +796,7 @@ basectl_main() {
         keep_temp=1
         shift
     done
-    local history_args=() history_scope="${BASE_CLI_HISTORY_SCOPE:-primary}"
+    local history_args=() history_scope
     local opt
 
     if [[ "${1:-}" == "help" ]]; then
@@ -827,6 +887,7 @@ basectl_main() {
     if ((run_bundle_enabled)); then
         basectl_initialize_run_bundle "$command" "$@" || return 1
     fi
+    history_scope="${BASE_CLI_HISTORY_SCOPE:-primary}"
     export BASE_CLI_HISTORY_SCOPE=internal
     BASE_CLI_HISTORY_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
     export BASE_CLI_HISTORY_STARTED_AT
@@ -882,10 +943,14 @@ basectl_main() {
         if ((command_status == 2)); then
             basectl_discard_invocation_run_bundle || {
                 base_std_log_warn "Unable to discard rejected invocation run bundle."
+                basectl_scrub_inherited_run_context
             }
         else
-            basectl_finalize_run_bundle "$command_status"
-            basectl_history_record "$command" "$command_status" "$history_scope" "${history_args[@]}"
+            if basectl_finalize_run_bundle "$command_status"; then
+                basectl_history_record "$command" "$command_status" "$history_scope" "${history_args[@]}"
+            else
+                basectl_scrub_inherited_run_context
+            fi
         fi
     fi
     return "$command_status"

--- a/cli/bash/commands/basectl/tests/runtime-dispatch.bats
+++ b/cli/bash/commands/basectl/tests/runtime-dispatch.bats
@@ -26,6 +26,259 @@ load ./basectl_helpers.bash
 }
 
 
+@test "basectl replaces an external inherited run root without mutating it" {
+    local cache_root="$TEST_TMPDIR/cache"
+    local external_root="$TEST_TMPDIR/private-token-external"
+    local fresh_root
+
+    mkdir -p "$external_root/logs" "$external_root/tmp/private"
+    touch "$external_root/logs/primary.log" "$external_root/tmp/private/proof.txt"
+    printf '%s\n' '{"sentinel":"must-survive"}' > "$external_root/run.json"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_CACHE_DIR="$cache_root" \
+        BASE_CLI_RUNTIME_OWNER=base \
+        BASE_CLI_RUN_ID=attacker-run \
+        BASE_CLI_RUN_ROOT="$external_root" \
+        BASE_BASH_LIBS_PRIMARY_LOG="$external_root/logs/primary.log" \
+        BASE_CLI_HISTORY_PARENT_RUN_ID=attacker-run \
+        BASE_CLI_HISTORY_SCOPE=internal \
+        bash -c '
+            source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
+            base_std_log_debug() { :; }
+            basectl_do_setup() { return 0; }
+            basectl_history_record() { :; }
+            basectl_main setup
+    '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"private-token-external"* ]]
+    grep -Fq '"sentinel":"must-survive"' "$external_root/run.json"
+    [ -f "$external_root/tmp/private/proof.txt" ]
+    fresh_root="$(find "$cache_root/base/runs" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+    [ -n "$fresh_root" ]
+    grep -Fq '"status":"ok"' "$fresh_root/run.json"
+}
+
+
+@test "basectl preserves an external inherited run root after command failure" {
+    local cache_root="$TEST_TMPDIR/cache"
+    local external_root="$TEST_TMPDIR/external-failure"
+    local fresh_root
+
+    mkdir -p "$external_root/logs" "$external_root/tmp/private"
+    touch "$external_root/logs/primary.log" "$external_root/tmp/private/proof.txt"
+    printf '%s\n' '{"sentinel":"must-survive"}' > "$external_root/run.json"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_CACHE_DIR="$cache_root" \
+        BASE_CLI_RUNTIME_OWNER=base \
+        BASE_CLI_RUN_ID=attacker-run \
+        BASE_CLI_RUN_ROOT="$external_root" \
+        BASE_BASH_LIBS_PRIMARY_LOG="$external_root/logs/primary.log" \
+        BASE_CLI_HISTORY_PARENT_RUN_ID=attacker-run \
+        BASE_CLI_HISTORY_SCOPE=internal \
+        bash -c '
+            source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
+            base_std_log_debug() { :; }
+            basectl_do_setup() { return 7; }
+            basectl_history_record() { :; }
+            basectl_main setup
+        '
+
+    [ "$status" -eq 7 ]
+    grep -Fq '"sentinel":"must-survive"' "$external_root/run.json"
+    [ -f "$external_root/tmp/private/proof.txt" ]
+    fresh_root="$(find "$cache_root/base/runs" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+    [ -n "$fresh_root" ]
+    grep -Fq '"status":"error"' "$fresh_root/run.json"
+    grep -Fq '"exit_code":7' "$fresh_root/run.json"
+}
+
+
+@test "basectl keep-temp applies only to the fresh bundle after invalid inheritance" {
+    local cache_root="$TEST_TMPDIR/cache"
+    local external_root="$TEST_TMPDIR/external-keep-temp"
+    local fresh_root
+
+    mkdir -p "$external_root/logs" "$external_root/tmp/private"
+    touch "$external_root/logs/primary.log" "$external_root/tmp/private/proof.txt"
+    printf '%s\n' '{"sentinel":"must-survive"}' > "$external_root/run.json"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_CACHE_DIR="$cache_root" \
+        BASE_CLI_RUNTIME_OWNER=base \
+        BASE_CLI_RUN_ID=attacker-run \
+        BASE_CLI_RUN_ROOT="$external_root" \
+        BASE_BASH_LIBS_PRIMARY_LOG="$external_root/logs/primary.log" \
+        BASE_CLI_HISTORY_PARENT_RUN_ID=attacker-run \
+        BASE_CLI_HISTORY_SCOPE=internal \
+        bash -c '
+            source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
+            base_std_log_debug() { :; }
+            basectl_do_setup() {
+                mkdir -p "$BASE_CLI_RUN_ROOT/tmp/base_setup"
+                touch "$BASE_CLI_RUN_ROOT/tmp/base_setup/fresh.txt"
+                return 0
+            }
+            basectl_history_record() { :; }
+            basectl_main --keep-temp setup
+        '
+
+    [ "$status" -eq 0 ]
+    grep -Fq '"sentinel":"must-survive"' "$external_root/run.json"
+    [ -f "$external_root/tmp/private/proof.txt" ]
+    fresh_root="$(find "$cache_root/base/runs" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+    [ -f "$fresh_root/tmp/base_setup/fresh.txt" ]
+}
+
+
+@test "basectl rejects a symlinked inherited run root" {
+    local cache_root="$TEST_TMPDIR/cache"
+    local external_root="$TEST_TMPDIR/external-symlink-target"
+    local inherited_root="$cache_root/base/runs/linked-run__setup"
+
+    mkdir -p "$external_root/logs" "$external_root/tmp/private" "$(dirname "$inherited_root")"
+    touch "$external_root/logs/primary.log" "$external_root/tmp/private/proof.txt"
+    printf '%s\n' '{"run_id":"linked-run","owner":"base","status":"running"}' > "$external_root/run.json"
+    ln -s "$external_root" "$inherited_root"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_CACHE_DIR="$cache_root" \
+        BASE_CLI_RUNTIME_OWNER=base \
+        BASE_CLI_RUN_ID=linked-run \
+        BASE_CLI_RUN_ROOT="$inherited_root" \
+        BASE_BASH_LIBS_PRIMARY_LOG="$inherited_root/logs/primary.log" \
+        BASE_CLI_HISTORY_PARENT_RUN_ID=linked-run \
+        BASE_CLI_HISTORY_SCOPE=internal \
+        bash -c '
+            source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
+            base_std_log_debug() { :; }
+            basectl_do_setup() { return 0; }
+            basectl_history_record() { :; }
+            basectl_main setup
+        '
+
+    [ "$status" -eq 0 ]
+    [ -L "$inherited_root" ]
+    [ -f "$external_root/tmp/private/proof.txt" ]
+    grep -Fq '"status":"running"' "$external_root/run.json"
+}
+
+
+@test "basectl rejects mismatched inherited run identity" {
+    local cache_root="$TEST_TMPDIR/cache"
+    local inherited_root="$cache_root/base/runs/expected-run__setup"
+
+    mkdir -p "$inherited_root/logs" "$inherited_root/tmp/private"
+    touch "$inherited_root/logs/primary.log" "$inherited_root/tmp/private/proof.txt"
+    printf '%s\n' '{"run_id":"different-run","owner":"base","status":"running"}' > "$inherited_root/run.json"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_CACHE_DIR="$cache_root" \
+        BASE_CLI_RUNTIME_OWNER=base \
+        BASE_CLI_RUN_ID=expected-run \
+        BASE_CLI_RUN_ROOT="$inherited_root" \
+        BASE_BASH_LIBS_PRIMARY_LOG="$inherited_root/logs/primary.log" \
+        BASE_CLI_HISTORY_PARENT_RUN_ID=wrong-parent \
+        BASE_CLI_HISTORY_SCOPE=internal \
+        bash -c '
+            source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
+            base_std_log_debug() { :; }
+            basectl_do_setup() { return 0; }
+            basectl_history_record() { :; }
+            basectl_main setup
+        '
+
+    [ "$status" -eq 0 ]
+    [ -f "$inherited_root/tmp/private/proof.txt" ]
+    grep -Fq '"run_id":"different-run"' "$inherited_root/run.json"
+}
+
+
+@test "basectl reuses a validated internal run bundle" {
+    local cache_root="$TEST_TMPDIR/cache"
+    local inherited_root="$cache_root/base/runs/parent-run__setup"
+
+    mkdir -p "$inherited_root/logs" "$inherited_root/tmp/private"
+    touch "$inherited_root/logs/primary.log" "$inherited_root/tmp/private/proof.txt"
+    printf '%s\n' '{"run_id":"parent-run","owner":"base","status":"running"}' > "$inherited_root/run.json"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_CACHE_DIR="$cache_root" \
+        BASE_CLI_RUNTIME_OWNER=base \
+        BASE_CLI_RUN_ID=parent-run \
+        BASE_CLI_RUN_ROOT="$inherited_root" \
+        BASE_BASH_LIBS_PRIMARY_LOG="$inherited_root/logs/primary.log" \
+        BASE_CLI_HISTORY_PARENT_RUN_ID=parent-run \
+        BASE_CLI_HISTORY_SCOPE=internal \
+        bash -c '
+            source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
+            base_std_log_debug() { :; }
+            basectl_do_setup() { return 0; }
+            basectl_history_record() { :; }
+            basectl_main setup
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Ignoring invalid inherited Base run context"* ]]
+    grep -Fq '"run_id":"parent-run"' "$inherited_root/run.json"
+    grep -Fq '"status":"ok"' "$inherited_root/run.json"
+    [ ! -e "$inherited_root/tmp" ]
+    [ "$(find "$cache_root/base/runs" -mindepth 1 -maxdepth 1 -type d | wc -l)" -eq 1 ]
+}
+
+
+@test "basectl revalidates a run root before finalization" {
+    local cache_root="$TEST_TMPDIR/cache"
+    local inherited_root="$cache_root/base/runs/parent-run__setup"
+    local original_root="$cache_root/base/runs/original-run"
+    local external_root="$TEST_TMPDIR/external-race-target"
+
+    mkdir -p "$inherited_root/logs" "$inherited_root/tmp/private" "$external_root/logs" "$external_root/tmp/private"
+    touch "$inherited_root/logs/primary.log" "$inherited_root/tmp/private/original.txt"
+    touch "$external_root/logs/primary.log" "$external_root/tmp/private/proof.txt"
+    printf '%s\n' '{"run_id":"parent-run","owner":"base","status":"running"}' > "$inherited_root/run.json"
+    printf '%s\n' '{"sentinel":"must-survive"}' > "$external_root/run.json"
+
+    run env \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_CACHE_DIR="$cache_root" \
+        BASE_CLI_RUNTIME_OWNER=base \
+        BASE_CLI_RUN_ID=parent-run \
+        BASE_CLI_RUN_ROOT="$inherited_root" \
+        BASE_BASH_LIBS_PRIMARY_LOG="$inherited_root/logs/primary.log" \
+        BASE_CLI_HISTORY_PARENT_RUN_ID=parent-run \
+        BASE_CLI_HISTORY_SCOPE=internal \
+        BASE_TEST_ORIGINAL_ROOT="$original_root" \
+        BASE_TEST_EXTERNAL_ROOT="$external_root" \
+        bash -c '
+            source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
+            basectl_initialize_run_bundle setup || exit $?
+            mv "$BASE_CLI_RUN_ROOT" "$BASE_TEST_ORIGINAL_ROOT" || exit $?
+            ln -s "$BASE_TEST_EXTERNAL_ROOT" "$BASE_CLI_RUN_ROOT" || exit $?
+            basectl_finalize_run_bundle 0
+        '
+
+    [ "$status" -ne 0 ]
+    [ -f "$external_root/tmp/private/proof.txt" ]
+    grep -Fq '"sentinel":"must-survive"' "$external_root/run.json"
+    [ -f "$original_root/tmp/private/original.txt" ]
+}
+
+
 @test "basectl rejects unknown commands before creating persistent runtime state" {
     local cache_root="$TEST_TMPDIR/cache"
 

--- a/docs/cache-ownership-and-layout.md
+++ b/docs/cache-ownership-and-layout.md
@@ -125,6 +125,12 @@ to this same file, which always captures DEBUG-level diagnostics even when the
 terminal is showing INFO. Normal command stdout remains stdout and is not
 captured here.
 
+Base-internal children may reuse a parent bundle only after the Bash dispatcher
+verifies that the inherited path is a real direct child of this `base/runs/`
+root and that its run metadata and parent markers match. Arbitrary, symlinked,
+completed, or mismatched inherited paths are never finalized; Base scrubs that
+state and creates a fresh bundle instead.
+
 An interactive `basectl activate` bundle remains `running` while the runtime
 shell is open. Shell startup inherits that bundle's run context for its
 diagnostics, but Base clears the context before the prompt so commands entered

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -127,6 +127,12 @@ Primary records use `scope: "primary"` and represent the command the user
 invoked. Delegated records use `scope: "internal"` and carry that invocation's
 `run_id` in `parent_run_id`.
 
+An inherited run bundle is reused only when its physical path is a non-symlink
+direct child of the active Base cache owner root and its owner, run ID, parent
+ID, primary log, and running metadata agree. Invalid inherited state is scrubbed
+without echoing its values, and the invocation receives a fresh local bundle.
+The same boundary is checked again before finalization.
+
 Fields should be omitted when unknown instead of guessed.
 
 The first implementation should not store:

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -133,7 +133,7 @@ the resulting directory tree.
 | --- | --- | --- | --- |
 | `BASE_CACHE_DIR` | User | Overrides the platform default Base cache root. | May be set before invoking Base. |
 | `BASE_CLI_RUNTIME_OWNER` | Base/project launcher | `base` for Base control-plane processes or `project` for a project-native process. | Do not set manually; launchers establish it. |
-| `BASE_CLI_RUN_ROOT` | Parent launcher | Points a Base-internal child at its parent run bundle so it reuses the parent's run ID and `logs/primary.log`. Project launchers deliberately unset it before creating a project-owned bundle. | Do not set manually. |
+| `BASE_CLI_RUN_ROOT` | Parent launcher | Points a Base-internal child at its parent run bundle so it reuses the parent's run ID and `logs/primary.log`. Reuse requires an internal Base context, matching run and parent IDs, running metadata, and a real direct child of the active cache's `base/runs/` directory. Invalid inherited state is scrubbed before Base creates a fresh bundle. Project launchers deliberately unset it before creating a project-owned bundle. | Do not set manually. |
 | `BASE_CLI_HISTORY_PARENT_RUN_ID` | Parent launcher | Links internal or project history records to the public Base invocation. | Do not set manually. |
 
 ## Project Runtime Variables

--- a/tests/test_observability_docs.py
+++ b/tests/test_observability_docs.py
@@ -32,3 +32,21 @@ def test_cleanup_docs_define_the_symlink_containment_boundary() -> None:
     assert "relative to trusted directory descriptors" in observability
     assert "Cleanup rejects symlinks below the resolved" in cache_layout
     assert "never follows them during deletion" in " ".join(commands.split())
+
+
+def test_run_bundle_docs_define_inherited_context_validation() -> None:
+    observability = OBSERVABILITY_DOC.read_text(encoding="utf-8")
+    cache_layout = (REPO_ROOT / "docs" / "cache-ownership-and-layout.md").read_text(
+        encoding="utf-8"
+    )
+    runtime_environment = (REPO_ROOT / "docs" / "runtime-environment.md").read_text(
+        encoding="utf-8"
+    )
+    architecture = (REPO_ROOT / ".ai-context" / "ARCHITECTURE.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "The same boundary is checked again before finalization" in observability
+    assert "Arbitrary, symlinked," in cache_layout
+    assert "Invalid inherited state is scrubbed" in runtime_environment
+    assert "Run-bundle propagation is an internal capability" in architecture


### PR DESCRIPTION
## Summary

- validate inherited Base run roots against the active physical cache owner boundary before reuse
- require matching internal scope, owner, canonical run ID, parent ID, primary log, and run metadata
- scrub invalid inherited state and create a fresh bundle without echoing inherited values
- revalidate before finalization and use a private per-write metadata temporary file
- preserve validated internal parent/child bundle reuse across Bash and Python delegation

## Issue

Fixes #1972

## Validation

- `bash -n cli/bash/commands/basectl/basectl.sh`
- `shellcheck -x cli/bash/commands/basectl/basectl.sh`
- `env TZ=UTC BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/runtime-dispatch.bats` (40 passed)
- focused runtime-shell, activate, and base-test BATS suites (31 passed)
- `env TZ=UTC BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python PYTHONPATH=cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q tests/test_observability_docs.py` (3 passed)
- isolated public-command proof that an external inherited root remains untouched and a fresh bundle is created
- isolated public-command proof that a validated internal parent bundle is reused and finalized
- `env -u BASE_HOME TZ=UTC BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python BASE_CACHE_DIR=/private/tmp/base-1972-full-rebase ./bin/base-test` (990 Python tests and 882 BATS tests passed)
- `git diff --check`

## Security Notes

Top-level inherited `BASE_CLI_RUN_ROOT` values can no longer direct metadata replacement, permission changes, or temporary-tree deletion outside the active Base cache. Symlinked, external, completed, mismatched, or unverifiable contexts are discarded before command execution. Finalization repeats the boundary checks to detect path replacement after initialization, and diagnostics do not reveal inherited values.

## Docs Impact

Updated the runtime environment, observability, and cache ownership documentation with the validated internal propagation contract.

## AI Context Impact

Updated `.ai-context/ARCHITECTURE.md` because run-bundle propagation and finalization are durable runtime boundaries.
