### PR TITLE
security: gate project IDE mutations and clarify trust scope (#1973)

### DIFF
--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -136,6 +136,14 @@ Setup parallelism should follow `docs/setup-parallelism.md`: model setup as a
 deterministic plan and parallelize only read-only preflight/planning work before
 considering mutating installers.
 
+Project-originated IDE app, extension, and global user-setting mutations are a
+separate setup consent boundary. `basectl setup --dry-run` must be reviewed,
+and applying the plan requires `--allow-project-ide-mutations`; `--yes` alone
+does not authorize it. Manifest command trust remains bound to the
+`base_manifest.yaml` SHA-256 only, so status and execution guidance warns that
+referenced scripts, direct executable files, Git HEAD, and uncommitted working
+tree changes are not independently verified or invalidating inputs.
+
 ## AI Context Maintenance
 
 Every meaningful PR should evaluate whether `.ai-context/` needs an update.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ numeric next development line is tracked in `DEVELOPMENT_VERSION`.
   repositories.
 - Documented the deliberate mutable Homebrew installer default, its runtime
   disclosure, and the paired URL/SHA-256 override path for managed environments.
+- Added explicit project-originated IDE mutation consent through
+  `--allow-project-ide-mutations`, with complete app, extension, and user-setting
+  plans in setup dry-run output; `--yes` does not grant this consent.
+- Documented and exposed the manifest-only command-trust scope, including
+  warnings that referenced scripts and Git state are not independently bound
+  to approval.
 
 ### Fixed
 

--- a/cli/bash/commands/basectl/subcommands/onboard.sh
+++ b/cli/bash/commands/basectl/subcommands/onboard.sh
@@ -17,6 +17,8 @@ Options:
   --profile <list>  Include named prerequisite profiles. Known profiles: dev, sre, ai, linux-lab.
   --dry-run     Explain planned onboarding steps without making changes.
   --yes         Approve setup changes and the shell-profile prompt; never grant manifest trust.
+  --allow-project-ide-mutations
+                Approve project-originated IDE app, extension, and user-setting mutations.
   --no-profile  Skip shell profile updates.
   -v            Enable DEBUG logging for underlying commands.
   -h, --help    Show this help text.
@@ -156,6 +158,7 @@ base_onboard_subcommand_main() {
     local projects_status=0
     local setup_status=0
     local trust_status=0
+    local allow_project_ide_mutations=0
     local check_args=()
     local doctor_args=()
     local setup_args=()
@@ -181,6 +184,9 @@ base_onboard_subcommand_main() {
                 ;;
             --yes)
                 yes=1
+                ;;
+            --allow-project-ide-mutations)
+                allow_project_ide_mutations=1
                 ;;
             --no-profile)
                 no_profile=1
