### PR TITLE
ci: align base-bash-libs workflow pins with GA (#1992)

### DIFF
--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -44,6 +44,10 @@ run a duplicate push workflow for feature branches. Its concurrency group uses
 the pull-request number, or the Git ref for default-branch runs, so superseded
 commits cancel without affecting unrelated pull requests.
 
+Every `base-bash-libs` checkout in that workflow uses one immutable GA revision.
+The workflow contract test guards against an RC or mixed dependency pin
+returning across the platform and source-checkout jobs.
+
 Common commands:
 
 ```bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: c134fb8a3397e2cfee1d90845cec44f56dacae7b
+          ref: b4243765726c133499feeabdc50154f99c0fec12
           path: .dependencies/base-bash-libs
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -215,7 +215,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: c134fb8a3397e2cfee1d90845cec44f56dacae7b
+          ref: b4243765726c133499feeabdc50154f99c0fec12
           path: .dependencies/base-bash-libs
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -279,7 +279,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: c134fb8a3397e2cfee1d90845cec44f56dacae7b
+          ref: b4243765726c133499feeabdc50154f99c0fec12
           path: .dependencies/base-bash-libs
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -25,6 +25,7 @@ ISSUE_BRANCH_POLICY_WORKFLOW = WORKFLOW_DIR / "issue-branch-policy.yml"
 ISSUE_BRANCH_POLICY_TEMPLATE = REPO_ROOT / "templates" / "issue-branch-policy.yml"
 IMPLEMENTATION_ISSUE_TEMPLATE = REPO_ROOT / ".github" / "ISSUE_TEMPLATE" / "implementation.yml"
 FULL_COMMIT_SHA_ACTION_REF = re.compile(r"^[^@]+@[0-9a-f]{40}$")
+BASE_BASH_LIBS_GA_COMMIT = "b4243765726c133499feeabdc50154f99c0fec12"
 
 
 def workflow_files() -> list[Path]:
@@ -149,6 +150,17 @@ def test_tests_workflow_runs_once_per_pr_commit_and_on_main() -> None:
         "Ubuntu source-checkout suite",
         "Security scanners",
     }
+
+
+def test_tests_workflow_pins_all_base_bash_libs_checkouts_to_ga_revision() -> None:
+    refs = [
+        step.get("with", {}).get("ref")
+        for _, _, step in workflow_steps(TESTS_WORKFLOW)
+        if step.get("with", {}).get("repository") == "basefoundry/base-bash-libs"
+    ]
+
+    assert refs
+    assert refs == [BASE_BASH_LIBS_GA_COMMIT] * len(refs)
 
 
 def test_issue_branch_policy_workflow_is_trusted_and_template_backed() -> None:


### PR DESCRIPTION
## Summary

- Align the macOS, integration, and Ubuntu source-checkout jobs in
  `.github/workflows/tests.yml` with the published `base-bash-libs` v2.0.0 GA
  commit `b4243765726c133499feeabdc50154f99c0fec12`.
- Add a workflow-contract test that requires every `base-bash-libs` checkout in
  the Tests workflow to use the same immutable GA revision.
- Record the invariant in `.ai-context/WORKFLOWS.md`.

## Issue

Fixes #1992.

## Validation

- Focused workflow and CI supply-chain tests: 52 passed.
- Full local gate: 999 Python tests passed and 891 BATS tests passed.
- `git diff --check` passed.
- Static audit confirms all four `base-bash-libs` checkouts in `tests.yml` use
  the GA commit and the RC commit is absent.

## Demo Impact

None. This changes only CI dependency pins and their regression coverage.
