### PR TITLE
Make basectl clean require explicit deletion consent

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -160,9 +160,10 @@ Pass `--format json`; text remains the default. Completed inspections keep
 findings in `data` with `error: null`, while controlled usage or upstream
 failures use an `error` object. The canonical field contract and exit semantics
 are documented in `docs/inspection-json.md`.
-- `basectl clean` - remove old Base runtime logs, temp files, and cache entries;
-  it rejects symlinked paths below the resolved Base cache root and never
-  follows them during deletion.
+- `basectl clean` - preview old completed Base run bundles and component caches;
+  it requires `--yes` for deletion, reports and retains active runs, rejects
+  symlinked paths below the resolved Base cache root, and never follows them
+  during deletion.
 - `basectl logs` - list, print, open, or tail recent Base CLI runtime logs.
 - `basectl history` - list recent structured Base command runs from the local
   history index, with comma-separated OR filters such as

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -82,8 +82,9 @@ such command directories exist. Optional utility CLIs such as `caff` and
 - `basectl setup/check/doctor --profile <list>` manage opt-in prerequisite
   profiles. `sre` is the first additional built-in profile, and profiles compose
   as comma-separated lists such as `--profile dev,sre`.
-- `basectl clean --older-than <age>` removes old runtime artifacts from the Base cache root.
-- `basectl clean --keep-last <count>` keeps the newest log files per CLI log directory.
+- `basectl clean --older-than <age>` previews old completed runtime artifacts from the Base cache root.
+- `basectl clean --keep-last <count>` keeps the newest completed run bundles per owner namespace.
+- `basectl clean ... --yes` applies the reviewed cleanup plan; active runs are always retained and reported.
 - `basectl logs` lists recent Base CLI runtime logs and can print, open, or tail
   the newest matching log file.
 - `basectl logs last-failed` prints the latest failed command metadata and a bounded

--- a/cli/bash/commands/basectl/subcommands/clean.sh
+++ b/cli/bash/commands/basectl/subcommands/clean.sh
@@ -9,16 +9,17 @@ Usage:
   basectl clean [--older-than <age>] [--keep-last <count>] [options]
 
 Options:
-  --older-than <age>  Remove runtime artifacts older than <age>.
+  --older-than <age>  Select runtime artifacts older than <age>.
                       Accepts integer ages with suffix d, h, m, or s.
                       Examples: 30d, 12h, 45m, 60s.
-  --keep-last <count> Keep the newest count log files per CLI log directory.
-  --dry-run           Print what would be removed without deleting anything.
+  --keep-last <count> Keep the newest completed run bundles per owner namespace.
+  --dry-run           Explicitly preview cleanup without deleting anything.
+  --yes               Delete matched artifacts after reviewing the preview.
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
 
-Remove old Base CLI runtime logs, temp files, and cache entries. At least one
-cleanup criterion is required.
+Preview cleanup of old Base CLI runtime logs, temp files, and cache entries.
+Deletion requires --yes, and at least one cleanup criterion is required.
 EOF
 }
 
@@ -38,7 +39,7 @@ base_clean_subcommand_main() {
                 args+=(--debug)
                 shift
                 ;;
-            --older-than|--keep-last|--dry-run)
+            --older-than|--keep-last|--dry-run|--yes)
                 args+=("$1")
                 if [[ "$1" == "--older-than" || "$1" == "--keep-last" ]]; then
                     if [[ "$1" == "--older-than" ]]; then

--- a/cli/bash/commands/basectl/tests/clean.bats
+++ b/cli/bash/commands/basectl/tests/clean.bats
@@ -19,11 +19,11 @@ exit 1
 EOF
     chmod +x "$python_bin"
 
