### PR TITLE
chore: align Base with base-cli 0.4.3

### DIFF
--- a/.github/workflows/base-check.yml
+++ b/.github/workflows/base-check.yml
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.2
+          ref: v0.4.3
           path: .base/base-cli
 
       - name: Set up Python

--- a/.github/workflows/base-demo-e2e.yml
+++ b/.github/workflows/base-demo-e2e.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.2
+          ref: v0.4.3
           path: .dependencies/base-cli
 
       - name: Check out base-bash-libs

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.2
+          ref: v0.4.3
           path: .dependencies/base-cli
 
       - name: Set up Python

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.2
+          ref: v0.4.3
           path: .dependencies/base-cli
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.2
+          ref: v0.4.3
           path: .dependencies/base-cli
 
       - name: Set up Python
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.2
+          ref: v0.4.3
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.2
+          ref: v0.4.3
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -221,7 +221,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.2
+          ref: v0.4.3
           path: .dependencies/base-cli
 
       - name: Expose standalone Python package checkout as sibling
@@ -285,7 +285,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.2
+          ref: v0.4.3
           path: .dependencies/base-cli
 
       - name: Expose reusable Bash library checkout as sibling
@@ -347,7 +347,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-cli
-          ref: v0.4.2
+          ref: v0.4.3
           path: .dependencies/base-cli
 
       - name: Set up Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ numeric next development line is tracked in `DEVELOPMENT_VERSION`.
 
 ### Changed
 
+- Align development dependencies and source-checkout CI workflows with the
+  released `base-cli` `0.4.3` provider.
+
 - Documented stable release versus contributor source installation and made
   mutable source checkouts report the next development line with their Git
   revision instead of reusing the latest published version identity.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 pylint==3.3.9
 click==8.4.1
-base-cli==0.4.2
+base-cli==0.4.3
 PyYAML==6.0.3
 pytest==9.0.3
 pytest-cov==7.1.0

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -701,7 +701,7 @@ def test_base_demo_e2e_workflow_covers_the_external_project_loop() -> None:
         "basefoundry/base-bash-libs",
     ]
     assert "b4243765726c133499feeabdc50154f99c0fec12" in str(steps)
-    assert "v0.4.2" in str(steps)
+    assert "v0.4.3" in str(steps)
 
     for command in (
         "basectl setup --ci base-demo",


### PR DESCRIPTION
## Summary

- pin the development dependency to `base-cli==0.4.3`
- move every Base source-checkout CI pin to the released `v0.4.3` tag
- update workflow contract coverage and the unreleased changelog

## Validation

- `tests/test_github_workflows.py` (46 passed)
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python BASE_CACHE_DIR=/private/tmp/base-dep-base-validation ./bin/base-test` (1,004 Python passed; 892 BATS passed)

No Base release is included.

Closes #1999