### PR TITLE
Reject credential-bearing workspace repository URLs

### DIFF
--- a/cli/python/base_projects/tests/test_workspace_agent_brief.py
+++ b/cli/python/base_projects/tests/test_workspace_agent_brief.py
@@ -30,7 +30,7 @@ def write_workspace_manifest(path: Path) -> None:
                 "    url: git@github.com:example/ready.git",
                 "  - name: partial",
                 "  - name: missing",
-                "    url: https://agent:supersecret@github.com/example/missing.git",
+                "    url: https://github.com/example/missing.git",
                 "  - name: optional",
                 "    url: git@github.com:example/optional.git",
                 "    required: false",
@@ -190,9 +190,8 @@ class WorkspaceAgentBriefTests(unittest.TestCase):
         self.assertEqual(repositories["partial"]["next_actions"], [])
         self.assertEqual(repositories["missing"]["handoff_status"], "missing_required")
         self.assertIsNone(repositories["missing"]["project"])
-        self.assertEqual(repositories["missing"]["url"], "https://[REDACTED]@github.com/example/missing.git")
-        self.assertNotIn("supersecret", stdout)
-        self.assertIn("https://[REDACTED]@github.com/example/missing.git", repositories["missing"]["next_actions"][0])
+        self.assertEqual(repositories["missing"]["url"], "https://github.com/example/missing.git")
+        self.assertIn("https://github.com/example/missing.git", repositories["missing"]["next_actions"][0])
         self.assertEqual(repositories["missing"]["signals"]["baseline"]["status"], "unavailable")
         self.assertEqual(repositories["optional"]["handoff_status"], "missing_optional")
         self.assertEqual(repositories["local-tool"]["scope"], "local_only")
@@ -231,22 +230,19 @@ class WorkspaceAgentBriefTests(unittest.TestCase):
             {"status", "command", "source"},
         )
 
-    def test_redacts_repository_url_secrets_in_json_and_clone_actions(self) -> None:
+    def test_rejects_unsafe_repository_urls_without_echoing_secrets(self) -> None:
         cases = (
             (
                 "scp userinfo",
                 "oauth2:topsecret@gitlab.com:example/private.git",
-                "[REDACTED]@gitlab.com:example/private.git",
                 ("topsecret",),
+                "contains embedded credentials or secret URL parameters",
             ),
             (
                 "query and fragment",
                 "https://gitlab.com/example/private.git?private_token=querysecret&password=passwordsecret"
                 "&client_secret=clientsecret&api_key=apikeysecret&authorization=authsecret"
                 "&ref=main#access_token=fragmentsecret",
-                "https://gitlab.com/example/private.git?private_token=[REDACTED]&password=[REDACTED]"
-                "&client_secret=[REDACTED]&api_key=[REDACTED]&authorization=[REDACTED]"
-                "&ref=main#access_token=[REDACTED]",
                 (
                     "querysecret",
                     "passwordsecret",
@@ -255,33 +251,34 @@ class WorkspaceAgentBriefTests(unittest.TestCase):
                     "authsecret",
                     "fragmentsecret",
                 ),
+                "contains embedded credentials or secret URL parameters",
             ),
             (
                 "malformed URL",
                 "https://[malformed/private.git?token=malformedsecret",
-                "[REDACTED]",
                 ("malformedsecret",),
+                "does not look like a Git URL or local path",
             ),
             (
                 "missing network authority",
                 "https:///oauth2:authoritysecret@gitlab.com/example/private.git",
-                "[REDACTED]",
                 ("authoritysecret",),
+                "does not look like a Git URL or local path",
             ),
             (
                 "invalid network port",
                 "https://gitlab.com:invalid/example/private.git?token=portsecret",
-                "[REDACTED]",
                 ("portsecret",),
+                "does not look like a Git URL or local path",
             ),
             (
                 "network URL control character",
                 "https://gitlab.com/example/private.git?token=controlsecret\nignored",
-                "[REDACTED]",
                 ("controlsecret",),
+                "does not look like a Git URL or local path",
             ),
         )
-        for label, url, expected_url, secrets in cases:
+        for label, url, secrets, expected_error in cases:
             with self.subTest(label=label):
                 with tempfile.TemporaryDirectory() as tmpdir:
                     root = Path(tmpdir)
@@ -321,14 +318,13 @@ class WorkspaceAgentBriefTests(unittest.TestCase):
                         home,
                     )
 