-    run_basectl clean --older-than 30d --dry-run
+    run_basectl clean --older-than 30d --yes
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"BASE_PROJECT=base"* ]]
-    [[ "$output" == *"ARGS=--older-than 30d --dry-run"* ]]
+    [[ "$output" == *"ARGS=--older-than 30d --yes"* ]]
 }
 
 @test "basectl clean prints help without requiring the Base Python venv" {
@@ -34,6 +34,8 @@ EOF
     [[ "$output" == *"basectl clean [--older-than <age>] [--keep-last <count>] [options]"* ]]
     [[ "$output" == *"Accepts integer ages with suffix d, h, m, or s"* ]]
     [[ "$output" == *"Examples: 30d, 12h, 45m, 60s."* ]]
+    [[ "$output" == *"--yes"* ]]
+    [[ "$output" == *"Deletion requires --yes"* ]]
 }
 
 @test "basectl clean reports missing cleanup criterion as a usage error" {

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -317,7 +317,7 @@ EOF
     [[ "$output" == *"prompt_names=list product-self-review"* ]]
     [[ "$output" == *"prompt_options=--output --help"* ]]
     [[ "$output" == *"docs_options=--show-url"* ]]
-    [[ "$output" == *"clean_options=--older-than --keep-last --dry-run"* ]]
+    [[ "$output" == *"clean_options=--older-than --keep-last --dry-run --yes"* ]]
     [[ "$output" == *"logs_options=--command --limit --latest --tail --open --lines"* ]]
     [[ "$output" == *"logs_last_options=--command --lines --format"* ]]
     [[ "$output" == *"logs_commands=last-failed"* ]]

--- a/cli/python/base_clean/engine.py
+++ b/cli/python/base_clean/engine.py
@@ -29,19 +29,30 @@ def main(argv: list[str] | None = None) -> int:
 @app.command(context_settings={"help_option_names": ["-h", "--help"]})
 @base_cli.option(
     "--older-than",
-    help="Remove runtime artifacts older than an age such as 30d, 12h, 45m, or 60s.",
+    help="Select runtime artifacts older than an age such as 30d, 12h, 45m, or 60s.",
 )
 @base_cli.option("--keep-last", help="Keep the newest N run bundles per owner namespace.")
-@base_cli.option("--dry-run", is_flag=True, help="Print what would be removed without deleting anything.")
-def run(ctx: base_cli.Context, older_than: str | None, keep_last: str | None, dry_run: bool) -> int:
+@base_cli.option("--dry-run", is_flag=True, help="Explicitly preview cleanup without deleting anything.")
+@base_cli.option("--yes", is_flag=True, help="Delete matched artifacts after reviewing the preview.")
+def run(  # pylint: disable=too-many-return-statements,too-many-branches
+    ctx: base_cli.Context,
+    older_than: str | None,
+    keep_last: str | None,
+    dry_run: bool,
+    yes: bool,
+) -> int:
     if not older_than and not keep_last:
         ctx.log.error("One of '--older-than' or '--keep-last' is required.")
+        return base_cli.ExitCode.USAGE_ERROR
+    if dry_run and yes:
+        ctx.log.error("Options '--dry-run' and '--yes' cannot be used together.")
         return base_cli.ExitCode.USAGE_ERROR
 
     cache_root = base_cache_root()
     ctx.log.debug("Scanning Base cache root '%s'.", cache_root)
 
     candidates: list[CleanCandidate] = []
+    active_runs: set[Path] = set()
     if older_than:
         try:
             threshold_seconds = parse_age(older_than)
@@ -49,7 +60,14 @@ def run(ctx: base_cli.Context, older_than: str | None, keep_last: str | None, dr
             ctx.log.error(str(exc))
             return base_cli.ExitCode.USAGE_ERROR
         cutoff = time.time() - threshold_seconds
-        candidates.extend(find_clean_candidates(cache_root, cutoff, ctx.log))
+        candidates.extend(
+            find_clean_candidates(
+                cache_root,
+                cutoff,
+                ctx.log,
+                active_runs=active_runs,
+            )
+        )
 
     if keep_last:
         try:
@@ -57,17 +75,24 @@ def run(ctx: base_cli.Context, older_than: str | None, keep_last: str | None, dr
         except ValueError as exc:
             ctx.log.error(str(exc))
             return base_cli.ExitCode.USAGE_ERROR
-        candidates.extend(find_log_retention_candidates(cache_root, keep_count, ctx.log))
+        candidates.extend(
+            find_log_retention_candidates(
+                cache_root,
+                keep_count,
+                ctx.log,
+                active_runs=active_runs,
+            )
+        )
 
     unique_candidates = tuple(deduplicate_candidates(candidates))
-
-    if not unique_candidates:
-        ctx.log.info("No Base runtime artifacts matched the clean criteria.")
-        return base_cli.ExitCode.SUCCESS
+    preview = dry_run or not yes
 
     acted_count = 0
     for candidate in unique_candidates:
-        if dry_run:
+        if candidate.category == "run" and run_is_running(candidate.path):
+            active_runs.add(candidate.path)
+            continue
+        if preview:
             if not clean_path_is_safe(cache_root, candidate.path, "candidate", ctx.log):
                 continue
             print(f"Would remove\t{candidate.category}\t{candidate.path}")
@@ -76,13 +101,20 @@ def run(ctx: base_cli.Context, older_than: str | None, keep_last: str | None, dr
             print(f"Removing\t{candidate.category}\t{candidate.path}")
             acted_count += 1
 
+    for active_run in sorted(active_runs, key=str):
+        print(f"Retaining\tactive run\t{active_run}")
+
+    if not unique_candidates:
+        ctx.log.info("No Base runtime artifacts matched the clean criteria.")
+        return base_cli.ExitCode.SUCCESS
+
     if not acted_count:
         ctx.log.info("No safe Base runtime artifacts matched the clean criteria.")
         return base_cli.ExitCode.SUCCESS
 
     ctx.log.info(
         "%s %s Base runtime artifact(s).",
-        "Would remove" if dry_run else "Removed",
+        "Would remove" if preview else "Removed",
         acted_count,
     )
     return base_cli.ExitCode.SUCCESS
@@ -118,7 +150,13 @@ def parse_keep_last(value: str) -> int:
     return amount
 
 
-def find_clean_candidates(cache_root: Path, cutoff: float, logger: object | None = None) -> list[CleanCandidate]:
+def find_clean_candidates(
+    cache_root: Path,
+    cutoff: float,
+    logger: object | None = None,
+    *,
+    active_runs: set[Path] | None = None,
+) -> list[CleanCandidate]:
     candidates: list[CleanCandidate] = []
     for owner_root in runtime_owner_roots(cache_root, logger):
         if logger is not None:
@@ -130,6 +168,7 @@ def find_clean_candidates(cache_root: Path, cutoff: float, logger: object | None
                 "run",
                 cutoff,
                 logger,
+                active_runs=active_runs,
             )
         )
         candidates.extend(
@@ -148,6 +187,8 @@ def find_log_retention_candidates(
     cache_root: Path,
     keep_count: int,
     logger: object | None = None,
+    *,
+    active_runs: set[Path] | None = None,
 ) -> list[CleanCandidate]:
     candidates: list[CleanCandidate] = []
     for owner_root in runtime_owner_roots(cache_root, logger):
@@ -170,7 +211,11 @@ def find_log_retention_candidates(
                 "candidate",
                 logger,
                 require_directory=True,
-            ) or run_is_running(path):
+            ):
+                continue
+            if run_is_running(path):
+                if active_runs is not None:
+                    active_runs.add(path)
                 continue
             try:
                 run_dirs.append((path, run_metadata_mtime(path)))
@@ -377,12 +422,14 @@ def deduplicate_candidates(candidates: list[CleanCandidate]) -> list[CleanCandid
     return sorted(unique.values(), key=lambda candidate: str(candidate.path))
 
 
-def find_category_candidates(
+def find_category_candidates(  # pylint: disable=too-many-arguments
     cache_root: Path,
     category_root: Path,
     category: str,
     cutoff: float,
     logger: object | None = None,
+    *,
+    active_runs: set[Path] | None = None,
 ) -> list[CleanCandidate]:
     if logger is not None:
         logger.debug("Scanning %s runtime artifacts in '%s'.", category, category_root)
@@ -398,6 +445,10 @@ def find_category_candidates(
     candidates = []
     for path in safe_directory_entries(category_root, "category root", logger):
         if not clean_path_is_safe(cache_root, path, "candidate", logger):
+            continue
+        if category == "run" and run_is_running(path):
+            if active_runs is not None:
+                active_runs.add(path)
             continue
         try:
             mtime = run_metadata_mtime(path) if category == "run" else path.stat().st_mtime

--- a/cli/python/base_clean/tests/test_engine.py
+++ b/cli/python/base_clean/tests/test_engine.py
@@ -1,21 +1,23 @@
 from __future__ import annotations
 
+import io
 import os
 import tempfile
 import time
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 from unittest import mock
 
 from base_clean import engine
 
 
-def create_old_run(root: Path) -> Path:
-    run_root = root / "old-run"
+def create_old_run(root: Path, *, status: str = "ok", name: str = "old-run") -> Path:
+    run_root = root / name
     (run_root / "logs").mkdir(parents=True)
     (run_root / "logs" / "proof.log").write_text("outside\n", encoding="utf-8")
     metadata = run_root / "run.json"
-    metadata.write_text('{"status":"ok"}\n', encoding="utf-8")
+    metadata.write_text(f'{{"status":"{status}"}}\n', encoding="utf-8")
     old_time = time.time() - 40 * 24 * 60 * 60
     os.utime(metadata, (old_time, old_time))
     return run_root
@@ -84,6 +86,24 @@ class BaseCleanTests(unittest.TestCase):  # pylint: disable=too-many-public-meth
             [(candidate.category, candidate.path.name) for candidate in candidates],
             [("cache", "old-cache"), ("run", "old-run")],
         )
+
+    def test_find_clean_candidates_retains_old_active_runs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir)
+            active_run = create_old_run(
+                cache_root / "base" / "runs",
+                status="running",
+            )
+            active_runs: set[Path] = set()
+
+            candidates = engine.find_clean_candidates(
+                cache_root,
+                time.time() - 30 * 24 * 60 * 60,
+                active_runs=active_runs,
+            )
+
+        self.assertEqual(candidates, [])
+        self.assertEqual(active_runs, {active_run})
 
     def test_find_clean_candidates_logs_examined_directories(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -365,11 +385,86 @@ class BaseCleanTests(unittest.TestCase):  # pylint: disable=too-many-public-meth
             old_time = time.time() - 40 * 24 * 60 * 60
             os.utime(old_run / "run.json", (old_time, old_time))
 
-            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
+            output = io.StringIO()
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}), redirect_stdout(
+                output
+            ):
                 result = engine.main(["--older-than", "30d", "--dry-run"])
 
             self.assertEqual(result, 0)
             self.assertTrue(old_log.exists())
+            self.assertIn(f"Would remove\trun\t{old_run}", output.getvalue())
+
+    def test_clean_defaults_to_preview_without_deletion_consent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir) / "cache-root"
+            old_run = create_old_run(cache_root / "base" / "runs")
+            output = io.StringIO()
+
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}), redirect_stdout(
+                output
+            ):
+                result = engine.main(["--older-than", "30d"])
+
+            self.assertEqual(result, 0)
+            self.assertTrue(old_run.is_dir())
+            self.assertIn(f"Would remove\trun\t{old_run}", output.getvalue())
+
+    def test_clean_rejects_conflicting_preview_and_deletion_consent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir) / "cache-root"
+            old_run = create_old_run(cache_root / "base" / "runs")
+
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
+                result = engine.main(["--older-than", "30d", "--dry-run", "--yes"])
+
+            self.assertEqual(result, 2)
+            self.assertTrue(old_run.is_dir())
+
+    def test_clean_reports_and_retains_old_active_runs_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir) / "cache-root"
+            runs_root = cache_root / "base" / "runs"
+            active_run = create_old_run(runs_root, status="running", name="active-run")
+            completed_run = create_old_run(runs_root, name="completed-run")
+            output = io.StringIO()
+
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}), redirect_stdout(
+                output
+            ):
+                result = engine.main(
+                    ["--older-than", "30d", "--keep-last", "1", "--yes"]
+                )
+
+            self.assertEqual(result, 0)
+            self.assertTrue(active_run.is_dir())
+            self.assertFalse(completed_run.exists())
+            self.assertEqual(
+                output.getvalue().count(f"Retaining\tactive run\t{active_run}"),
+                1,
+            )
+
+    def test_clean_preview_reports_matches_and_retained_active_runs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = Path(tmpdir) / "cache-root"
+            runs_root = cache_root / "base" / "runs"
+            active_run = create_old_run(runs_root, status="running", name="active-run")
+            completed_run = create_old_run(runs_root, name="completed-run")
+            output = io.StringIO()
+
+            with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}), redirect_stdout(
+                output
+            ):
+                result = engine.main(["--older-than", "30d", "--keep-last", "1"])
+
+            self.assertEqual(result, 0)
+            self.assertTrue(active_run.is_dir())
+            self.assertTrue(completed_run.is_dir())
+            self.assertIn(f"Would remove\trun\t{completed_run}", output.getvalue())
+            self.assertEqual(
+                output.getvalue().count(f"Retaining\tactive run\t{active_run}"),
+                1,
+            )
 
     def test_clean_removes_old_entries(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -383,7 +478,7 @@ class BaseCleanTests(unittest.TestCase):  # pylint: disable=too-many-public-meth
             os.utime(old_run / "run.json", (old_time, old_time))
 
             with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
-                result = engine.main(["--older-than", "30d"])
+                result = engine.main(["--older-than", "30d", "--yes"])
 
             self.assertEqual(result, 0)
             self.assertFalse(old_log.exists())
@@ -405,7 +500,7 @@ class BaseCleanTests(unittest.TestCase):  # pylint: disable=too-many-public-meth
             os.utime(new_run / "run.json", (now, now))
 
             with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
-                result = engine.main(["--keep-last", "1"])
+                result = engine.main(["--keep-last", "1", "--yes"])
 
             self.assertEqual(result, 0)
             self.assertFalse(old_run.exists())
@@ -423,7 +518,7 @@ class BaseCleanTests(unittest.TestCase):  # pylint: disable=too-many-public-meth
             os.utime(old_run / "run.json", (old_time, old_time))
 
             with mock.patch.dict(os.environ, {"BASE_CACHE_DIR": str(cache_root)}):
-                result = engine.main(["--older-than", "30d", "--keep-last", "1"])
+                result = engine.main(["--older-than", "30d", "--keep-last", "1", "--yes"])
 
             self.assertEqual(result, 0)
             self.assertFalse(old_run.exists())

--- a/docs/cache-ownership-and-layout.md
+++ b/docs/cache-ownership-and-layout.md
@@ -204,7 +204,9 @@ another application's cache root. Cleanup rejects symlinks below the resolved
 Base cache root and performs deletion relative to trusted directory descriptors
 so an owner, category, or candidate path cannot redirect removal elsewhere.
 Persistent component caches may be pruned by age, while history metadata is
-retained until an explicit history-retention policy is applied.
+retained until an explicit history-retention policy is applied. Cleanup previews
+matches by default and requires `--yes` for deletion; active runs are reported
+as retained and are never reclassified as stale by cleanup.
 
 ## Implementation boundary
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -122,7 +122,7 @@ manifest trust.
 | `basectl history --report` | Print a local Markdown or JSON activity report from history and log metadata. | `--limit <count>`, `--format <markdown\|json>`, `--oldest-first`, `--last <duration>`, `--since <time>`, `--until <time>`, `--local-time` |
 | `basectl logs --open` | Open the newest matching log in `PAGER` or `EDITOR`. | `--command <name[,name...]>` |
 | `basectl logs --tail` | Tail and follow the newest matching log. | `--command <name[,name...]>`, `--lines <count>` |
-| `basectl clean` | Remove old Base runtime logs, temp files, and cache entries. | `--older-than <age>`, `--keep-last <count>`, `--dry-run` |
+| `basectl clean` | Preview cleanup of completed Base run bundles and component caches; use `--yes` to delete matches. Active runs are retained and reported. | `--older-than <age>`, `--keep-last <count>`, `--dry-run`, `--yes` |
 | `basectl config path` | Print the local Base config path. | none |
 | `basectl config show` | Show local Base config as redacted JSON. | none |
 | `basectl config doctor` | Diagnose local Base config. | none |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -171,10 +171,15 @@ history can show that a recorded log or bundle is missing.
 
 The retention contract should be:
 
-- `basectl clean --older-than <age>` removes completed run bundles and component
+- `basectl clean --older-than <age>` selects completed run bundles and component
   caches older than the age.
 - `basectl clean --keep-last <count>` retains the newest completed bundles per
   owner namespace.
+- Cleanup is a dry-run preview by default. `--yes` is required to delete matched
+  artifacts, and `--dry-run` cannot be combined with `--yes`.
+- Run bundles whose metadata status is `running` are excluded from both age and
+  count retention and are reported explicitly as retained active runs. Stale-run
+  recovery remains a separate, intentional operation.
 - Cleanup resolves its Base cache boundary before scanning, rejects symlinked
   owner, category, and candidate path components, and reopens deletion targets
   relative to trusted directory descriptors. Unsafe or unverifiable paths are

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -197,7 +197,7 @@ and their own build systems. See [Setup Hooks Boundary](setup-hooks.md).
 | `basectl history [--format json]` | Inspect structured local command history with ordering and time-window filters |
 | `basectl history --report [--format json]` | Summarize local command history and log metadata without raw log dumps |
 | `basectl config path\|show\|doctor` | Machine-local config |
-| `basectl clean [--older-than\|--keep-last]` | Prune cache/logs |
+| `basectl clean [--older-than\|--keep-last] [--yes]` | Preview completed-run/cache pruning; require `--yes` to delete and retain active runs |
 
 ### Workspace
 

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -800,7 +800,7 @@ _base_basectl_completion() {
             _base_basectl_completion_compgen "--show-url -h --help" "$cur"
             ;;
         clean)
-            _base_basectl_completion_compgen "--older-than --keep-last --dry-run -v -h --help" "$cur"
+            _base_basectl_completion_compgen "--older-than --keep-last --dry-run --yes -v -h --help" "$cur"
             ;;
         logs)
             if ((COMP_CWORD == 2)) && [[ "$cur" != -* ]]; then

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -886,8 +886,9 @@ _base_basectl_completion() {
             ;;
         clean)
             _arguments '--older-than[Artifact age]:age:' \
