### PR TITLE
feat(workspace): expose aggregate status in status JSON

### DIFF
--- a/cli/python/base_projects/tests/test_workspace_status_aggregate.py
+++ b/cli/python/base_projects/tests/test_workspace_status_aggregate.py
@@ -1,0 +1,51 @@
+"""Aggregate status field on workspace status JSON (#1993)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from base_projects.workspace_report_json import workspace_aggregate_status
+from base_projects.workspace_report_json import workspace_status_to_json
+
+
+def _status(name: str, status: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        status=status,
+        root=Path(f"/tmp/{name}"),
+        manifest_path=None,
+        venv="ok",
+        manifest="ok",
+        last_check=None,
+        issues=(),
+        python_runtime=None,
+        repository=None,
+        required=False,
+        repo="ok",
+    )
+
+
+def test_workspace_aggregate_status_all_ok():
+    assert workspace_aggregate_status((_status("a", "ok"), _status("b", "ok"))) == "ok"
+
+
+def test_workspace_aggregate_status_attention():
+    assert workspace_aggregate_status((_status("a", "ok"), _status("b", "warn"))) == "attention"
+
+
+def test_workspace_aggregate_status_empty():
+    assert workspace_aggregate_status(()) == "ok"
+
+
+def test_workspace_status_to_json_includes_aggregate_ok(tmp_path: Path):
+    payload = workspace_status_to_json(tmp_path, (_status("a", "ok"), _status("b", "ok")))
+    assert payload["status"] == "ok"
+    assert payload["project_count"] == 2
+    assert [p["status"] for p in payload["projects"]] == ["ok", "ok"]
+
+
+def test_workspace_status_to_json_includes_aggregate_attention(tmp_path: Path):
+    payload = workspace_status_to_json(tmp_path, (_status("a", "ok"), _status("b", "error")))
+    assert payload["status"] == "attention"
+    assert payload["projects"][1]["status"] == "error"

--- a/cli/python/base_projects/workspace_report_json.py
+++ b/cli/python/base_projects/workspace_report_json.py
@@ -17,6 +17,18 @@ from base_setup.checks import check_to_json
 from base_setup.checks import checks_status
 
 
+
+
+def workspace_aggregate_status(statuses: tuple[Any, ...]) -> str:
+    """Overall workspace health using the same rule as the text renderer.
+
+    Returns ``ok`` when every project reports ``ok``, otherwise ``attention``.
+    An empty workspace is ``ok`` (nothing needs attention).
+    """
+    if any(getattr(status, "status", None) != "ok" for status in statuses):
+        return "attention"
+    return "ok"
+
 def workspace_status_to_json(
     workspace_root: Path,
     statuses: tuple[Any, ...],
@@ -24,6 +36,7 @@ def workspace_status_to_json(
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "workspace": str(workspace_root),
+        "status": workspace_aggregate_status(statuses),
         "project_count": workspace_project_count(statuses, workspace_manifest),
         "projects": [workspace_status_item_to_json(status, workspace_manifest) for status in statuses],
     }


### PR DESCRIPTION
## Summary
`basectl workspace status --format json` now includes a top-level `status` field using the same vocabulary as the text renderer:

- `ok` — every project reports `ok` (including empty workspaces)
- `attention` — any project reports a non-`ok` status

Per-project fields are unchanged.

Fixes #1993

## Test plan
- [ ] `cli/python/base_projects/tests/test_workspace_status_aggregate.py`
- [ ] Compare JSON `status` with text "need attention" / "look ok" for mixed workspaces