@@ -232,6 +238,9 @@ base_onboard_subcommand_main() {
     if ((yes)); then
         setup_args+=(--yes)
     fi
+    if ((allow_project_ide_mutations)); then
+        setup_args+=(--allow-project-ide-mutations)
+    fi
     if ((dry_run)); then
         setup_args+=(--dry-run)
         profile_args+=(--dry-run)
@@ -257,6 +266,15 @@ base_onboard_subcommand_main() {
     if ((dry_run)); then
         base_onboard_execute "$dry_run" "${setup_args[@]}" || return $?
     elif base_onboard_confirm "$yes" "Proceed with setup?"; then
+        if ((allow_project_ide_mutations)); then
+            :
+        elif ((yes)); then
+            printf '%s\n' "Project-originated IDE mutations remain unapproved because --yes does not grant them."
+        elif base_onboard_confirm 0 "Allow project-originated IDE mutations if requested by the manifest?"; then
+            setup_args+=(--allow-project-ide-mutations)
+        else
+            printf '%s\n' "Project-originated IDE mutations were not approved; setup will stop if the manifest requests them."
+        fi
         base_onboard_print_next "${setup_args[@]}"
         base_onboard_run_command "${setup_args[@]}"
         setup_status=$?

--- a/cli/bash/commands/basectl/subcommands/setup.sh
+++ b/cli/bash/commands/basectl/subcommands/setup.sh
@@ -26,6 +26,8 @@ Options:
   --upgrade-pip      Upgrade pip in the selected Base-managed or pip-managed
                      project virtual environment. uv-managed projects are left unchanged.
   --yes              Apply setup changes that require explicit confirmation.
+  --allow-project-ide-mutations
+                     Approve project-originated IDE app, extension, and user-setting mutations.
   -v                 Enable DEBUG logging for this subcommand.
   -h, --help         Show this help text.
 
@@ -168,6 +170,9 @@ base_setup_subcommand_main() {
                 ;;
             --yes)
                 setup_enable_yes
+                ;;
+            --allow-project-ide-mutations)
+                setup_enable_project_ide_mutations
                 ;;
             --profile)
                 shift

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -58,7 +58,7 @@ setup_ensure_cached_paths() {
 setup_clear_run_state() {
     # Clear legacy lowercase state too so inherited environments cannot trigger
     # lib_std.sh dry-run behavior unless this command explicitly enables it.
-    unset BASE_BASH_LIBS_DRY_RUN BASE_SETUP_CHECK_STATUS_FILE BASE_SETUP_PROFILE_ERROR BASE_SETUP_PROFILES BASE_SETUP_PROJECT_NAME BASE_SETUP_MANIFEST BASE_SETUP_REMOTE_NETWORK BASE_SETUP_RECREATE_VENV BASE_SETUP_UPGRADE_PIP BASE_SETUP_YES
+    unset BASE_BASH_LIBS_DRY_RUN BASE_SETUP_CHECK_STATUS_FILE BASE_SETUP_PROFILE_ERROR BASE_SETUP_PROFILES BASE_SETUP_PROJECT_NAME BASE_SETUP_MANIFEST BASE_SETUP_REMOTE_NETWORK BASE_SETUP_RECREATE_VENV BASE_SETUP_UPGRADE_PIP BASE_SETUP_YES BASE_SETUP_ALLOW_PROJECT_IDE_MUTATIONS
     setup_refresh_cached_paths
 }
 
@@ -89,6 +89,14 @@ setup_enable_yes() {
 
 setup_yes_enabled() {
     [[ "${BASE_SETUP_YES:-false}" == true ]]
+}
+
+setup_enable_project_ide_mutations() {
+    export BASE_SETUP_ALLOW_PROJECT_IDE_MUTATIONS=true
+}
+
+setup_project_ide_mutations_allowed() {
+    [[ "${BASE_SETUP_ALLOW_PROJECT_IDE_MUTATIONS:-false}" == true ]]
 }
 
 setup_test_assume_interactive() {

--- a/cli/bash/commands/basectl/subcommands/setup_project_artifacts.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_project_artifacts.sh
@@ -111,6 +111,10 @@ setup_project_artifact_build_command() {
         _BASE_SETUP_PROJECT_ARTIFACT_ARGS+=(--remote-network)
         _BASE_SETUP_PROJECT_ARTIFACT_REMOTE_NETWORK=true
     fi
+    if [[ "$_BASE_SETUP_PROJECT_ARTIFACT_ACTION" == setup ]] &&
+        setup_project_ide_mutations_allowed; then
+        _BASE_SETUP_PROJECT_ARTIFACT_ARGS+=(--allow-project-ide-mutations)
+    fi
     _BASE_SETUP_PROJECT_ARTIFACT_ARGS+=("$_BASE_SETUP_PROJECT_ARTIFACT_PROJECT")
     _BASE_SETUP_PROJECT_ARTIFACT_PLATFORM="$(setup_current_platform)" || return 1
 

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -311,7 +311,7 @@ EOF
     [[ "$output" == *"workspace_init_options=--owner --path --workspace --manifest --include-optional --dry-run"* ]]
     [[ "$output" == *"workspace_configure_options=--workspace --manifest --dry-run"* ]]
     [[ "$output" == *"workspace_setup_options=--workspace --manifest --dry-run --yes"* ]]
-    [[ "$output" == *"onboard_options=--profile --dry-run --yes --no-profile"* ]]
+    [[ "$output" == *"onboard_options=--profile --dry-run --yes --allow-project-ide-mutations --no-profile"* ]]
     [[ "$output" == *"onboard_projects=base demo"* ]]
     [[ "$output" == *"onboard_profiles=dev sre ai linux-lab dev,sre dev,ai dev,linux-lab sre,ai sre,linux-lab ai,linux-lab dev,sre,ai dev,sre,linux-lab dev,ai,linux-lab sre,ai,linux-lab dev,sre,ai,linux-lab"* ]]
     [[ "$output" == *"prompt_names=list product-self-review"* ]]

--- a/cli/bash/commands/basectl/tests/onboard.bats
+++ b/cli/bash/commands/basectl/tests/onboard.bats
@@ -12,6 +12,7 @@ load ./basectl_helpers.bash
     [[ "$output" == *"--profile <list>"* ]]
     [[ "$output" != *"--dev"* ]]
     [[ "$output" == *"--dry-run"* ]]
+    [[ "$output" == *"--allow-project-ide-mutations"* ]]
     [[ "$output" == *"--no-profile"* ]]
     [[ "$output" == *"Defaults to 'base'."* ]]
     [[ "$output" == *"manifest command trust"* ]]
@@ -176,7 +177,7 @@ load ./basectl_helpers.bash
 @test "basectl onboard accepted flow runs setup profile doctor and projects" {
     local tty_input="$TEST_TMPDIR/onboard-tty"
 
-    printf 'y\ny\n' > "$tty_input"
+    printf 'y\ny\ny\n' > "$tty_input"
 
     run env \
         HOME="$TEST_HOME" \
@@ -192,7 +193,8 @@ load ./basectl_helpers.bash
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"RUN:check base --profile dev"* ]]
-    [[ "$output" == *"RUN:setup base --profile dev"* ]]
+    [[ "$output" == *"Allow project-originated IDE mutations if requested by the manifest? [y/N]"* ]]
+    [[ "$output" == *"RUN:setup base --profile dev --allow-project-ide-mutations"* ]]
     [[ "$output" == *"RUN:update-profile"* ]]
     [[ "$output" == *"RUN:doctor base --profile dev"* ]]
     [[ "$output" == *"RUN:projects list"* ]]
@@ -239,10 +241,28 @@ load ./basectl_helpers.bash
     [[ "$output" == *"This installs or verifies Base platform prerequisites, Base Python, and Base-managed artifacts."* ]]
     [[ "$output" != *"This installs or verifies Homebrew, Xcode Command Line Tools"* ]]
     [[ "$output" == *"RUN:setup base --yes"* ]]
+    [[ "$output" == *"Project-originated IDE mutations remain unapproved because --yes does not grant them."* ]]
+    [[ "$output" != *"RUN:setup base --yes --allow-project-ide-mutations"* ]]
     [[ "$output" == *"Shell profile updates skipped because --no-profile was set."* ]]
     [[ "$output" == *"RUN:trust status"* ]]
     [[ "$output" != *"RUN:trust allow"* ]]
     [[ "$output" != *"RUN:update-profile"* ]]
+}
+
+@test "basectl onboard explicit IDE mutation approval is forwarded with --yes" {
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/onboard.sh"
+            base_onboard_run_command() { printf "RUN:%s\n" "$*"; return 0; }
+            base_onboard_subcommand_main --yes --allow-project-ide-mutations --no-profile
+        '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"RUN:setup base --yes --allow-project-ide-mutations"* ]]
+    [[ "$output" != *"remain unapproved"* ]]
 }
 
 @test "basectl onboard --yes satisfies the Ubuntu Debian setup consent boundary" {

--- a/cli/bash/commands/basectl/tests/setup-command.bats
+++ b/cli/bash/commands/basectl/tests/setup-command.bats
@@ -12,5 +12,6 @@ load ./basectl_helpers.bash
     [[ "$output" == *"Prepare the local Base CLI environment on supported setup platforms."* ]]
     [[ "$output" == *"Install or verify macOS prerequisites on macOS."* ]]
     [[ "$output" == *"Install or verify apt prerequisites on Ubuntu/Debian Linux with interactive consent or --yes."* ]]
+    [[ "$output" == *"--allow-project-ide-mutations"* ]]
     [[ "$output" != *"Install Homebrew if needed."* ]]
 }

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -21,6 +21,7 @@ load ./setup_helpers.bash
     [[ "$output" == *"--recreate-venv"* ]]
     [[ "$output" == *"--upgrade-pip"* ]]
     [[ "$output" == *"--yes"* ]]
+    [[ "$output" == *"--allow-project-ide-mutations"* ]]
     [[ "$output" == *"Prepare the local Base CLI environment on supported setup platforms."* ]]
     [[ "$output" == *"On Ubuntu/Debian Linux, setup can install apt prerequisites with"* ]]
     [[ "$output" == *"interactive consent or --yes."* ]]
@@ -809,13 +810,13 @@ EOF
     create_project_setup_venv_stub "$demo_venv_dir"
     printf 'project:\n  name: demo\nartifacts: []\n' > "$manifest_path"
 
-    run_base_command setup --dry-run --manifest "$manifest_path" demo
+    run_base_command setup --dry-run --allow-project-ide-mutations --manifest "$manifest_path" demo
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"Running Python project setup layer."* ]]
     [ -f "$TEST_STATE_DIR/project-setup-ran" ]
     [ "$(cat "$TEST_STATE_DIR/project-setup-project")" = "demo" ]