-                '--keep-last[Keep newest log files per CLI log directory]:count:' \
-                '--dry-run[Log without removing files]' \
+                '--keep-last[Keep newest completed run bundles per owner namespace]:count:' \
+                '--dry-run[Explicitly preview cleanup without deleting artifacts]' \
+                '--yes[Delete matched artifacts after reviewing the preview]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
             ;;
         logs)

--- a/tests/test_observability_docs.py
+++ b/tests/test_observability_docs.py
@@ -34,6 +34,20 @@ def test_cleanup_docs_define_the_symlink_containment_boundary() -> None:
     assert "never follows them during deletion" in " ".join(commands.split())
 
 
+def test_cleanup_docs_define_consent_and_active_run_retention() -> None:
+    observability = OBSERVABILITY_DOC.read_text(encoding="utf-8")
+    cache_layout = (REPO_ROOT / "docs" / "cache-ownership-and-layout.md").read_text(
+        encoding="utf-8"
+    )
+    commands = (REPO_ROOT / ".ai-context" / "COMMANDS.md").read_text(encoding="utf-8")
+
+    assert "dry-run preview by default" in observability
+    assert "`--yes` is required" in observability
+    assert "reported explicitly as retained active runs" in observability
+    assert "requires `--yes` for deletion" in cache_layout
+    assert "reports and retains active runs" in commands
+
+
 def test_run_bundle_docs_define_inherited_context_validation() -> None:
     observability = OBSERVABILITY_DOC.read_text(encoding="utf-8")
     cache_layout = (REPO_ROOT / "docs" / "cache-ownership-and-layout.md").read_text(


### PR DESCRIPTION
## Summary

- make `basectl clean` a dry-run preview by default and require `--yes` for deletion
- reject the contradictory `--dry-run --yes` combination as a usage error
- exclude `status=running` bundles from both age and count retention
- deduplicate and report retained active bundles across combined cleanup criteria
- update Bash/Zsh completions, help, command references, runtime docs, and AI command context

## Issue

Fixes #1974

## Validation

- focused `base_clean` and observability pytest suite (35 passed, 20 subtests passed)
- focused clean/help/completion BATS suites (33 passed)
- focused Pylint for changed Python modules
- Bash syntax and ShellCheck for the cleanup dispatcher and Bash completion
- isolated public-command proof: default invocation previewed and preserved a completed bundle
- isolated public-command proof: `--yes` deleted the completed bundle while retaining and reporting an old active bundle
- isolated public-command proof: `--dry-run --yes` returned usage status 2 without deletion
- `env -u BASE_HOME TZ=UTC BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python BASE_CACHE_DIR=/private/tmp/base-1974-full ./bin/base-test` (996 Python tests and 882 BATS tests passed)
- `git diff --check`

## Security Notes

Cleanup cannot mutate cache state without explicit `--yes` consent. Active runs are excluded during candidate discovery and checked again before an action, while the existing symlink and descriptor-relative deletion boundaries remain unchanged. Cleanup does not infer that an old running bundle is stale.

## Docs Impact

Updated command help, the command reference, observability and cache ownership contracts, the technical overview, and the Bash command README for preview-by-default cleanup and active-run retention.

## AI Context Impact

Updated `.ai-context/COMMANDS.md` because deletion consent and active-run retention are durable public command contracts.
