### PR TITLE
security: document mutable Homebrew installer default (#1994)

### DIFF
--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -48,6 +48,12 @@ Every `base-bash-libs` checkout in that workflow uses one immutable GA revision.
 The workflow contract test guards against an RC or mixed dependency pin
 returning across the platform and source-checkout jobs.
 
+First-mile Homebrew installation remains mutable by default and logs that
+policy. Managed environments can opt into checksum verification with paired
+installer URL and SHA-256 overrides; the bootstrap documentation records why
+Base does not hard-code a checksum for Homebrew's independently changing
+`HEAD` installer.
+
 Common commands:
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ numeric next development line is tracked in `DEVELOPMENT_VERSION`.
   MIT and AGPL releases retain their original licenses.
 - Made `basectl repo init` generate Apache-2.0 licenses by default for new
   repositories.
+- Documented the deliberate mutable Homebrew installer default, its runtime
+  disclosure, and the paired URL/SHA-256 override path for managed environments.
 
 ### Fixed
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -34,6 +34,16 @@ curl -fsSL https://raw.githubusercontent.com/basefoundry/base/HEAD/bootstrap.sh 
 Use `BASE_HOMEBREW_INSTALLER_URL` and `BASE_HOMEBREW_INSTALLER_SHA256` instead
 when the same pin should apply to all Base Homebrew entry points.
 
+Both `bootstrap.sh` and `install.sh` keep the mutable Homebrew installer
+default and disclose that choice at runtime. Base does not hard-code a
+Homebrew URL and checksum because Homebrew maintains its official installer
+independently at `HEAD`: a fixed digest can become stale as Homebrew changes
+it, forcing Base releases for upstream installer updates or causing first-mile
+installs to fail or lag. This is a deliberate availability and trust trade-off,
+not an integrity guarantee. Managed environments that require verification
+should provide both the installer URL and SHA-256 pair shown above; partial
+pinning fails closed.
+
 On macOS, the bootstrapper verifies macOS, installs missing first-mile
 prerequisites, and then prints the exact commands needed to finish setup. For
 the default source checkout path, the handoff usually looks like:

--- a/docs/remote-installer-policy.md
+++ b/docs/remote-installer-policy.md
@@ -48,6 +48,14 @@ instead of pinning a reviewed commit by default. When Base uses a default path,
 it identifies the URL as mutable and explicitly says that the script is not
 checksum-verified.
 
+For Homebrew, this default keeps first-mile setup aligned with the upstream
+installer that Homebrew maintains at `HEAD`. A Base-owned URL and checksum
+would become stale whenever Homebrew changes that installer, forcing a Base
+update for each upstream change or risking a blocked or lagging bootstrap path.
+This is a deliberate availability and trust trade-off; managed environments
+should use the paired Homebrew URL and SHA-256 overrides below when they need
+checksum verification.
+
 Teams that require pinned, mirrored, or managed Homebrew installer content can
 opt in by setting both a
 Homebrew installer location and its expected SHA-256 before running Base:

--- a/tests/test_bootstrap_docs.py
+++ b/tests/test_bootstrap_docs.py
@@ -38,6 +38,18 @@ def test_bootstrap_quick_start_surfaces_verified_homebrew_installer_path() -> No
     assert "BASE_HOMEBREW_INSTALLER_SHA256" in quick_start
 
 
+def test_bootstrap_docs_explain_mutable_homebrew_default_rationale() -> None:
+    text = BOOTSTRAP_DOC.read_text(encoding="utf-8")
+    quick_start = section(text, "## Quick Start", "## Install Mode")
+    normalized = " ".join(quick_start.split())
+
+    assert "mutable Homebrew installer default" in normalized
+    assert "become stale" in normalized
+    assert "availability and trust trade-off" in normalized
+    assert "BASE_HOMEBREW_INSTALLER_URL" in normalized
+    assert "BASE_HOMEBREW_INSTALLER_SHA256" in normalized
+
+
 def test_readme_trust_conscious_proof_reviews_manifest_trust_before_demo() -> None:
     text = README.read_text(encoding="utf-8")
     proof = section(text, "### Trust-Conscious Proof, No Dotfile Changes", "### Shell Startup Is Explicit")


### PR DESCRIPTION
## Summary

- Record the decision to keep Homebrew's official mutable installer as the
  default first-mile path and preserve its runtime disclosure.
- Document why Base does not hard-code a default URL/SHA-256 pair and how
  managed environments opt into checksum verification.
- Add documentation regression coverage for the policy rationale.

## Issue

Fixes #1994.

## Validation

- Focused bootstrap documentation tests: 4 passed.
- Bootstrap/install BATS: 46 passed.
- Full local gate: 1,000 Python tests and 891 BATS tests passed.
- `bash -n`, ShellCheck, and `git diff --check` passed.

## Decision

Base keeps the mutable Homebrew installer default, with explicit runtime
disclosure, because Homebrew independently changes the official `HEAD`
installer and a Base-owned fixed digest would become stale. Managed
environments can set paired URL and SHA-256 overrides; partial pinning fails
closed.

## Demo Impact

None. This is documentation and regression coverage only.