-    [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --dry-run --manifest "$manifest_path" --action setup demo)" ]
+    [ "$(cat "$TEST_STATE_DIR/project-setup-args")" = "$(printf '%s\n' --dry-run --manifest "$manifest_path" --action setup --allow-project-ide-mutations demo)" ]
 }
 
 @test "basectl setup --upgrade-pip upgrades a pip-managed project virtualenv" {

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -50,6 +50,7 @@ class ManifestAction:
     output_format: str
     write: bool = False
     remote_network: bool = False
+    allow_project_ide_mutations: bool = False
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -73,6 +74,11 @@ def main(argv: list[str] | None = None) -> int:
     is_flag=True,
     help="Opt in to bounded network reachability diagnostics for project Git origin.",
 )
+@base_cli.option(
+    "--allow-project-ide-mutations",
+    is_flag=True,
+    help="Approve project-originated IDE app, extension, and user-setting mutations for setup.",
+)
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 def run(
     ctx: base_cli.Context,
@@ -84,6 +90,7 @@ def run(
     action: str,
     output_format: str,
     remote_network: bool,
+    allow_project_ide_mutations: bool,
 ) -> int:
     manifest_path = Path(manifest).resolve() if manifest else discover_manifest(Path(start_dir))
     if manifest_path is not None:
@@ -99,7 +106,14 @@ def run(
         base_manifest = read_manifest(manifest_path)
         ctx.bind_project(base_manifest.project_name, manifest_path.parent, manifest_path)
         validate_project_name(base_manifest, project)
-        manifest_action = ManifestAction(action, dry_run, output_format, write, remote_network)
+        manifest_action = ManifestAction(
+            action,
+            dry_run,
+            output_format,
+            write,
+            remote_network,
+            allow_project_ide_mutations,
+        )
         if action == "route":
             status = route_manifest(ctx, manifest_action, base_manifest)
         elif action == "devcontainer":
@@ -137,7 +151,13 @@ def run_manifest_action(
 ) -> int:
     action = manifest_action.action
     if action == "setup":
-        reconcile_manifest(ctx, default_manifest, base_manifest, dry_run=manifest_action.dry_run)
+        reconcile_manifest(
+            ctx,
+            default_manifest,
+            base_manifest,
+            dry_run=manifest_action.dry_run,
+            allow_project_ide_mutations=manifest_action.allow_project_ide_mutations,
+        )
         status = 0
     elif action == "bootstrap":
         reconcile_bootstrap_artifacts(ctx, default_manifest, base_manifest, dry_run=manifest_action.dry_run)

--- a/cli/python/base_setup/ide.py
+++ b/cli/python/base_setup/ide.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
 import base_cli
 from base_cli_adapters.config import UserConfig
+
 from .ide_schema import IDE_DEFINITIONS
 from .ide_schema import IdeDefinition
 
@@ -25,6 +30,16 @@ from .ide_settings import resolve_ide_settings
 from .ide_settings import write_json_atomic
 from .manifest import BaseManifest, IdeConfig
 
+
+@dataclass(frozen=True)
+class IdeMutationPlan:
+    definition: IdeDefinition
+    install: bool
+    extensions: tuple[str, ...]
+    settings: dict[str, object]
+    settings_file: Path | None
+
+
 # Compatibility exports for callers that imported IDE install, extension, and
 # settings helpers from this module before the focused IDE modules existed.
 __all__ = (
@@ -33,6 +48,7 @@ __all__ = (
     "BaseManifest",
     "IdeConfig",
     "IdeDefinition",
+    "IdeMutationPlan",
     "IdeDiagnosticSnapshot",
     "UserConfig",
     "check_ide_extension",
@@ -46,6 +62,7 @@ __all__ = (
     "ide_settings_file",
     "list_ide_extensions",
     "log_ide_preference_warnings",
+    "log_project_ide_mutation_plan",
     "merge_ide_settings",
     "read_ide_settings",
     "reconcile_ide_extensions",
@@ -53,6 +70,7 @@ __all__ = (
     "reconcile_ide_installs",
     "reconcile_ide_settings",
     "resolve_ide_settings",
+    "project_ide_mutation_plans",
     "write_json_atomic",
 )
 
@@ -91,6 +109,52 @@ def effective_ide_config(project_ide: dict[str, IdeConfig], user_config: UserCon
                 settings=settings,
             )
     return effective
+
+
+def project_ide_mutation_plans(
+    project_manifest: BaseManifest,
+    effective_manifest: BaseManifest,
+) -> tuple[IdeMutationPlan, ...]:
+    plans: list[IdeMutationPlan] = []
+    for ide_name, project_config in sorted(project_manifest.ide.items()):
+        effective_config = effective_manifest.ide.get(ide_name)
+        if effective_config is None:
+            continue
+        if not (project_config.install or project_config.extensions or project_config.settings):
+            continue
+        resolved_settings = resolve_ide_settings(effective_manifest, effective_config.settings)
+        plans.append(
+            IdeMutationPlan(
+                definition=IDE_DEFINITIONS[ide_name],
+                install=effective_config.install,
+                extensions=effective_config.extensions,
+                settings=resolved_settings,
+                settings_file=ide_settings_file(IDE_DEFINITIONS[ide_name]) if resolved_settings else None,
+            )
+        )
+    return tuple(plans)
+
+
+def log_project_ide_mutation_plan(
+    ctx: base_cli.Context,
+    project_manifest: BaseManifest,
+    effective_manifest: BaseManifest,
+) -> tuple[IdeMutationPlan, ...]:
+    plans = project_ide_mutation_plans(project_manifest, effective_manifest)
+    if not plans:
+        return ()
+
+    ctx.log.info("Project '%s' requests project-originated IDE mutations:", project_manifest.project_name)
+    for plan in plans:
+        if plan.install:
+            ctx.log.info("  %s app: brew install --cask %s", plan.definition.label, plan.definition.cask)
+        for extension in plan.extensions:
+            ctx.log.info("  %s extension: %s", plan.definition.label, extension)
+        if plan.settings_file is not None:
+            ctx.log.info("  %s user settings file: %s", plan.definition.label, plan.settings_file)
+            for key, value in plan.settings.items():
+                ctx.log.info("    %s = %s", key, json.dumps(value, sort_keys=True))
+    return plans
 
 
 def ide_preference_warning_checks(manifest: BaseManifest, user_config: UserConfig) -> list[ArtifactCheck]:

--- a/cli/python/base_setup/setup_reconcile.py
+++ b/cli/python/base_setup/setup_reconcile.py
@@ -11,9 +11,11 @@ from .artifacts import reconcile_artifacts
 from .artifacts import resolve_artifact_definitions
 from .delegates import reconcile_brewfile
 from .delegates import reconcile_mise
+from .errors import ArtifactError
 from .ide import effective_ide_config
 from .ide import ide_preference_warning_checks
 from .ide import log_ide_preference_warnings
+from .ide import log_project_ide_mutation_plan
 from .ide_extensions import reconcile_ide_extensions
 from .ide_installs import reconcile_ide_installs
 from .ide_settings import reconcile_ide_settings
@@ -29,12 +31,21 @@ def reconcile_manifest(
     default_manifest: BaseManifest,
     manifest: BaseManifest,
     dry_run: bool,
+    allow_project_ide_mutations: bool = False,
 ) -> None:
     ctx.log.info("Reading Base manifest at '%s'.", manifest.path)
     ctx.log.info("Setting up project '%s'.", manifest.project_name)
     user_config = ctx.user_config
     log_ide_preference_warnings(ctx, ide_preference_warning_checks(manifest, user_config))
     effective_manifest = effective_manifest_with_user_config(manifest, user_config)
+
+    ide_mutation_plans = log_project_ide_mutation_plan(ctx, manifest, effective_manifest)
+    if ide_mutation_plans and not dry_run and not allow_project_ide_mutations:
+        raise ArtifactError(
+            f"Project '{manifest.project_name}' requests project-originated IDE mutations. "
+            "Review the exact plan with 'basectl setup --dry-run', then rerun with "
+            "'--allow-project-ide-mutations' to apply it. '--yes' does not grant this approval."
+        )
 
     artifacts = setup_artifacts(default_manifest, effective_manifest)
     definitions = resolve_artifact_definitions(artifacts)

--- a/cli/python/base_setup/tests/test_ide_settings.py
+++ b/cli/python/base_setup/tests/test_ide_settings.py
@@ -31,6 +31,7 @@ class IdeSettingsTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as home_dir, mock.patch.dict(os.environ, {"HOME": home_dir}):
             plans = ide.log_project_ide_mutation_plan(ctx, manifest, manifest)
+            expected_settings_file = ide.ide_settings_file(ide.IDE_DEFINITIONS["vscode"])
 
         self.assertEqual(len(plans), 1)
         self.assertEqual(plans[0].definition, ide.IDE_DEFINITIONS["vscode"])
@@ -39,8 +40,7 @@ class IdeSettingsTests(unittest.TestCase):
         self.assertIn("  VS Code app: brew install --cask visual-studio-code", info_messages)
         self.assertIn("  VS Code extension: ms-python.python", info_messages)
         self.assertIn(
-            "  VS Code user settings file: "
-            f"{Path(home_dir) / 'Library' / 'Application Support' / 'Code' / 'User' / 'settings.json'}",
+            f"  VS Code user settings file: {expected_settings_file}",
             info_messages,
         )
         self.assertIn("    editor.formatOnSave = true", info_messages)

--- a/cli/python/base_setup/tests/test_ide_settings.py
+++ b/cli/python/base_setup/tests/test_ide_settings.py
@@ -13,6 +13,38 @@ from base_setup.tests.helpers import fake_context
 
 class IdeSettingsTests(unittest.TestCase):
 
+    def test_project_ide_mutation_plan_lists_apps_extensions_and_settings(self) -> None:
+        ctx = fake_context()
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            ide={
+                "vscode": IdeConfig(
+                    install=True,
+                    extensions=("ms-python.python",),
+                    settings={"editor.formatOnSave": True},
+                )
+            },
+        )
+
+        with tempfile.TemporaryDirectory() as home_dir, mock.patch.dict(os.environ, {"HOME": home_dir}):
+            plans = ide.log_project_ide_mutation_plan(ctx, manifest, manifest)
+
+        self.assertEqual(len(plans), 1)
+        self.assertEqual(plans[0].definition, ide.IDE_DEFINITIONS["vscode"])
+        info_messages = [call.args[0] % call.args[1:] for call in ctx.log.info.call_args_list]
+        self.assertIn("Project 'demo' requests project-originated IDE mutations:", info_messages)
+        self.assertIn("  VS Code app: brew install --cask visual-studio-code", info_messages)
+        self.assertIn("  VS Code extension: ms-python.python", info_messages)
+        self.assertIn(
+            "  VS Code user settings file: "
+            f"{Path(home_dir) / 'Library' / 'Application Support' / 'Code' / 'User' / 'settings.json'}",
+            info_messages,
+        )
+        self.assertIn("    editor.formatOnSave = true", info_messages)
+
     def test_resolve_ide_settings_auto_interpreter_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             venv_dir = Path(tmpdir) / "demo-venv"

--- a/cli/python/base_setup/tests/test_user_ide_preferences.py
+++ b/cli/python/base_setup/tests/test_user_ide_preferences.py
@@ -12,6 +12,7 @@ from unittest import mock
 from base_cli_adapters.config import UserConfig, UserIdeConfig, UserIdePreference
 from base_setup import engine, ide
 from base_setup.github_manifest import GithubConfig, GithubPrConfig
+from base_setup.errors import ArtifactError
 from base_setup.manifest import BaseManifest, IdeConfig, read_manifest
 from base_setup.tests.helpers import fake_context
 
@@ -223,6 +224,76 @@ class UserIdePreferenceMergeTests(unittest.TestCase):
 
         effective_manifest = reconcile_ide_installs.call_args.args[1]
         self.assertEqual(effective_manifest.ide, {})
+
+    def test_reconcile_manifest_blocks_project_ide_mutations_without_explicit_consent(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            ide={
+                "vscode": IdeConfig(
+                    install=True,
+                    extensions=("ms-python.python",),
+                    settings={"editor.formatOnSave": True},
+                )
+            },
+        )
+        ctx = fake_context()
+
+        with mock.patch("base_setup.setup_reconcile.reconcile_brewfile") as reconcile_brewfile:
+            with self.assertRaisesRegex(ArtifactError, "--allow-project-ide-mutations"):
+                engine.reconcile_manifest(ctx, default_manifest, manifest, dry_run=False)
+
+        reconcile_brewfile.assert_not_called()
+
+    def test_reconcile_manifest_applies_project_ide_mutations_with_explicit_consent(self) -> None:
+        default_manifest = BaseManifest(
+            path=Path("default_manifest.yaml"),
+            project_name="base-defaults",
+            brewfile=None,
+            artifacts=(),
+        )
+        manifest = BaseManifest(
+            path=Path("base_manifest.yaml"),
+            project_name="demo",
+            brewfile=None,
+            artifacts=(),
+            ide={
+                "vscode": IdeConfig(
+                    install=True,
+                    extensions=("ms-python.python",),
+                    settings={"editor.formatOnSave": True},
+                )
+            },
+        )
+        ctx = fake_context()
+
+        with (
+            mock.patch("base_setup.setup_reconcile.reconcile_brewfile"),
+            mock.patch("base_setup.setup_reconcile.reconcile_mise"),
+            mock.patch("base_setup.setup_reconcile.reconcile_ide_installs") as reconcile_ide_installs,
+            mock.patch("base_setup.setup_reconcile.reconcile_ide_extensions") as reconcile_ide_extensions,
+            mock.patch("base_setup.setup_reconcile.reconcile_ide_settings") as reconcile_ide_settings,
+            mock.patch("base_setup.setup_reconcile.reconcile_uv_project"),
+        ):
+            engine.reconcile_manifest(
+                ctx,
+                default_manifest,
+                manifest,
+                dry_run=False,
+                allow_project_ide_mutations=True,
+            )
+
+        reconcile_ide_installs.assert_called_once_with(ctx, mock.ANY, dry_run=False)
+        reconcile_ide_extensions.assert_called_once_with(ctx, mock.ANY, dry_run=False)
+        reconcile_ide_settings.assert_called_once_with(ctx, mock.ANY, dry_run=False)
 
     def test_manifest_checks_accepts_injected_user_config(self) -> None:
         default_manifest = BaseManifest(

--- a/cli/python/base_trust/engine.py
+++ b/cli/python/base_trust/engine.py
@@ -19,6 +19,8 @@ from base_setup.manifest_loader import ManifestError
 from .trust_store import ALLOWED_COMMANDS  # pylint: disable=unused-import
 from .trust_store import SCHEMA_VERSION
 from .trust_store import TRUST_RELATIVE_ROOT  # pylint: disable=unused-import
+from .trust_store import TRUST_SCOPE  # pylint: disable=unused-import
+from .trust_store import TRUST_SCOPE_WARNING
 from .trust_store import ManifestCommandTrustIdentity
 from .trust_store import ManifestCommandTrustStore
 from .trust_store import TrustStatus
@@ -32,6 +34,7 @@ from .trust_store import identity_key_from_record  # pylint: disable=unused-impo
 from .trust_store import manifest_command_surfaces
 from .trust_store import manifest_command_surfaces_from_manifest
 from .trust_store import sha256_file  # pylint: disable=unused-import
+from .trust_store import trust_scope_payload
 from .trust_store import write_json_atomic  # pylint: disable=unused-import
 
 
@@ -140,6 +143,7 @@ def allow_command(ctx: base_cli.Context, project: str, workspace: str | None, ma
         return base_cli.ExitCode.USAGE_ERROR
 
     print_identity("Allowing manifest command trust", identity)
+    print_trust_scope_warning()
     ManifestCommandTrustStore().allow(identity, base_version=read_base_version(ctx.application_home))
     print(f"Allowed manifest commands for project '{identity.project_name}'.")
     return base_cli.ExitCode.SUCCESS
@@ -286,6 +290,7 @@ def status_payload(trust_status: TrustStatus) -> dict[str, Any]:
         "status": trust_status.status,
         "reason": trust_status.reason,
         "project": trust_status.identity.project_payload(),
+        "trust_scope": trust_scope_payload(),
     }
     if trust_status.is_allowed:
         payload["record"] = trust_status.record
@@ -324,6 +329,8 @@ def print_status_text(trust_status: TrustStatus, surfaces: tuple[str, ...]) -> N
     if trust_status.is_allowed:
         print(f"Manifest command trust is allowed for project '{identity.project_name}'.")
         print_identity("Trusted identity", identity)
+        print()
+        print_trust_scope_warning()
         return
 
     if trust_status.reason == "manifest_changed":
@@ -334,6 +341,8 @@ def print_status_text(trust_status: TrustStatus, surfaces: tuple[str, ...]) -> N
     else:
         print(f"Manifest command trust is blocked for project '{identity.project_name}'.")
     print_identity("Current identity", identity)
+    print()
+    print_trust_scope_warning()
     print()
     print_review_guidance(identity, surfaces, stream=sys.stdout)
     print()
@@ -369,6 +378,8 @@ def print_blocked_command_text(
     print(f"Manifest SHA-256: {identity.manifest_sha256}", file=stream)
     if identity.origin is not None:
         print(f"Origin: {identity.origin}", file=stream)
+    print(file=stream)
+    print_trust_scope_warning(stream=stream)
     print(file=stream)
     print_review_guidance(identity, surfaces, stream=stream)
     print(file=stream)
@@ -409,6 +420,13 @@ def print_identity(title: str, identity: ManifestCommandTrustIdentity) -> None:
         print(f"  Origin: {identity.origin}")
     if identity.head is not None:
         print(f"  HEAD: {identity.head}")
+
+
+def print_trust_scope_warning(*, stream: Any | None = None) -> None:
+    if stream is None:
+        stream = sys.stdout
+    print("Trust scope:", file=stream)
+    print(f"  {TRUST_SCOPE_WARNING}", file=stream)
 
 
 if __name__ == "__main__":

--- a/cli/python/base_trust/tests/test_engine.py
+++ b/cli/python/base_trust/tests/test_engine.py
@@ -97,6 +97,8 @@ class ManifestCommandTrustTests(unittest.TestCase):
             "ManifestCommandTrustStore",
             "SCHEMA_VERSION",
             "TRUST_RELATIVE_ROOT",
+            "TRUST_SCOPE",
+            "TRUST_SCOPE_WARNING",
             "TrustStatus",
             "compute_identity_key",
             "compute_trust_identity_for_manifest",
@@ -106,6 +108,7 @@ class ManifestCommandTrustTests(unittest.TestCase):
             "identity_key_from_record",
             "manifest_command_surfaces",
             "sha256_file",
+            "trust_scope_payload",
             "write_json_atomic",
         )
 
@@ -197,6 +200,10 @@ class ManifestCommandTrustTests(unittest.TestCase):
         self.assertEqual(payload["schema_version"], 1)
         self.assertEqual(payload["status"], "blocked")
         self.assertEqual(payload["reason"], "not_allowed")
+        self.assertEqual(payload["trust_scope"]["approval_basis"], "base_manifest.yaml_sha256")
+        self.assertTrue(payload["trust_scope"]["manifest_changes_invalidate"])
+        self.assertFalse(payload["trust_scope"]["referenced_script_changes_invalidate"])
+        self.assertFalse(payload["trust_scope"]["git_head_changes_invalidate"])
         self.assertEqual(payload["project"]["name"], "demo")
         self.assertEqual(payload["project"]["manifest_sha256"], expected_digest)
         self.assertEqual(
@@ -377,6 +384,8 @@ class ManifestCommandTrustTests(unittest.TestCase):
         self.assertIn(f"Manifest SHA-256: {expected_digest}", stderr.getvalue())
         self.assertIn("Review first:", stderr.getvalue())
         self.assertIn("  basectl test demo --dry-run", stderr.getvalue())
+        self.assertIn("Trust scope:", stderr.getvalue())
+        self.assertIn("referenced scripts", stderr.getvalue())
         self.assertNotIn("  basectl run demo --list", stderr.getvalue())
         self.assertIn("Allow after review:", stderr.getvalue())
         self.assertIn(f"  basectl trust allow demo --manifest-sha256 {expected_digest}", stderr.getvalue())
@@ -406,6 +415,8 @@ class ManifestCommandTrustTests(unittest.TestCase):
         self.assertIn("basectl demo demo --dry-run", result.stdout)
         self.assertIn(f"Inspect activate.source entries in {manifest_path.resolve()}", result.stdout)
         self.assertIn("basectl trust allow demo --manifest-sha256", result.stdout)
+        self.assertIn("Trust scope:", result.stdout)
+        self.assertIn("Git HEAD", result.stdout)
 
     def test_changed_manifest_status_shows_recorded_digest_and_reapproval_guidance(self) -> None:
         from base_trust import engine
@@ -440,6 +451,40 @@ class ManifestCommandTrustTests(unittest.TestCase):
             f"basectl trust allow demo --manifest-sha256 {current_digest}",
             result.stdout,
         )
+
+    def test_referenced_script_and_git_head_changes_do_not_invalidate_manifest_trust(self) -> None:
+        from base_trust import engine
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            project_root = root / "work" / "demo"
+            manifest_path = self.manifest_factory.write_command_surfaces(project_root)
+            referenced_script = project_root / "demo.sh"
+            referenced_script.write_text("#!/bin/sh\nprintf 'before\\n'\n", encoding="utf-8")
+            initial_head = init_git_repo(project_root, "https://github.com/example/demo.git")
+            identity = engine.compute_trust_identity_for_manifest(manifest_path)
+            engine.ManifestCommandTrustStore(home=home).allow(identity, base_version="9.9.9")
+
+            referenced_script.write_text("#!/bin/sh\nprintf 'after\\n'\n", encoding="utf-8")
+            subprocess.run(["git", "add", "demo.sh"], cwd=project_root, check=True, stdout=subprocess.PIPE)
+            subprocess.run(
+                ["git", "commit", "-m", "Change referenced script"],
+                cwd=project_root,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            current_identity = engine.compute_trust_identity_for_manifest(manifest_path)
+            status = engine.ManifestCommandTrustStore(home=home).status(current_identity)
+            payload = engine.status_payload(status)
+
+        self.assertNotEqual(current_identity.head, initial_head)
+        self.assertEqual(current_identity.manifest_sha256, identity.manifest_sha256)
+        self.assertTrue(status.is_allowed)
+        self.assertEqual(payload["status"], "allowed")
+        self.assertFalse(payload["trust_scope"]["referenced_script_changes_invalidate"])
+        self.assertFalse(payload["trust_scope"]["git_head_changes_invalidate"])
 
     def test_require_allows_matching_trust_record_for_manifest_path(self) -> None:
         from base_trust import engine

--- a/cli/python/base_trust/trust_store.py
+++ b/cli/python/base_trust/trust_store.py
@@ -17,6 +17,25 @@ from base_setup.manifest import read_manifest
 SCHEMA_VERSION = 1
 ALLOWED_COMMANDS = ["test", "run", "build", "demo", "activate"]
 TRUST_RELATIVE_ROOT = Path("trust") / "manifest-commands"
+TRUST_SCOPE_WARNING = (
+    "Approval is bound to the base_manifest.yaml SHA-256 only. Manifest changes "
+    "invalidate approval; referenced scripts, direct executable files, Git HEAD, "
+    "and uncommitted working-tree changes are not independently verified or bound "
+    "to approval. Re-review those inputs before execution after repository changes."
+)
+TRUST_SCOPE = {
+    "approval_basis": "base_manifest.yaml_sha256",
+    "manifest_changes_invalidate": True,
+    "referenced_script_changes_invalidate": False,
+    "direct_executable_file_changes_invalidate": False,
+    "git_head_changes_invalidate": False,
+    "working_tree_changes_invalidate": False,
+    "warning": TRUST_SCOPE_WARNING,
+}
+
+
+def trust_scope_payload() -> dict[str, object]:
+    return dict(TRUST_SCOPE)
 
 
 @dataclass(frozen=True)

--- a/docs/basectl-onboard.md
+++ b/docs/basectl-onboard.md
@@ -14,7 +14,8 @@ slower, friendlier, and more explanatory because that is its purpose.
 commands:
 
 1. runs `basectl check [project]`
-2. prompts before running `basectl setup [project]`
+2. prompts before running `basectl setup [project]`, including a separate
+   consent prompt if the project manifest requests IDE mutations
 3. prompts before running `basectl update-profile`, unless profile updates are
    disabled
 4. runs `basectl doctor [project]`
@@ -39,6 +40,8 @@ Options:
   --profile <list> Include named prerequisite profiles.
   --dry-run        Explain and show planned actions without making changes.
   --yes            Accept setup/profile prompts; never grant manifest trust.
+  --allow-project-ide-mutations
+                   Approve project-originated IDE app, extension, and user-setting mutations.
   --no-profile     Skip shell profile updates.
   -v               Enable DEBUG logging for underlying commands.
   -h, --help       Show help text.
@@ -98,6 +101,8 @@ boundary.
 - `basectl check [project]` for quick environment state
 - `basectl doctor [project]` for human-readable diagnosis and suggested fixes
 - `basectl setup [project]` for actual reconciliation
+- `basectl setup --allow-project-ide-mutations` when the user has reviewed and
+  approved the exact project-originated IDE mutation plan
 - `basectl setup --profile <list>` when the user opts into Base prerequisite
   profiles
 - `basectl update-profile` for shell startup integration
@@ -126,15 +131,19 @@ The shipped flow is simple and checklist-oriented:
 2. Run `basectl check`.
 3. If checks fail, explain that setup can reconcile the missing pieces.
 4. Ask for confirmation before running `basectl setup`.
-5. If `--profile` was requested, include those prerequisite profiles in setup.
-6. Ask for confirmation before running `basectl update-profile`, unless
+5. If the manifest requests project-originated IDE app, extension, or
+   user-setting changes, show the exact plan and ask for separate approval.
+   `--yes` does not answer this prompt; `--allow-project-ide-mutations` is the
+   explicit non-interactive approval.
+6. If `--profile` was requested, include those prerequisite profiles in setup.
+7. Ask for confirmation before running `basectl update-profile`, unless
    `--no-profile` was set.
-7. Run `basectl doctor` to summarize the final state.
-8. Print discovered projects with `basectl projects list` when available.
-9. Run the read-only `basectl trust status` workspace view, which filters out
+8. Run `basectl doctor` to summarize the final state.
+9. Print discovered projects with `basectl projects list` when available.
+10. Run the read-only `basectl trust status` workspace view, which filters out
    manifests without executable command surfaces and prints exact review and
    digest-bound allow guidance for those that need it.
-10. Suggest `basectl` or `basectl activate base` after any required trust
+11. Suggest `basectl` or `basectl activate base` after any required trust
     review.
 
 The command shows the exact Base command before it runs it. For example:
@@ -155,8 +164,13 @@ Prompts should be explicit but sparse:
 - Treat Enter as the conservative answer when there is risk.
 - `--yes` may accept normal setup/profile prompts, but should not bypass fatal
   safety checks such as unsupported operating systems or grant manifest
-  command trust. It is forwarded to setup so package-manager consent does not
-  unexpectedly remain interactive on Ubuntu/Debian.
+  command trust. It also never grants project-originated IDE mutation consent.
+  It is forwarded to setup so package-manager consent does not unexpectedly
+  remain interactive on Ubuntu/Debian.
+- Project-originated IDE app, extension, and global user-setting changes need
+  a separate approval through the interactive IDE prompt or
+  `--allow-project-ide-mutations`. Setup prints the exact dry-run plan first;
+  without this approval it stops before project setup reconcilers run.
 - `--dry-run` should not prompt for actions it will not perform.
 
 ## Output Style
@@ -177,6 +191,9 @@ Failures are recoverable and specific:
 - If `basectl check` fails, continue to the setup prompt.
 - If `basectl setup` fails, run or recommend `basectl doctor` and stop before
   profile updates.
+- If IDE mutation consent is not supplied, explain that `--yes` is insufficient
+  and recommend reviewing `basectl setup --dry-run` before rerunning with
+  `--allow-project-ide-mutations`.
 - If `basectl update-profile` fails, leave setup success intact and explain how
   to rerun that step.
 - If `basectl doctor` reports remaining findings, preserve its output and
@@ -217,6 +234,8 @@ Tests should cover:
 - declined setup prompt
 - accepted setup prompt
 - `--yes` non-interactive flow
+- separate project-originated IDE mutation consent, including `--yes` not
+  implying that consent
 - `--profile <list>` passing through to setup and doctor
 - `--no-profile` skipping profile updates
 - setup failure stopping later steps

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -54,10 +54,10 @@ full compatibility contract.
 
 | Command | What it does | Important flags |
 |---|---|---|
-| `basectl setup [project]` | Install or reconcile Base and optional project artifacts. | `--ci`, `--format <text\|json>`, `--profile <dev,sre,ai>`, `--dry-run`, `--manifest <path>`, `--recreate-venv`, `--upgrade-pip`, `--notify`, `--no-notify` |
+| `basectl setup [project]` | Install or reconcile Base and optional project artifacts. Project-originated IDE app, extension, and user-setting mutations require separate approval. | `--ci`, `--format <text\|json>`, `--profile <dev,sre,ai>`, `--dry-run`, `--manifest <path>`, `--allow-project-ide-mutations`, `--recreate-venv`, `--upgrade-pip`, `--notify`, `--no-notify` |
 | `basectl update-profile` | Create, refresh, or remove Base-managed Bash and Zsh startup snippets, backing up existing dotfiles before changes. | `--defaults`, `--no-defaults`, `--remove`, `--dry-run` |
 | `basectl update [project]` | Update a Base-managed project checkout through Git, or update Base through Homebrew when Base is Homebrew-managed, then run setup for the selected project. | `--dry-run` |
-| `basectl onboard [project]` | Guide first-run setup through check, setup, shell profile, doctor, project discovery, and read-only manifest trust status. Defaults to `base`. | `--profile <list>`, `--dry-run`, `--yes`, `--no-profile` |
+| `basectl onboard [project]` | Guide first-run setup through check, setup, shell profile, doctor, project discovery, and read-only manifest trust status. Defaults to `base`. | `--profile <list>`, `--dry-run`, `--yes`, `--allow-project-ide-mutations`, `--no-profile` |
 | `basectl version` | Show the installed Base version. | none |
 
 ## Daily Project Loop

--- a/docs/manifest-command-trust.md
+++ b/docs/manifest-command-trust.md
@@ -48,9 +48,12 @@ without executing project-owned shell code:
 - `basectl check [project]` and `basectl doctor [project]`
 - `basectl export-context [project]`
 
-Setup delegates such as Brewfiles, `mise install`, IDE setup, and artifacts are
-separate trust boundaries. They should not be folded into this first manifest
-command allow flow unless a later issue explicitly expands the scope.
+Setup delegates such as Brewfiles, `mise install`, and artifacts are separate
+trust boundaries. Project-originated IDE mutations have their own explicit
+approval boundary: `basectl setup --dry-run` shows the complete app, extension,
+and user-settings plan, and applying that plan requires
+`--allow-project-ide-mutations`. `--yes` never supplies this approval. This
+keeps command execution trust and machine-wide IDE mutation consent separate.
 
 ## Trust Identity
 
@@ -67,8 +70,14 @@ command contract. The identity includes:
 
 The enforcement key includes the canonical project root, manifest path, and
 manifest digest. The remote URL and Git HEAD are stored for display and audit,
-but the manifest digest is the signal that forces re-approval after command
-declarations change.
+but the manifest digest is the only repository input that forces re-approval
+after command declarations change. Status, allow, and blocked-command output
+prints the following warning so the boundary is visible:
+
+> Approval is bound to the `base_manifest.yaml` SHA-256 only. Manifest changes
+> invalidate approval; referenced scripts, direct executable files, Git HEAD,
+> and uncommitted working-tree changes are not independently verified or bound
+> to approval. Re-review those inputs before execution after repository changes.
 
 This intentionally resembles `direnv allow`: approval is local to the machine
 and is invalidated by a content change in the trusted file. It does not try to
@@ -192,6 +201,14 @@ step, and then call `trust allow` with that digest.
     "origin": "https://github.com/example/demo.git",
     "head": "<commit-sha>"
   },
+  "trust_scope": {
+    "approval_basis": "base_manifest.yaml_sha256",
+    "manifest_changes_invalidate": true,
+    "referenced_script_changes_invalidate": false,
+    "direct_executable_file_changes_invalidate": false,
+    "git_head_changes_invalidate": false,
+    "working_tree_changes_invalidate": false
+  },
   "allow_command": "basectl trust allow demo --manifest-sha256 <sha256>"
 }
 ```
@@ -228,5 +245,7 @@ Execution commands print the text block above and exit non-zero; JSON remains on
 2. [#1382](https://github.com/basefoundry/base/issues/1382): add Bash
    enforcement before `test`, `run`, `build`, `demo`, and activation source
    execution. Preserve `--dry-run` and `--list` inspection paths.
-3. After enforcement lands, decide whether setup delegates need a separate
-   approval surface.
+3. [#1973](https://github.com/basefoundry/base/issues/1973): require explicit
+   consent for project-originated IDE app, extension, and user-setting
+   mutations; show the complete dry-run plan; and document that command trust
+   is bound to the manifest digest only.

--- a/docs/setup-common-ownership.md
+++ b/docs/setup-common-ownership.md
@@ -23,7 +23,8 @@ breaking up the file into domain-scoped helpers or Python-owned surfaces.
 - Preserve the top-level setup contract: `basectl check` inspects,
   `basectl setup` applies, `basectl setup --dry-run` previews, and
   `basectl setup --yes` is consent for prompts, not an automatic "fix
-  everything" mode.
+  everything" mode. Project-originated IDE app, extension, and user-setting
+  mutations additionally require `--allow-project-ide-mutations`.
 - Preserve public function names and call sites during shell extraction. Move
   code first; rename only in later, separately reviewed cleanup.
 - Keep Bash responsible for host bootstrap, shell process orchestration, prompt

--- a/docs/tool-boundaries.md
+++ b/docs/tool-boundaries.md
@@ -508,6 +508,9 @@ How Base should coexist:
 - install declared extensions through `code` or `cursor`
 - add missing user-level settings without overwriting user values
 - report missing app, CLI, extension, and settings state through check/doctor
+- show the complete project-originated IDE mutation plan in `setup --dry-run`
+  and require `--allow-project-ide-mutations` before applying it; `--yes` alone
+  does not authorize these app, extension, or global user-setting changes
 
 Current stance: strong coexistence, Base as IDE-readiness orchestrator rather
 than IDE owner.

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -600,7 +600,7 @@ _base_basectl_completion_help() {
 _base_basectl_completion() {
     local command cur
     local commands="activate setup check test export-context devcontainer devenv-report build demo run repo ci release prompt docs clean logs history config trust doctor gh onboard update-profile update projects workspace version help"
-    local setup_options="--ci --format --profile --dry-run --manifest --notify --no-notify --recreate-venv --upgrade-pip --yes -v -h --help"
+    local setup_options="--ci --format --profile --dry-run --manifest --notify --no-notify --recreate-venv --upgrade-pip --yes --allow-project-ide-mutations -v -h --help"
     local check_options="--ci --profile --format --manifest --remote-network -v -h --help"
     local doctor_options="--ci --profile --format --manifest --remote-network --no-color -v -h --help"
 
@@ -925,7 +925,7 @@ _base_basectl_completion() {
         onboard)
             _base_basectl_completion_project_profiles_or_options \
                 "$cur" \
-                "--profile --dry-run --yes --no-profile -v -h --help" \
+                "--profile --dry-run --yes --allow-project-ide-mutations --no-profile -v -h --help" \
                 2 ""
             ;;
         update-profile)

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -611,6 +611,7 @@ _base_basectl_completion() {
                 '--recreate-venv[Recreate the Base venv]' \
                 '--upgrade-pip[Upgrade pip in the selected virtual environment]' \
                 '--yes[Apply setup changes that require explicit confirmation]' \
+                '--allow-project-ide-mutations[Approve project-originated IDE app, extension, and user-setting mutations]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '2:Base project:->projects'
             if [[ "$state" == projects ]]; then
@@ -1139,6 +1140,7 @@ _base_basectl_completion() {
             _arguments '--profile[Include prerequisite profiles]:profile:(dev sre ai linux-lab dev,sre dev,ai dev,linux-lab sre,ai sre,linux-lab ai,linux-lab dev,sre,ai dev,sre,linux-lab dev,ai,linux-lab sre,ai,linux-lab dev,sre,ai,linux-lab)' \
                 '--dry-run[Explain planned onboarding steps without making changes]' \
                 '--yes[Accept default answers for setup and shell profile prompts]' \
+                '--allow-project-ide-mutations[Approve project-originated IDE app, extension, and user-setting mutations]' \
                 '--no-profile[Skip shell profile updates]' \
                 '-v[Enable DEBUG logging]' \
                 '(-h --help)'{-h,--help}'[Show help text]' \


### PR DESCRIPTION
## Summary

- Require explicit `--allow-project-ide-mutations` approval for project-originated IDE app, extension, and global user-setting changes; `--yes` does not grant this approval.
- Show the complete IDE mutation plan, including cask, extension IDs, settings file, and setting values, in setup dry-run output.
- Publish the manifest-only command-trust scope in text and JSON output, with warnings for unbound referenced scripts and Git state.
- Document the setup, onboarding, trust, workflow, ownership, and completion contracts.

## Contract

- `basectl setup --dry-run` is the review step for project-originated IDE mutations.
- `basectl setup` without `--allow-project-ide-mutations` fails before project setup reconcilers apply those mutations.
- Onboarding has a separate interactive IDE consent prompt; `basectl onboard --yes` intentionally does not answer it.
- Manifest command approval remains bound to the `base_manifest.yaml` SHA-256. Referenced scripts, direct executable files, Git HEAD, and uncommitted working-tree changes are warned about but do not independently invalidate approval.

## Validation

- `env -u BASE_HOME ... ./bin/base-test`
- 1,004 Python tests passed
- 892 BATS tests passed
- Focused shell suite: 103 tests passed
- Focused Python suite: 69 tests and 35 subtests passed
- Pylint passed for all changed Python files
- ShellCheck and Bash syntax checks passed
- `git diff --check` passed

Fixes #1973
