### PR TITLE
feat: expose workspace status aggregate in JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ numeric next development line is tracked in `DEVELOPMENT_VERSION`.
 
 ### Changed
 
+- Added a top-level aggregate status to `basectl workspace status --format
+  json`, using the existing `error`, `warn`, and `ok` precedence while
+  preserving per-project fields.
+
 - Align development dependencies and source-checkout CI workflows with the
   released `base-cli` `0.4.3` provider.
 

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -538,6 +538,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
         self.assertEqual(payload["projects"][0]["status"], "ok")
+        self.assertEqual(payload["status"], "ok")
         self.assertEqual(payload["projects"][0]["venv"], "not_applicable")
         self.assertEqual(payload["projects"][0]["issues"], [])
 
@@ -590,6 +591,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertTrue(stdout.startswith("{\n"))
         self.assertIn('  "workspace": ', stdout)
+        self.assertEqual(payload["status"], "warn")
         self.assertEqual(payload["workspace"], str(workspace.resolve()))
         self.assertEqual(payload["project_count"], 1)
         self.assertEqual(payload["projects"][0]["name"], "demo")
@@ -679,6 +681,35 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertIn("broken               error  unknown        invalid", stdout)
         self.assertIn("demo                 warn   missing        valid", stdout)
         self.assertIn("2 project(s) need attention", stdout)
+
+    def test_workspace_status_json_aggregates_mixed_project_states(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            self.manifest_factory.write_shell(workspace / "healthy", "healthy")
+            self.manifest_factory.write_project(workspace / "attention", "attention")
+            broken_root = workspace / "broken"
+            broken_root.mkdir(parents=True)
+            (broken_root / "base_manifest.yaml").write_text("project: [", encoding="utf-8")
+
+            status, stdout, stderr = invoke_engine(
+                ["status", "--workspace", str(workspace), "--format", "json"],
+                base_home,
+                home,
+            )
+
+        payload = json.loads(stdout)
+        projects_by_name = {project["name"]: project for project in payload["projects"]}
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(projects_by_name["healthy"]["status"], "ok")
+        self.assertEqual(projects_by_name["attention"]["status"], "warn")
+        self.assertEqual(projects_by_name["broken"]["status"], "error")
 
     def test_projects_list_reuses_project_cache_when_manifests_are_unchanged(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_projects/workspace_report_json.py
+++ b/cli/python/base_projects/workspace_report_json.py
@@ -11,6 +11,7 @@ from base_projects.workspace_agent_brief import WorkspaceAgentBriefRepository
 from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_onboarding import WorkspaceOnboardingRepository
 from base_projects.workspace_onboarding import WorkspaceOnboardingSummary
+from base_projects.workspace_report_common import most_severe_status
 from base_setup.checks import ArtifactCheck
 from base_setup.checks import DIAGNOSTIC_JSON_SCHEMA_VERSION
 from base_setup.checks import check_to_json
@@ -24,6 +25,7 @@ def workspace_status_to_json(
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "workspace": str(workspace_root),
+        "status": most_severe_status(*(status.status for status in statuses)),
         "project_count": workspace_project_count(statuses, workspace_manifest),
         "projects": [workspace_status_item_to_json(status, workspace_manifest) for status in statuses],
     }

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -32,6 +32,11 @@ basectl workspace status | tee status.tsv # headerless TSV rows
 basectl workspace status --format json   # one stable JSON document
 ```
 
+The JSON document emitted by `basectl workspace status --format json` includes
+a top-level aggregate `status` alongside `workspace`, `project_count`, and
+`projects`. The aggregate uses `error` over `warn` over `ok` precedence; each
+project record retains its existing `status` field.
+
 The terminal check is made on stdout, so redirecting stdout changes only the
 default `text` presentation. An explicitly selected `--format text` follows
 the same rule. Logging, warnings, and usage errors stay on stderr and never

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -65,6 +65,23 @@ check date in the `LAST CHECK` column, while JSON output includes the full
 timestamp and check status. Projects without a recorded check show `-` in text
 output and `null` in JSON output.
 
+JSON status output includes a top-level `status` aggregate in addition to each
+project's status. It uses the same status vocabulary and precedence as workspace
+reports: `error` takes precedence over `warn`, which takes precedence over `ok`.
+An empty workspace has aggregate status `ok`.
+
+```json
+{
+  "workspace": "/Users/example/work",
+  "status": "warn",
+  "project_count": 2,
+  "projects": [
+    {"name": "base", "status": "ok"},
+    {"name": "demo", "status": "warn"}
+  ]
+}
+```
+
 The latest-check record is optional persistence state. If a check succeeds but
 cannot save that record, the check result remains authoritative and workspace
 status reports the missing record as `-` or `null` until a later check can save


### PR DESCRIPTION
## Summary

Add a top-level `status` to `basectl workspace status --format json`, derived from the existing workspace project statuses with `error` taking precedence over `warn`, then `ok`. Existing per-project fields remain unchanged.

## Issue

Fixes #1993

## Validation

- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python BASE_CACHE_DIR=/private/tmp/base-1993-full-cache ./bin/base-test` — 1,005 passed.
- `git diff --check`

## Docs Impact

- Documented the aggregate `status` field and precedence in `docs/workspace-manifest.md` and `docs/output-formats.md`.
- Added the change to the `Unreleased` section of `CHANGELOG.md`.