-                payload = json.loads(stdout)
-                private = payload["repositories"][0]
-                self.assertEqual(status, 0)
-                self.assertEqual(stderr, "")
-                self.assertEqual(private["url"], expected_url)
-                self.assertIn(expected_url, private["next_actions"][0])
+                self.assertEqual(status, 1)
+                self.assertEqual(stdout, "")
+                self.assertIn(expected_error, stderr)
+                if "embedded credentials" in expected_error:
+                    self.assertIn("Git credential helper or SSH configuration", stderr)
                 for secret in secrets:
-                    self.assertNotIn(secret, stdout)
+                    self.assertNotIn(secret, stdout + stderr)
 
     def test_manifest_validation_is_recommended_through_basectl_test(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_projects/tests/test_workspace_manifest.py
+++ b/cli/python/base_projects/tests/test_workspace_manifest.py
@@ -125,6 +125,62 @@ repos:
             ):
                 read_workspace_manifest(path)
 
+    def test_rejects_repository_url_secrets_without_echoing_them(self) -> None:
+        cases = (
+            ("https://user:USERINFO_SECRET@github.com/example/private.git", "USERINFO_SECRET"),
+            ("oauth2:SCP_SECRET@gitlab.com:example/private.git", "SCP_SECRET"),
+            ("https://github.com/example/private.git?token=QUERY_SECRET", "QUERY_SECRET"),
+            ("ssh://git@github.com/example/private.git#password=FRAGMENT_SECRET", "FRAGMENT_SECRET"),
+        )
+        for url, secret in cases:
+            with self.subTest(url=url):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    path = Path(tmpdir) / "workspace.yaml"
+                    write_workspace_manifest(
+                        path,
+                        "\n".join(
+                            (
+                                "schema_version: 1",
+                                "workspace:",
+                                "  name: demo-workspace",
+                                "repos:",
+                                "  - name: private",
+                                f"    url: '{url}'",
+                                "",
+                            )
+                        ),
+                    )
+
+                    with self.assertRaises(WorkspaceManifestError) as raised:
+                        read_workspace_manifest(path)
+
+                message = str(raised.exception)
+                self.assertIn("contains embedded credentials or secret URL parameters", message)
+                self.assertIn("Git credential helper or SSH configuration", message)
+                self.assertNotIn(secret, message)
+
+    def test_rejects_malformed_repository_url_without_echoing_it(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "workspace.yaml"
+            write_workspace_manifest(
+                path,
+                """
+schema_version: 1
+workspace:
+  name: demo-workspace
+repos:
+  - name: private
+    url: "https://[malformed/private.git?token=MALFORMED_SECRET"
+""",
+            )
+
+            with self.assertRaises(WorkspaceManifestError) as raised:
+                read_workspace_manifest(path)
+
+        message = str(raised.exception)
+        self.assertIn("does not look like a Git URL or local path", message)
+        self.assertNotIn("MALFORMED_SECRET", message)
+
     def test_requires_schema_version(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "workspace.yaml"

--- a/cli/python/base_projects/tests/test_workspace_repository_url.py
+++ b/cli/python/base_projects/tests/test_workspace_repository_url.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from base_projects import engine
+from base_projects.workspace_agent_brief import agent_brief_repository_from_status
+from base_projects.workspace_clone_command import clone_workspace_repo
+from base_projects.workspace_manifest import WorkspaceManifest
+from base_projects.workspace_manifest import WorkspaceManifestRepo
+from base_projects.workspace_onboarding import onboarding_repository_from_status
+from base_projects.workspace_report_common import missing_repo_fix
+from base_projects.workspace_report_common import workspace_repo_check_details
+from base_projects.workspace_report_json import workspace_agent_brief_item_to_json
+from base_projects.workspace_report_json import workspace_onboarding_item_to_json
+from base_projects.workspace_report_json import workspace_status_item_to_json
+from base_projects.workspace_repository_url import redact_repository_url
+from base_projects.workspace_repository_url import repository_url_problem
+from base_projects.workspace_statuses import WorkspaceProjectStatus
+
+
+class TerminalStringIO(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+def invoke_engine(args: list[str], base_home: Path, home: Path) -> tuple[int, str, str]:
+    stdout = TerminalStringIO()
+    stderr = io.StringIO()
+    env = {
+        "HOME": str(home),
+        "BASE_HOME": str(base_home),
+        "BASE_PROJECT": "",
+        "BASE_PROJECT_MANIFEST": "",
+    }
+    with mock.patch.dict(os.environ, env):
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            status = engine.main(args)
+    return status, stdout.getvalue(), stderr.getvalue()
+
+
+class WorkspaceRepositoryUrlTests(unittest.TestCase):
+    def test_safe_repository_urls_are_unchanged(self) -> None:
+        urls = (
+            "https://github.com/basefoundry/base.git",
+            "ssh://git@github.com/basefoundry/base.git",
+            "git@github.com:basefoundry/base.git",
+            "file:///private/tmp/base.git",
+            "/private/tmp/base.git",
+        )
+        for url in urls:
+            with self.subTest(url=url):
+                self.assertEqual(redact_repository_url(url), url)
+                self.assertIsNone(repository_url_problem(url))
+
+    def test_sanitizer_covers_userinfo_parameters_and_malformed_urls(self) -> None:
+        cases = (
+            (
+                "https://user:USERINFO_SECRET@github.com/example/private.git",
+                "https://[REDACTED]@github.com/example/private.git",
+                "sensitive",
+            ),
+            (
+                "oauth2:SCP_SECRET@gitlab.com:example/private.git",
+                "[REDACTED]@gitlab.com:example/private.git",
+                "sensitive",
+            ),
+            (
+                "https://github.com/example/private.git?token=QUERY_SECRET&ref=main#password=FRAGMENT_SECRET",
+                "https://github.com/example/private.git?token=[REDACTED]&ref=main#password=[REDACTED]",
+                "sensitive",
+            ),
+            (
+                "https://[malformed/private.git?token=MALFORMED_SECRET",
+                "[REDACTED]",
+                "invalid",
+            ),
+        )
+        for url, expected, problem in cases:
+            with self.subTest(url=url):
+                self.assertEqual(redact_repository_url(url), expected)
+                self.assertEqual(repository_url_problem(url), problem)
+                self.assertNotIn("_SECRET", expected)
+
+    def test_every_workspace_command_rejects_credentials_without_persisting_or_printing_them(self) -> None:
+        sentinel = "WORKSPACE_SECRET_SENTINEL"
+        invocations = (
+            ("status text", ["status"]),
+            ("status json", ["status", "--format", "json"]),
+            ("check text", ["check"]),
+            ("check json", ["check", "--format", "json"]),
+            ("doctor text", ["doctor"]),
+            ("doctor json", ["doctor", "--format", "json"]),
+            ("onboarding text", ["onboarding"]),
+            ("onboarding json", ["onboarding", "--format", "json"]),
+            ("agent brief text", ["agent-brief"]),
+            ("agent brief json", ["agent-brief", "--format", "json"]),
+            ("clone plan", ["clone", "--dry-run"]),
+        )
+        for label, command in invocations:
+            with self.subTest(label=label):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    root = Path(tmpdir)
+                    home = root / "home"
+                    workspace = root / "workspace"
+                    base_home = root / "base"
+                    manifest_path = root / "workspace.yaml"
+                    home.mkdir()
+                    workspace.mkdir()
+                    default_manifest = base_home / "lib" / "base" / "default_manifest.yaml"
+                    default_manifest.parent.mkdir(parents=True)
+                    default_manifest.write_text(
+                        "project:\n  name: base-defaults\nartifacts: []\n",
+                        encoding="utf-8",
+                    )
+                    manifest_path.write_text(
+                        "\n".join(
+                            (
+                                "schema_version: 1",
+                                "workspace:",
+                                "  name: private-suite",
+                                "repos:",
+                                "  - name: private",
+                                f"    url: https://user:{sentinel}@github.com/example/private.git",
+                                "",
+                            )
+                        ),
+                        encoding="utf-8",
+                    )
+                    args = command + ["--workspace", str(workspace), "--manifest", str(manifest_path)]
+
+                    with mock.patch("base_projects.workspace_clone_command.run_project_command") as run_command:
+                        status, stdout, stderr = invoke_engine(args, base_home, home)
+
+                    run_command.assert_not_called()
+                    self.assertEqual(status, 1)
+                    self.assertNotIn(sentinel, stdout + stderr)
+                    self.assertIn("Git credential helper or SSH configuration", stdout + stderr)
+                    for path in home.rglob("*"):
+                        if path.is_file():
+                            self.assertNotIn(sentinel, path.read_text(encoding="utf-8", errors="replace"))
+
+    def test_status_json_defensively_redacts_an_internal_unsafe_url(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest = WorkspaceManifest(
+                path=root / "workspace.yaml",
+                name="private-suite",
+                repos=(WorkspaceManifestRepo(name="private"),),
+            )
+            status = WorkspaceProjectStatus(
+                name="private",
+                root=root / "private",
+                manifest_path=None,
+                status="error",
+                venv="unknown",
+                manifest="unknown",
+                issues=(),
+                expected=True,
+                required=True,
+                repo="missing",
+                repository="private",
+                url="https://github.com/example/private.git?token=JSON_SECRET_SENTINEL",
+            )
+
+            payload = workspace_status_item_to_json(status, manifest)
+
+        self.assertEqual(
+            payload["url"],
+            "https://github.com/example/private.git?token=[REDACTED]",
+        )
+        self.assertNotIn("JSON_SECRET_SENTINEL", str(payload))
+
+    def test_every_internal_repository_url_consumer_defensively_sanitizes(self) -> None:
+        sentinel = "INTERNAL_SECRET_SENTINEL"
+        unsafe_url = f"https://user:{sentinel}@gitlab.com/example/private.git?token={sentinel}"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            repo = WorkspaceManifestRepo(name="private", url=unsafe_url)
+            manifest = WorkspaceManifest(
+                path=root / "workspace.yaml",
+                name="private-suite",
+                repos=(repo,),
+            )
+            status = WorkspaceProjectStatus(
+                name="private",
+                root=root / "private",
+                manifest_path=None,
+                status="error",
+                venv="unknown",
+                manifest="unknown",
+                issues=(),
+                expected=True,
+                required=True,
+                repo="missing",
+                repository="private",
+                url=unsafe_url,
+            )
+            onboarding = onboarding_repository_from_status(status)
+            agent_brief = agent_brief_repository_from_status(status)
+            rendered_consumers = (
+                workspace_repo_check_details(repo, status.root, present=False),
+                missing_repo_fix(repo, status.root),
+                workspace_status_item_to_json(status, manifest),
+                workspace_onboarding_item_to_json(onboarding),
+                workspace_agent_brief_item_to_json(agent_brief),
+            )
+
+            ctx = mock.Mock()
+            result = clone_workspace_repo(
+                ctx,
+                root / "base" / "bin" / "basectl",
+                repo,
+                status.root,
+                dry_run=True,
+            )
+
+        self.assertEqual(result, 1)
+        error_call = ctx.log.error.call_args.args
+        rendered_consumers += (error_call[0] % error_call[1:],)
+        for rendered in rendered_consumers:
+            with self.subTest(rendered=rendered):
+                self.assertNotIn(sentinel, str(rendered))
+                self.assertIn("[REDACTED]", str(rendered))

--- a/cli/python/base_projects/workspace_agent_brief.py
+++ b/cli/python/base_projects/workspace_agent_brief.py
@@ -1,19 +1,13 @@
 from __future__ import annotations
 
 import os
-import re
 import shlex
 from dataclasses import dataclass
 from pathlib import Path
-from urllib.parse import SplitResult
-from urllib.parse import unquote_plus
-from urllib.parse import urlsplit
-from urllib.parse import urlunsplit
 
-from base_cli.redaction import REDACTED
-from base_cli.redaction import is_secret_key
 from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_onboarding import test_command_for_status
+from base_projects.workspace_repository_url import redact_repository_url
 from base_projects.workspace_statuses import WorkspaceProjectStatus
 from base_projects.workspace_statuses import workspace_manifest_project_statuses
 from base_setup.manifest import read_manifest
@@ -48,11 +42,6 @@ UNMANAGED_AGENT_GUIDANCE_FILES = (
     "AGENTS.md",
     "skills.md",
 )
-
-SCP_REPOSITORY_URL_RE = re.compile(r"^(?P<userinfo>[^@\s]+)@(?P<location>[^:\s]+:.+)$")
-URL_PARAMETER_SEPARATOR_RE = re.compile(r"([&;])")
-NETWORK_REPOSITORY_URL_SCHEMES = frozenset(("git", "https", "ssh"))
-
 
 @dataclass(frozen=True)
 class RepositoryFileSignal:
@@ -233,80 +222,6 @@ def executable_file(path: Path) -> bool:
         return path.is_file() and os.access(path, os.X_OK)
     except OSError:
         return False
-
-
-def redact_repository_url(value: str) -> str:
-    if Path(value).is_absolute():
-        return value
-
-    if any(character.isspace() or ord(character) < 32 or ord(character) == 127 for character in value):
-        return REDACTED
-
-    scp_match = None if "://" in value else SCP_REPOSITORY_URL_RE.match(value)
-    if scp_match is not None:
-        userinfo = scp_match.group("userinfo")
-        sanitized_userinfo = userinfo if userinfo == "git" else REDACTED
-        sanitized = f"{sanitized_userinfo}@{scp_match.group('location')}"
-        return redact_url_suffix_parameters(sanitized)
-
-    parsed = parse_repository_url(value)
-    if parsed is None:
-        return REDACTED
-
-    netloc = parsed.netloc
-    userinfo, separator, host = netloc.rpartition("@")
-    if separator and userinfo != "git":
-        netloc = f"{REDACTED}@{host}"
-    return urlunsplit(
-        (
-            parsed.scheme,
-            netloc,
-            parsed.path,
-            redact_url_parameters(parsed.query),
-            redact_url_parameters(parsed.fragment),
-        )
-    )
-
-
-def parse_repository_url(value: str) -> SplitResult | None:
-    try:
-        parsed = urlsplit(value)
-    except ValueError:
-        return None
-    if parsed.scheme in NETWORK_REPOSITORY_URL_SCHEMES:
-        return parsed if valid_network_repository_url(parsed) else None
-    if parsed.scheme == "file":
-        return parsed
-    return None
-
-
-def valid_network_repository_url(parsed: SplitResult) -> bool:
-    try:
-        hostname = parsed.hostname
-        _port = parsed.port
-    except ValueError:
-        return False
-    return bool(parsed.netloc and hostname)
-
-
-def redact_url_suffix_parameters(value: str) -> str:
-    base_and_query, fragment_separator, fragment = value.partition("#")
-    base, query_separator, query = base_and_query.partition("?")
-    sanitized = base
-    if query_separator:
-        sanitized = f"{sanitized}?{redact_url_parameters(query)}"
-    if fragment_separator:
-        sanitized = f"{sanitized}#{redact_url_parameters(fragment)}"
-    return sanitized
-
-
-def redact_url_parameters(value: str) -> str:
-    parts = URL_PARAMETER_SEPARATOR_RE.split(value)
-    for index in range(0, len(parts), 2):
-        key, separator, _parameter_value = parts[index].partition("=")
-        if separator and is_secret_key(unquote_plus(key)):
-            parts[index] = f"{key}={REDACTED}"
-    return "".join(parts)
 
 
 def repository_ai_context_status(root: Path) -> str:

--- a/cli/python/base_projects/workspace_checks.py
+++ b/cli/python/base_projects/workspace_checks.py
@@ -15,6 +15,7 @@ from base_projects.workspace_report_common import missing_repo_message
 from base_projects.workspace_report_common import project_venv_dir
 from base_projects.workspace_report_common import project_venv_ready
 from base_projects.workspace_report_common import workspace_repo_check_details
+from base_projects.workspace_repository_url import redact_repository_url
 from base_projects.workspace_scanner import ManifestEntry
 from base_projects.workspace_scanner import workspace_manifest_entries
 from base_setup.checks import ArtifactCheck
@@ -138,7 +139,7 @@ def workspace_expected_repo_check_result(
             required=repo.required,
             repo="present",
             repository=repo.name,
-            url=repo.url,
+            url=redact_repository_url(repo.url) if repo.url is not None else None,
             default_branch=repo.default_branch,
         )
 
@@ -154,7 +155,7 @@ def workspace_expected_repo_check_result(
         required=repo.required,
         repo="missing",
         repository=repo.name,
-        url=repo.url,
+        url=redact_repository_url(repo.url) if repo.url is not None else None,
         default_branch=repo.default_branch,
     )
 
@@ -173,7 +174,7 @@ def attach_check_result_repo_metadata(
         required=repo.required,
         repo="present",
         repository=repo.name,
-        url=repo.url,
+        url=redact_repository_url(repo.url) if repo.url is not None else None,
         default_branch=repo.default_branch,
     )
 

--- a/cli/python/base_projects/workspace_clone_command.py
+++ b/cli/python/base_projects/workspace_clone_command.py
@@ -15,6 +15,7 @@ from base_projects.workspace_context import resolve_workspace_root
 from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_manifest import WorkspaceManifestError
 from base_projects.workspace_manifest import WorkspaceManifestRepo
+from base_projects.workspace_repository_url import redact_repository_url
 from base_projects.workspace_scanner import ProjectDiscoveryError
 
 
@@ -118,7 +119,7 @@ def clone_workspace_repo(
         ctx.log.error(
             "Repository '%s' has unsupported clone URL '%s'. Only github.com repository URLs are supported.",
             repo.name,
-            repo.url,
+            redact_repository_url(repo.url) if repo.url is not None else None,
         )
         return base_cli.ExitCode.FAILURE
 

--- a/cli/python/base_projects/workspace_manifest.py
+++ b/cli/python/base_projects/workspace_manifest.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from base_projects.workspace_repository_url import repository_url_problem
 
 try:
     import yaml
@@ -161,19 +162,21 @@ def _read_optional_string(path: Path, field: str, value: Any) -> str | None:
 
 
 def _validate_repo_url(path: Path, index: int, url: str) -> None:
-    if url.startswith("http://"):
+    problem = repository_url_problem(url)
+    if problem == "insecure_http":
         raise WorkspaceManifestError(
             f"{path}: repos[{index}].url uses insecure cleartext HTTP. "
             "Use HTTPS, SSH, file://, or an absolute local path."
         )
-    if url.startswith(("https://", "git://", "ssh://", "file://")):
-        return
-    if re.match(r"^[^@\s]+@[^:\s]+:.+$", url):
-        return
-    if Path(url).is_absolute():
+    if problem == "sensitive":
+        raise WorkspaceManifestError(
+            f"{path}: repos[{index}].url contains embedded credentials or secret URL parameters. "
+            "Remove them and use a Git credential helper or SSH configuration."
+        )
+    if problem is None:
         return
     raise WorkspaceManifestError(
-        f"{path}: repos[{index}].url does not look like a Git URL or local path: '{url}'."
+        f"{path}: repos[{index}].url does not look like a Git URL or local path."
     )
 
 

--- a/cli/python/base_projects/workspace_onboarding.py
+++ b/cli/python/base_projects/workspace_onboarding.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from base_projects.project_commands import test_command as manifest_test_command
 from base_projects.workspace_manifest import WorkspaceManifest
+from base_projects.workspace_repository_url import redact_repository_url
 from base_projects.workspace_statuses import WorkspaceProjectStatus
 from base_projects.workspace_statuses import workspace_manifest_project_statuses
 from base_setup.manifest import read_manifest
@@ -73,7 +74,7 @@ def onboarding_repository_from_status(status: WorkspaceProjectStatus) -> Workspa
         venv=status.venv,
         next_action=next_action_for_status(status, status_name),
         manifest_path=status.manifest_path,
-        url=status.url,
+        url=redact_repository_url(status.url) if status.url is not None else None,
         default_branch=status.default_branch,
         setup_command=setup_command,
         validation_command=validation_command,
@@ -109,7 +110,7 @@ def validation_command_for_status(status: WorkspaceProjectStatus) -> str | None:
 def clone_command_for_status(status: WorkspaceProjectStatus) -> str | None:
     if status.repo != "missing" or status.url is None:
         return None
-    return shlex.join(["git", "clone", status.url, str(status.root)])
+    return shlex.join(["git", "clone", redact_repository_url(status.url), str(status.root)])
 
 
 def test_command_for_status(status: WorkspaceProjectStatus) -> str | None:
@@ -140,6 +141,6 @@ def next_action_for_status(status: WorkspaceProjectStatus, status_name: str) -> 
 
 def missing_required_next_action(status: WorkspaceProjectStatus) -> str:
     if status.url is not None:
-        return f"Clone {status.url} into {status.root}, then run setup."
+        return f"Clone {redact_repository_url(status.url)} into {status.root}, then run setup."
     repository = status.repository or status.root.name
     return f"Create or clone repository '{repository}' into {status.root}, then run setup."

--- a/cli/python/base_projects/workspace_report_common.py
+++ b/cli/python/base_projects/workspace_report_common.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from base_cli_adapters.paths import base_state_root
 from base_projects.workspace_manifest import WorkspaceManifestRepo
+from base_projects.workspace_repository_url import redact_repository_url
 from base_setup.manifest_model import BaseManifest
 from base_setup.project_routing import route_for_manifest
 
@@ -66,7 +67,7 @@ def workspace_repo_check_details(repo: WorkspaceManifestRepo, root: Path, presen
         "present": present,
     }
     if repo.url is not None:
-        details["url"] = repo.url
+        details["url"] = redact_repository_url(repo.url)
     if repo.default_branch is not None:
         details["default_branch"] = repo.default_branch
     return details
@@ -79,7 +80,7 @@ def missing_repo_message(repo: WorkspaceManifestRepo, root: Path) -> str:
 
 def missing_repo_fix(repo: WorkspaceManifestRepo, root: Path) -> str:
     if repo.url:
-        return f"Clone '{repo.url}' into '{root}'."
+        return f"Clone '{redact_repository_url(repo.url)}' into '{root}'."
     return f"Create or clone repository '{repo.name}' into '{root}'."
 
 

--- a/cli/python/base_projects/workspace_report_json.py
+++ b/cli/python/base_projects/workspace_report_json.py
@@ -12,6 +12,7 @@ from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_onboarding import WorkspaceOnboardingRepository
 from base_projects.workspace_onboarding import WorkspaceOnboardingSummary
 from base_projects.workspace_report_common import most_severe_status
+from base_projects.workspace_repository_url import redact_repository_url
 from base_setup.checks import ArtifactCheck
 from base_setup.checks import DIAGNOSTIC_JSON_SCHEMA_VERSION
 from base_setup.checks import check_to_json
@@ -121,7 +122,7 @@ def workspace_agent_brief_item_to_json(repository: WorkspaceAgentBriefRepository
         "next_actions": list(repository.next_actions),
     }
     if repository.url is not None:
-        payload["url"] = repository.url
+        payload["url"] = redact_repository_url(repository.url)
     if repository.default_branch is not None:
         payload["default_branch"] = repository.default_branch
     return payload
@@ -160,7 +161,7 @@ def workspace_onboarding_item_to_json(repository: WorkspaceOnboardingRepository)
         "clone_command": repository.clone_command,
     }
     if repository.url is not None:
-        payload["url"] = repository.url
+        payload["url"] = redact_repository_url(repository.url)
     if repository.default_branch is not None:
         payload["default_branch"] = repository.default_branch
     return payload
@@ -207,7 +208,7 @@ def workspace_manifest_item_metadata(item: Any) -> dict[str, Any]:
         "repo": item.repo,
     }
     if item.url is not None:
-        metadata["url"] = item.url
+        metadata["url"] = redact_repository_url(item.url)
     if item.default_branch is not None:
         metadata["default_branch"] = item.default_branch
     return metadata

--- a/cli/python/base_projects/workspace_repository_url.py
+++ b/cli/python/base_projects/workspace_repository_url.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import SplitResult
+from urllib.parse import unquote_plus
+from urllib.parse import urlsplit
+from urllib.parse import urlunsplit
+
+from base_cli.redaction import REDACTED
+from base_cli.redaction import is_secret_key
+
+
+SCP_REPOSITORY_URL_RE = re.compile(r"^(?P<userinfo>[^@\s]+)@(?P<location>[^:\s]+:.+)$")
+URL_PARAMETER_SEPARATOR_RE = re.compile(r"([&;])")
+NETWORK_REPOSITORY_URL_SCHEMES = frozenset(("git", "https", "ssh"))
+
+
+def redact_repository_url(value: str) -> str:
+    if Path(value).is_absolute():
+        return value
+
+    if any(character.isspace() or ord(character) < 32 or ord(character) == 127 for character in value):
+        return REDACTED
+
+    scp_match = None if "://" in value else SCP_REPOSITORY_URL_RE.match(value)
+    if scp_match is not None:
+        userinfo = scp_match.group("userinfo")
+        sanitized_userinfo = userinfo if userinfo == "git" else REDACTED
+        sanitized = f"{sanitized_userinfo}@{scp_match.group('location')}"
+        return redact_url_suffix_parameters(sanitized)
+
+    parsed = parse_repository_url(value)
+    if parsed is None:
+        return REDACTED
+
+    netloc = parsed.netloc
+    userinfo, separator, host = netloc.rpartition("@")
+    if separator and userinfo != "git":
+        netloc = f"{REDACTED}@{host}"
+    return urlunsplit(
+        (
+            parsed.scheme,
+            netloc,
+            parsed.path,
+            redact_url_parameters(parsed.query),
+            redact_url_parameters(parsed.fragment),
+        )
+    )
+
+
+def repository_url_problem(value: str) -> str | None:
+    if Path(value).is_absolute():
+        return None
+    if value.startswith("http://"):
+        return "insecure_http"
+
+    sanitized = redact_repository_url(value)
+    if sanitized == REDACTED:
+        return "invalid"
+    if sanitized != value:
+        return "sensitive"
+    return None
+
+
+def parse_repository_url(value: str) -> SplitResult | None:
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return None
+    if parsed.scheme in NETWORK_REPOSITORY_URL_SCHEMES:
+        return parsed if valid_network_repository_url(parsed) else None
+    if parsed.scheme == "file":
+        return parsed
+    return None
+
+
+def valid_network_repository_url(parsed: SplitResult) -> bool:
+    try:
+        hostname = parsed.hostname
+        _port = parsed.port
+    except ValueError:
+        return False
+    return bool(parsed.netloc and hostname)
+
+
+def redact_url_suffix_parameters(value: str) -> str:
+    base_and_query, fragment_separator, fragment = value.partition("#")
+    base, query_separator, query = base_and_query.partition("?")
+    sanitized = base
+    if query_separator:
+        sanitized = f"{sanitized}?{redact_url_parameters(query)}"
+    if fragment_separator:
+        sanitized = f"{sanitized}#{redact_url_parameters(fragment)}"
+    return sanitized
+
+
+def redact_url_parameters(value: str) -> str:
+    parts = URL_PARAMETER_SEPARATOR_RE.split(value)
+    for index in range(0, len(parts), 2):
+        key, separator, _parameter_value = parts[index].partition("=")
+        if separator and is_secret_key(unquote_plus(key)):
+            parts[index] = f"{key}={REDACTED}"
+    return "".join(parts)

--- a/cli/python/base_projects/workspace_statuses.py
+++ b/cli/python/base_projects/workspace_statuses.py
@@ -13,6 +13,7 @@ from base_projects.workspace_report_common import most_severe_status
 from base_projects.workspace_report_common import project_last_check
 from base_projects.workspace_report_common import project_venv_dir
 from base_projects.workspace_report_common import project_venv_ready
+from base_projects.workspace_repository_url import redact_repository_url
 from base_projects.workspace_scanner import ManifestEntry
 from base_projects.workspace_scanner import workspace_manifest_entries
 from base_setup.manifest import read_manifest
@@ -98,7 +99,7 @@ def workspace_expected_repo_status(
             required=repo.required,
             repo="present",
             repository=repo.name,
-            url=repo.url,
+            url=redact_repository_url(repo.url) if repo.url is not None else None,
             default_branch=repo.default_branch,
         )
 
@@ -115,7 +116,7 @@ def workspace_expected_repo_status(
         required=repo.required,
         repo="missing",
         repository=repo.name,
-        url=repo.url,
+        url=redact_repository_url(repo.url) if repo.url is not None else None,
         default_branch=repo.default_branch,
     )
 
@@ -130,7 +131,7 @@ def attach_status_repo_metadata(
         required=repo.required,
         repo="present",
         repository=repo.name,
-        url=repo.url,
+        url=redact_repository_url(repo.url) if repo.url is not None else None,
         default_branch=repo.default_branch,
     )
 

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -199,8 +199,10 @@ stable identifier used in reports.
 accepts HTTPS, SSH, Git protocol, SCP-style SSH, `file://`, and absolute local
 path repository sources so workspace reports can describe GitHub, GitLab,
 Bitbucket, internal Git, and local repositories. Cleartext `http://`
-repository URLs are rejected by default. Base does not parse credentials or
-manage authentication.
+repository URLs, embedded URL credentials, and secret-shaped query or fragment
+parameters are rejected before any report or clone plan is rendered. Keep
+credentials in Git credential helpers or SSH configuration; Base does not
+parse credentials or manage authentication.
 
 The current `basectl workspace clone` implementation only materializes GitHub
 repositories because it delegates to `basectl repo clone`. Non-GitHub URLs
@@ -548,9 +550,10 @@ version `1`, the important state meanings are:
   non-executed validation path, or `null` when unavailable.
 
 The readiness fraction counts expected required repositories only; optional and
-extra local repositories do not change the denominator. Credentials embedded
-in manifest repository URL userinfo and secret-shaped query or fragment
-parameters are redacted from JSON and suggested clone actions. Ordinary
+extra local repositories do not change the denominator. Manifest repository
+URLs with embedded credentials or secret-shaped query or fragment parameters
+are rejected without echoing the secret. Every report and suggested clone
+action also applies the shared repository URL sanitizer defensively. Ordinary
 `git@host:path` SSH URLs remain intact. When only a manifest-declared test
 command supplies validation, the brief recommends `basectl test`; it does not
 expose or execute the raw command.


### PR DESCRIPTION
## Summary
- Reject workspace manifest URLs containing userinfo credentials or secret query and fragment parameters without echoing their values.
- Move repository URL sanitization into one shared boundary and apply it defensively to status, checks, doctor details, onboarding, agent briefs, clone actions, JSON, and errors.
- Preserve ordinary HTTPS, SSH, Git protocol, file, and absolute local repository URLs and document the credential-helper/SSH contract.

## Issue
Fixes #2004

## Validation
- 52 focused Python tests plus 38 subtests across every repository URL consumer.
- 15 focused workspace BATS tests.
- 1,016 Python tests and 892 BATS tests through the complete Base harness.
- Pylint and diff checks.

## Security Notes
Unsafe manifest URLs fail before any report, diagnostic, history-bearing command, or clone plan is built. Errors name the policy and recovery path but never interpolate the rejected URL. Output boundaries still sanitize internal values to contain future or direct-call bypasses.