### PR TITLE
Prove release commit provenance before publishing

### DIFF
--- a/cli/python/base_release/engine.py
+++ b/cli/python/base_release/engine.py
@@ -17,8 +17,11 @@ from .release_parser import parse_release_args
 from .release_parser import print_usage
 from .release_parser import selected_release_check_format
 from .release_publish import release_publish_recovery_guidance, require_interactive_publish_confirmation
-from .release_publish import run_release_step, write_temp_release_notes
+from .release_publish import run_release_step, verify_github_release
+from .release_publish import verify_local_annotated_tag, verify_remote_annotated_tag
+from .release_publish import write_temp_release_notes
 from .release_readiness import extract_changelog_section, gh_cli_finding, github_release_finding
+from .release_readiness import require_release_provenance
 
 app = base_cli_app(name="base_release")
 
@@ -203,8 +206,10 @@ def release_publish_command(ctx: ReleaseContext, args: ReleaseArguments) -> int:
     notes = extract_changelog_section(ctx.changelog, ctx.version)
 
     if args.dry_run:
+        expected_sha = require_release_provenance(ctx)
         print(f"DRY RUN: release publish for {ctx.manifest.project_name} v{ctx.version}")
         print("")
+        print(f"Verified reviewed release commit: {expected_sha}")
         print(f"Would create annotated tag: {ctx.tag_name}")
         print(f"Would push tag to origin: {ctx.tag_name}")
         print(f"Would create GitHub Release: {title}")
@@ -218,17 +223,25 @@ def release_publish_command(ctx: ReleaseContext, args: ReleaseArguments) -> int:
         require_interactive_publish_confirmation(ctx, title)
 
     project_root = ctx.manifest_path.parent
-    run_release_step(["git", "tag", "-a", ctx.tag_name, "-m", f"Release {ctx.tag_name}"], cwd=project_root)
+    expected_sha = require_release_provenance(ctx)
+    run_release_step(
+        ["git", "tag", "-a", ctx.tag_name, expected_sha, "-m", f"Release {ctx.tag_name}"],
+        cwd=project_root,
+    )
+    verify_local_annotated_tag(project_root, ctx.tag_name, expected_sha)
     run_release_step(["git", "push", "origin", ctx.tag_name], cwd=project_root)
 
-    notes_path = write_temp_release_notes(notes)
+    notes_path = None
     try:
+        verify_remote_annotated_tag(project_root, ctx.tag_name, expected_sha)
+        notes_path = write_temp_release_notes(notes)
         run_release_step(
             [
                 "gh",
                 "release",
                 "create",
                 ctx.tag_name,
+                "--verify-tag",
                 "--repo",
                 ctx.release.github.repository,
                 "--title",
@@ -238,16 +251,19 @@ def release_publish_command(ctx: ReleaseContext, args: ReleaseArguments) -> int:
             ],
             cwd=project_root,
         )
+        verify_github_release(ctx, expected_sha)
     except ReleaseError as exc:
         raise ReleaseError(
             str(exc),
             guidance=release_publish_recovery_guidance(ctx, title),
         ) from exc
     finally:
-        notes_path.unlink(missing_ok=True)
+        if notes_path is not None:
+            notes_path.unlink(missing_ok=True)
 
     print(f"GitHub Release published: {github_release_url(ctx.release.github.repository, ctx.tag_name)}")
     print(f"Tag URL: {github_tag_url(ctx.release.github.repository, ctx.tag_name)}")
+    print(f"Release commit verified: {expected_sha}")
     print("")
     print_homebrew_handoff(ctx, after_publish=True)
     return base_cli.ExitCode.SUCCESS

--- a/cli/python/base_release/release_publish.py
+++ b/cli/python/base_release/release_publish.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from urllib.parse import quote
 
 import base_cli
 from base_setup import process
@@ -13,6 +14,7 @@ from .release_model import ReleaseContext, ReleaseError
 from .release_readiness import last_non_empty_line
 
 RELEASE_STEP_TIMEOUT_SECONDS = 120
+FULL_GIT_SHA_LENGTHS = frozenset((40, 64))
 
 
 def release_publish_recovery_guidance(ctx: ReleaseContext, title: str) -> str:
@@ -23,15 +25,15 @@ def release_publish_recovery_guidance(ctx: ReleaseContext, title: str) -> str:
         f"--manifest {shlex.quote(str(ctx.manifest_path))}"
     )
     create_release_command = (
-        f"gh release create {shlex.quote(ctx.tag_name)} "
+        f"gh release create {shlex.quote(ctx.tag_name)} --verify-tag "
         f"--repo {shlex.quote(ctx.release.github.repository)} "
         f"--title {shlex.quote(title)} "
         f"--notes-file {shlex.quote(notes_file)}"
     )
     return (
         f"Release publish already created and pushed tag {ctx.tag_name}, "
-        "but GitHub Release creation failed.\n"
-        "To complete the release after fixing GitHub access, create the GitHub Release from the pushed tag:\n"
+        "but GitHub Release creation or verification did not complete cleanly.\n"
+        "After confirming the pushed annotated tag resolves to the intended commit, complete the GitHub Release:\n"
         f"  {notes_command} > {shlex.quote(notes_file)}\n"
         f"  {create_release_command}\n"
         "To abandon this release attempt, remove the local and remote tag after confirming no one else is using it:\n"
@@ -52,6 +54,10 @@ def require_interactive_publish_confirmation(ctx: ReleaseContext, title: str) ->
 
 
 def run_release_step(command: list[str], *, cwd: Path | None = None) -> None:
+    capture_release_step(command, cwd=cwd)
+
+
+def capture_release_step(command: list[str], *, cwd: Path | None = None) -> str:
     joined = shlex.join(command)
     try:
         result = process.run_capture(
@@ -69,6 +75,119 @@ def run_release_step(command: list[str], *, cwd: Path | None = None) -> None:
         if detail:
             raise ReleaseError(f"Release command failed: {joined}: {detail}")
         raise ReleaseError(f"Release command failed: {joined}")
+    return result.stdout.strip()
+
+
+def verify_local_annotated_tag(root: Path, tag_name: str, expected_sha: str) -> None:
+    object_type = capture_release_step(["git", "cat-file", "-t", f"refs/tags/{tag_name}"], cwd=root)
+    if object_type != "tag":
+        raise ReleaseError(f"Local release tag {tag_name} is not an annotated tag.")
+    peeled_sha = capture_release_step(["git", "rev-parse", f"refs/tags/{tag_name}^{{}}"], cwd=root).lower()
+    if peeled_sha != expected_sha:
+        raise ReleaseError(
+            f"Local annotated tag {tag_name} resolves to {peeled_sha or 'no commit'}, expected {expected_sha}."
+        )
+
+
+def verify_remote_annotated_tag(root: Path, tag_name: str, expected_sha: str) -> None:
+    output = capture_release_step(
+        [
+            "git",
+            "ls-remote",
+            "--tags",
+            "origin",
+            f"refs/tags/{tag_name}",
+            f"refs/tags/{tag_name}^{{}}",
+        ],
+        cwd=root,
+    )
+    tag_object_sha: str | None = None
+    peeled_sha: str | None = None
+    for line in output.splitlines():
+        value, separator, ref_name = line.partition("\t")
+        normalized = value.lower()
+        if not separator or not valid_full_git_sha(normalized):
+            continue
+        if ref_name == f"refs/tags/{tag_name}":
+            tag_object_sha = normalized
+        elif ref_name == f"refs/tags/{tag_name}^{{}}":
+            peeled_sha = normalized
+    if tag_object_sha is None or peeled_sha is None:
+        raise ReleaseError(f"Remote tag {tag_name} is missing or is not an annotated tag on origin.")
+    if peeled_sha != expected_sha:
+        raise ReleaseError(
+            f"Remote annotated tag {tag_name} resolves to {peeled_sha}, expected release commit {expected_sha}."
+        )
+
+
+def verify_github_release(ctx: ReleaseContext, expected_sha: str) -> None:
+    release_tag = capture_release_step(
+        [
+            "gh",
+            "release",
+            "view",
+            ctx.tag_name,
+            "--repo",
+            ctx.release.github.repository,
+            "--json",
+            "tagName",
+            "--jq",
+            ".tagName",
+        ],
+        cwd=ctx.manifest_path.parent,
+    )
+    if release_tag != ctx.tag_name:
+        raise ReleaseError(
+            f"GitHub Release resolved tag '{release_tag or 'none'}', expected '{ctx.tag_name}'."
+        )
+
+    encoded_tag = quote(ctx.tag_name, safe="")
+    ref_type, tag_object_sha = parse_github_object(
+        capture_release_step(
+            [
+                "gh",
+                "api",
+                f"repos/{ctx.release.github.repository}/git/ref/tags/{encoded_tag}",
+                "--jq",
+                '.object.type + "\\t" + .object.sha',
+            ],
+            cwd=ctx.manifest_path.parent,
+        ),
+        description=f"GitHub tag ref {ctx.tag_name}",
+    )
+    if ref_type != "tag":
+        raise ReleaseError(f"GitHub tag {ctx.tag_name} is not annotated.")
+
+    tag_target_type, github_sha = parse_github_object(
+        capture_release_step(
+            [
+                "gh",
+                "api",
+                f"repos/{ctx.release.github.repository}/git/tags/{tag_object_sha}",
+                "--jq",
+                '.object.type + "\\t" + .object.sha',
+            ],
+            cwd=ctx.manifest_path.parent,
+        ),
+        description=f"GitHub annotated tag {ctx.tag_name}",
+    )
+    if tag_target_type != "commit" or github_sha != expected_sha:
+        raise ReleaseError(
+            f"GitHub annotated tag {ctx.tag_name} resolves to {tag_target_type} {github_sha}, "
+            f"expected commit {expected_sha}."
+        )
+
+
+def parse_github_object(output: str, *, description: str) -> tuple[str, str]:
+    object_type, separator, object_sha = output.strip().partition("\t")
+    normalized_sha = object_sha.lower()
+    if not separator or object_type not in {"commit", "tag"} or not valid_full_git_sha(normalized_sha):
+        raise ReleaseError(f"{description} did not resolve to an unambiguous full Git object.")
+    return object_type, normalized_sha
+
+
+def valid_full_git_sha(value: str) -> bool:
+    return len(value) in FULL_GIT_SHA_LENGTHS and all(character in "0123456789abcdef" for character in value)
 
 
 def write_temp_release_notes(notes: str) -> Path:

--- a/cli/python/base_release/release_readiness.py
+++ b/cli/python/base_release/release_readiness.py
@@ -3,13 +3,23 @@ from __future__ import annotations
 import re
 import shutil
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
+
+from base_setup.git_remote_parse import parse_origin_remote
 
 from .release_model import ReleaseContext, ReleaseError, ReleaseFinding
 
 CHANGELOG_HEADER_RE = re.compile(r"^##\s+(?:\[(?P<bracket>[^\]]+)\]|(?P<plain>\S+))(?:\s+-.*)?$")
 GIT_INSPECTION_TIMEOUT_SECONDS = 10
+FULL_GIT_SHA_RE = re.compile(r"^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$")
+
+
+@dataclass(frozen=True)
+class ReleaseProvenanceInspection:
+    findings: tuple[ReleaseFinding, ...]
+    commit_sha: str | None = None
 
 
 def release_findings(
@@ -23,12 +33,233 @@ def release_findings(
         version_file_finding(ctx),
         changelog_finding(ctx),
         git_worktree_finding(ctx.manifest_path.parent),
-        git_branch_finding(ctx.manifest_path.parent),
+        *inspect_release_provenance(ctx).findings,
         gh_check(),
         local_tag_finding(ctx.manifest_path.parent, ctx.tag_name),
         remote_tag_finding(ctx.manifest_path.parent, ctx.tag_name),
     ]
     return tuple(findings)
+
+
+def inspect_release_provenance(ctx: ReleaseContext) -> ReleaseProvenanceInspection:
+    root = ctx.manifest_path.parent
+    origin_finding = origin_repository_finding(root, ctx.release.github.repository)
+    if origin_finding.status != "ok":
+        return ReleaseProvenanceInspection(
+            findings=(
+                origin_finding,
+                ReleaseFinding(
+                    "error",
+                    "default_branch",
+                    "Unable to verify the remote default branch until origin matches the configured repository.",
+                ),
+                ReleaseFinding(
+                    "error",
+                    "release_commit",
+                    "Unable to verify the release commit until origin matches the configured repository.",
+                ),
+            )
+        )
+
+    remote_default, remote_error = remote_default_branch(root)
+    current_branch = current_git_branch(root)
+    local_head = current_git_head(root)
+    if remote_default is None:
+        detail = remote_error or "the remote did not advertise a symbolic default branch and full commit SHA"
+        return ReleaseProvenanceInspection(
+            findings=(
+                origin_finding,
+                ReleaseFinding(
+                    "error",
+                    "default_branch",
+                    f"Unable to resolve origin's current default branch: {detail}. "
+                    "Confirm origin is reachable and its default branch is configured, then retry.",
+                ),
+                ReleaseFinding(
+                    "error",
+                    "release_commit",
+                    "Unable to compare local HEAD with the current remote default-branch commit.",
+                ),
+            )
+        )
+
+    default_branch, remote_head = remote_default
+    branch_finding = release_default_branch_finding(current_branch, default_branch)
+    commit_finding = release_commit_finding(local_head, default_branch, remote_head)
+    commit_sha = remote_head if branch_finding.status == "ok" and commit_finding.status == "ok" else None
+    return ReleaseProvenanceInspection(
+        findings=(origin_finding, branch_finding, commit_finding),
+        commit_sha=commit_sha,
+    )
+
+
+def require_release_provenance(ctx: ReleaseContext) -> str:
+    inspection = inspect_release_provenance(ctx)
+    if inspection.commit_sha is not None and all(finding.status == "ok" for finding in inspection.findings):
+        return inspection.commit_sha
+    detail = "; ".join(finding.message for finding in inspection.findings if finding.status != "ok")
+    raise ReleaseError(f"Release provenance changed or could not be verified before tagging: {detail}")
+
+
+def origin_repository_finding(root: Path, configured_repository: str) -> ReleaseFinding:
+    fetch_urls = git_remote_urls(root, push=False)
+    push_urls = git_remote_urls(root, push=True)
+    if fetch_urls is None or push_urls is None or not fetch_urls or not push_urls:
+        return ReleaseFinding(
+            "error",
+            "origin_repository",
+            "Unable to resolve every origin fetch and push URL. Configure origin for the release repository and retry.",
+        )
+
+    configured = configured_repository.casefold()
+    for remote_url in (*fetch_urls, *push_urls):
+        remote = parse_origin_remote(remote_url, root)
+        if not remote.valid or remote.provider != "github" or not remote.repository:
+            return ReleaseFinding(
+                "error",
+                "origin_repository",
+                f"Origin must use the configured GitHub repository '{configured_repository}' for fetch and push. "
+                "Update origin and retry.",
+            )
+        if remote.repository.casefold() != configured:
+            return ReleaseFinding(
+                "error",
+                "origin_repository",
+                f"Origin resolves to GitHub repository '{remote.repository}', but release.github.repository is "
+                f"'{configured_repository}'. Update origin or the manifest before publishing.",
+            )
+
+    return ReleaseFinding(
+        "ok",
+        "origin_repository",
+        f"Every origin fetch and push URL matches GitHub repository '{configured_repository}'.",
+    )
+
+
+def git_remote_urls(root: Path, *, push: bool) -> tuple[str, ...] | None:
+    command = ["git", "remote", "get-url", "--all"]
+    if push:
+        command.append("--push")
+    command.append("origin")
+    try:
+        result = subprocess.run(
+            command,
+            cwd=root,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=GIT_INSPECTION_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
+
+
+def remote_default_branch(root: Path) -> tuple[tuple[str, str] | None, str | None]:
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", "--symref", "origin", "HEAD"],
+            cwd=root,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=GIT_INSPECTION_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return None, "the remote inspection timed out"
+    except OSError:
+        return None, "Git could not inspect origin"
+    if result.returncode != 0:
+        return None, "Git could not read origin HEAD"
+    return parse_remote_default_branch(result.stdout)
+
+
+def parse_remote_default_branch(output: str) -> tuple[tuple[str, str] | None, str | None]:
+    branch: str | None = None
+    commit_sha: str | None = None
+    for line in output.splitlines():
+        if line.startswith("ref: refs/heads/") and line.endswith("\tHEAD"):
+            branch = line.removeprefix("ref: refs/heads/").removesuffix("\tHEAD")
+            continue
+        value, separator, ref_name = line.partition("\t")
+        if separator and ref_name == "HEAD" and FULL_GIT_SHA_RE.fullmatch(value):
+            commit_sha = value.lower()
+    if not branch:
+        return None, "origin did not advertise HEAD as a branch"
+    if not commit_sha:
+        return None, "origin did not advertise HEAD as a full commit SHA"
+    return (branch, commit_sha), None
+
+
+def current_git_head(root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", "HEAD"],
+            cwd=root,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=GIT_INSPECTION_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    value = result.stdout.strip().lower()
+    if result.returncode != 0 or not FULL_GIT_SHA_RE.fullmatch(value):
+        return None
+    return value
+
+
+def release_default_branch_finding(current_branch: str | None, default_branch: str) -> ReleaseFinding:
+    if current_branch is None:
+        return ReleaseFinding(
+            "error",
+            "default_branch",
+            "Unable to inspect the current Git branch. Check out the remote default branch and retry.",
+        )
+    if not current_branch:
+        return ReleaseFinding(
+            "error",
+            "default_branch",
+            f"Git HEAD is detached. Check out origin's default branch '{default_branch}' and retry.",
+        )
+    if current_branch != default_branch:
+        return ReleaseFinding(
+            "error",
+            "default_branch",
+            f"Current branch '{current_branch}' is not origin's default branch '{default_branch}'. "
+            f"Merge the reviewed release PR, check out '{default_branch}', synchronize it, and retry.",
+        )
+    return ReleaseFinding(
+        "ok",
+        "default_branch",
+        f"Current branch '{current_branch}' matches origin's default branch.",
+    )
+
+
+def release_commit_finding(local_head: str | None, default_branch: str, remote_head: str) -> ReleaseFinding:
+    if local_head is None:
+        return ReleaseFinding(
+            "error",
+            "release_commit",
+            "Unable to resolve local HEAD to a full commit SHA. Repair the checkout and retry.",
+        )
+    if local_head != remote_head:
+        return ReleaseFinding(
+            "error",
+            "release_commit",
+            f"Local HEAD {local_head} does not match current origin/{default_branch} {remote_head}. "
+            "Fetch origin, reconcile any behind, ahead, or diverged commits, and retry from the synchronized branch.",
+        )
+    return ReleaseFinding(
+        "ok",
+        "release_commit",
+        f"Local HEAD and origin/{default_branch} resolve to reviewed commit {local_head}.",
+    )
 
 
 def version_file_finding(ctx: ReleaseContext) -> ReleaseFinding:

--- a/cli/python/base_release/tests/test_engine.py
+++ b/cli/python/base_release/tests/test_engine.py
@@ -31,6 +31,12 @@ READY_FINDINGS = (
     ReleaseFinding("ok", "local_tag", "Local tag is available."),
     ReleaseFinding("ok", "remote_tag", "Remote tag is available."),
 )
+READY_SHA = "a" * 40
+READY_PROVENANCE_FINDINGS = (
+    ReleaseFinding("ok", "origin_repository", "Origin repository matches."),
+    ReleaseFinding("ok", "default_branch", "Current branch is main."),
+    ReleaseFinding("ok", "release_commit", f"Release commit is {READY_SHA}."),
+)
 
 
 @contextmanager
@@ -368,11 +374,16 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
             root = Path(tmpdir)
             manifest_path = self.manifest_factory.write_release(root)
 
-            with mock.patch("base_release.engine.release_findings", return_value=READY_FINDINGS), mock.patch(
-                "base_release.engine.github_release_finding",
-                return_value=ReleaseFinding("ok", "github_release", "GitHub Release is available."),
-                create=True,
-            ), mock.patch("base_release.engine.run_release_step", create=True) as run_step:
+            with (
+                mock.patch("base_release.engine.release_findings", return_value=READY_FINDINGS),
+                mock.patch(
+                    "base_release.engine.github_release_finding",
+                    return_value=ReleaseFinding("ok", "github_release", "GitHub Release is available."),
+                    create=True,
+                ),
+                mock.patch("base_release.engine.require_release_provenance", return_value=READY_SHA),
+                mock.patch("base_release.engine.run_release_step", create=True) as run_step,
+            ):
                 status, stdout, stderr = run_engine(
                     ["publish", "--dry-run", "--version", "1.2.3", "--manifest", str(manifest_path)],
                     root,
@@ -380,6 +391,7 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
         self.assertEqual(status, 0, stderr)
         self.assertIn("DRY RUN", stdout)
+        self.assertIn(f"Verified reviewed release commit: {READY_SHA}", stdout)
         self.assertIn("Would create annotated tag: v1.2.3", stdout)
         self.assertIn("Would push tag to origin: v1.2.3", stdout)
         self.assertIn("Would create GitHub Release: Demo v1.2.3", stdout)
@@ -418,14 +430,22 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
                     self.assertIn("Added the release assistant.", notes_path.read_text(encoding="utf-8"))
                 commands.append((command, cwd))
 
-            with mock.patch("base_release.engine.release_findings", return_value=READY_FINDINGS), mock.patch(
-                "base_release.engine.github_release_finding",
-                return_value=ReleaseFinding("ok", "github_release", "GitHub Release is available."),
-                create=True,
-            ), mock.patch(
-                "base_release.engine.run_release_step",
-                side_effect=fake_run_release_step,
-                create=True,
+            with (
+                mock.patch("base_release.engine.release_findings", return_value=READY_FINDINGS),
+                mock.patch(
+                    "base_release.engine.github_release_finding",
+                    return_value=ReleaseFinding("ok", "github_release", "GitHub Release is available."),
+                    create=True,
+                ),
+                mock.patch("base_release.engine.require_release_provenance", return_value=READY_SHA),
+                mock.patch("base_release.engine.verify_local_annotated_tag") as verify_local,
+                mock.patch("base_release.engine.verify_remote_annotated_tag") as verify_remote,
+                mock.patch("base_release.engine.verify_github_release") as verify_github,
+                mock.patch(
+                    "base_release.engine.run_release_step",
+                    side_effect=fake_run_release_step,
+                    create=True,
+                ),
             ):
                 status, stdout, stderr = run_engine(
                     ["publish", "--yes", "--version", "1.2.3", "--manifest", str(manifest_path)],
@@ -433,14 +453,16 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
                 )
 
         self.assertEqual(status, 0, stderr)
-        self.assertEqual(commands[0][0], ["git", "tag", "-a", "v1.2.3", "-m", "Release v1.2.3"])
+        self.assertEqual(
+            commands[0][0],
+            ["git", "tag", "-a", "v1.2.3", READY_SHA, "-m", "Release v1.2.3"],
+        )
         self.assertEqual(commands[0][1], root.resolve())
         self.assertEqual(commands[1][0], ["git", "push", "origin", "v1.2.3"])
         self.assertEqual(commands[1][1], root.resolve())
-        self.assertEqual(
-            commands[2][0][:7],
-            ["gh", "release", "create", "v1.2.3", "--repo", "codeforester/demo", "--title"],
-        )
+        self.assertEqual(commands[2][0][:8], [
+            "gh", "release", "create", "v1.2.3", "--verify-tag", "--repo", "codeforester/demo", "--title"
+        ])
         self.assertEqual(
             commands[2][1],
             root.resolve(),
@@ -448,6 +470,10 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertIn("GitHub Release published: https://github.com/codeforester/demo/releases/tag/v1.2.3", stdout)
         self.assertIn("Tag URL: https://github.com/codeforester/demo/tree/v1.2.3", stdout)
         self.assertIn("Homebrew handoff required after GitHub release", stdout)
+        self.assertIn(f"Release commit verified: {READY_SHA}", stdout)
+        verify_local.assert_called_once_with(root.resolve(), "v1.2.3", READY_SHA)
+        verify_remote.assert_called_once_with(root.resolve(), "v1.2.3", READY_SHA)
+        verify_github.assert_called_once()
 
 
     def test_publish_yes_reports_recovery_when_github_release_create_fails_after_tag_push(self) -> None:
@@ -461,14 +487,21 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
                 if command[:3] == ["gh", "release", "create"]:
                     raise ReleaseError("Release command failed: gh release create v1.2.3: network unavailable")
 
-            with mock.patch("base_release.engine.release_findings", return_value=READY_FINDINGS), mock.patch(
-                "base_release.engine.github_release_finding",
-                return_value=ReleaseFinding("ok", "github_release", "GitHub Release is available."),
-                create=True,
-            ), mock.patch(
-                "base_release.engine.run_release_step",
-                side_effect=fake_run_release_step,
-                create=True,
+            with (
+                mock.patch("base_release.engine.release_findings", return_value=READY_FINDINGS),
+                mock.patch(
+                    "base_release.engine.github_release_finding",
+                    return_value=ReleaseFinding("ok", "github_release", "GitHub Release is available."),
+                    create=True,
+                ),
+                mock.patch("base_release.engine.require_release_provenance", return_value=READY_SHA),
+                mock.patch("base_release.engine.verify_local_annotated_tag"),
+                mock.patch("base_release.engine.verify_remote_annotated_tag"),
+                mock.patch(
+                    "base_release.engine.run_release_step",
+                    side_effect=fake_run_release_step,
+                    create=True,
+                ),
             ):
                 status, stdout, stderr = run_engine(
                     ["publish", "--yes", "--version", "1.2.3", "--manifest", str(manifest_path)],
@@ -477,7 +510,10 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
         self.assertEqual(status, 1)
         self.assertEqual(stdout, "")
-        self.assertEqual(commands[0][0], ["git", "tag", "-a", "v1.2.3", "-m", "Release v1.2.3"])
+        self.assertEqual(
+            commands[0][0],
+            ["git", "tag", "-a", "v1.2.3", READY_SHA, "-m", "Release v1.2.3"],
+        )
         self.assertEqual(commands[1][0], ["git", "push", "origin", "v1.2.3"])
         stderr_lines = stderr.splitlines()
         self.assertEqual(
@@ -487,7 +523,7 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertIn("Recovery guidance:", stderr_lines)
         self.assertIn("Release publish already created and pushed tag v1.2.3", stderr)
         self.assertIn("basectl release notes --version 1.2.3", stderr)
-        self.assertIn("gh release create v1.2.3 --repo codeforester/demo", stderr)
+        self.assertIn("gh release create v1.2.3 --verify-tag --repo codeforester/demo", stderr)
         self.assertIn("git push origin :refs/tags/v1.2.3", stderr)
 
 
@@ -509,6 +545,33 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertIn("Release publish blocked by readiness findings", stdout)
         self.assertIn("error  git", stdout)
         self.assertEqual(stderr, "")
+        run_step.assert_not_called()
+
+    def test_publish_rechecks_provenance_before_first_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = self.manifest_factory.write_release(root)
+
+            with (
+                mock.patch("base_release.engine.release_findings", return_value=READY_FINDINGS),
+                mock.patch(
+                    "base_release.engine.github_release_finding",
+                    return_value=ReleaseFinding("ok", "github_release", "GitHub Release is available."),
+                ),
+                mock.patch(
+                    "base_release.engine.require_release_provenance",
+                    side_effect=ReleaseError("Local HEAD changed after readiness."),
+                ),
+                mock.patch("base_release.engine.run_release_step") as run_step,
+            ):
+                status, stdout, stderr = run_engine(
+                    ["publish", "--yes", "--version", "1.2.3", "--manifest", str(manifest_path)],
+                    root,
+                )
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stdout, "")
+        self.assertIn("Local HEAD changed after readiness", stderr)
         run_step.assert_not_called()
 
 
@@ -578,9 +641,18 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
             manifest_path = self.manifest_factory.write_release(root)
             add_origin(root)
 
-            with mock.patch(
-                "base_release.engine.gh_cli_finding",
-                return_value=ReleaseFinding("ok", "gh", "GitHub CLI is authenticated for github.com."),
+            with (
+                mock.patch(
+                    "base_release.engine.gh_cli_finding",
+                    return_value=ReleaseFinding("ok", "gh", "GitHub CLI is authenticated for github.com."),
+                ),
+                mock.patch(
+                    "base_release.release_readiness.inspect_release_provenance",
+                    return_value=release_readiness.ReleaseProvenanceInspection(
+                        findings=READY_PROVENANCE_FINDINGS,
+                        commit_sha=READY_SHA,
+                    ),
+                ),
             ):
                 status, stdout, stderr = run_engine(
                     ["check", "--version", "1.2.3", "--manifest", str(manifest_path)],
@@ -660,6 +732,172 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
 
 
 class ReleaseHelperTests(unittest.TestCase):
+    def test_origin_repository_requires_matching_fetch_and_push_identities(self) -> None:
+        matching = (
+            ("https://github.com/codeforester/demo.git",),
+            ("git@github.com:codeforester/demo.git",),
+        )
+        with mock.patch("base_release.release_readiness.git_remote_urls", side_effect=matching):
+            finding = release_readiness.origin_repository_finding(Path("/repo"), "codeforester/demo")
+
+        self.assertEqual(finding.status, "ok")
+
+        mismatched_push = (
+            ("https://github.com/codeforester/demo.git",),
+            ("git@github.com:other/wrong.git",),
+        )
+        with mock.patch("base_release.release_readiness.git_remote_urls", side_effect=mismatched_push):
+            finding = release_readiness.origin_repository_finding(Path("/repo"), "codeforester/demo")
+
+        self.assertEqual(finding.status, "error")
+        self.assertIn("other/wrong", finding.message)
+        self.assertIn("codeforester/demo", finding.message)
+
+    def test_remote_default_branch_uses_live_origin_head_not_tracking_refs(self) -> None:
+        output = f"ref: refs/heads/main\tHEAD\n{READY_SHA}\tHEAD\n"
+        completed = subprocess.CompletedProcess(["git", "ls-remote"], 0, stdout=output)
+        with mock.patch("base_release.release_readiness.subprocess.run", return_value=completed) as run_git:
+            remote, error = release_readiness.remote_default_branch(Path("/repo"))
+
+        self.assertEqual((remote, error), (("main", READY_SHA), None))
+        self.assertEqual(run_git.call_args.args[0], ["git", "ls-remote", "--symref", "origin", "HEAD"])
+
+    def test_remote_default_branch_rejects_ambiguous_or_incomplete_responses(self) -> None:
+        cases = (
+            (f"{READY_SHA}\tHEAD\n", "did not advertise HEAD as a branch"),
+            ("ref: refs/heads/main\tHEAD\ndeadbeef\tHEAD\n", "full commit SHA"),
+            ("", "did not advertise HEAD as a branch"),
+        )
+        for output, expected_error in cases:
+            with self.subTest(output=output):
+                remote, error = release_readiness.parse_remote_default_branch(output)
+                self.assertIsNone(remote)
+                self.assertIn(expected_error, error or "")
+
+    def test_feature_detached_and_unsynchronized_release_commits_fail_closed(self) -> None:
+        branch_cases = (
+            ("feature/release", "not origin's default branch"),
+            ("", "detached"),
+            (None, "Unable to inspect"),
+        )
+        for branch, expected in branch_cases:
+            with self.subTest(branch=branch):
+                finding = release_readiness.release_default_branch_finding(branch, "main")
+                self.assertEqual(finding.status, "error")
+                self.assertIn(expected, finding.message)
+
+        for local_head in ("b" * 40, "c" * 40):
+            with self.subTest(local_head=local_head):
+                finding = release_readiness.release_commit_finding(local_head, "main", READY_SHA)
+                self.assertEqual(finding.status, "error")
+                self.assertIn(f"Local HEAD {local_head}", finding.message)
+                self.assertIn(f"origin/main {READY_SHA}", finding.message)
+                self.assertIn("behind, ahead, or diverged", finding.message)
+
+    def test_provenance_recheck_returns_only_an_exact_ready_commit(self) -> None:
+        ctx = mock.Mock()
+        ctx.manifest_path = Path("/repo/base_manifest.yaml")
+        ctx.release.github.repository = "codeforester/demo"
+        with (
+            mock.patch(
+                "base_release.release_readiness.origin_repository_finding",
+                return_value=READY_PROVENANCE_FINDINGS[0],
+            ),
+            mock.patch(
+                "base_release.release_readiness.remote_default_branch",
+                return_value=(("main", READY_SHA), None),
+            ),
+            mock.patch("base_release.release_readiness.current_git_branch", return_value="main"),
+            mock.patch("base_release.release_readiness.current_git_head", return_value=READY_SHA),
+        ):
+            inspection = release_readiness.inspect_release_provenance(ctx)
+            commit_sha = release_readiness.require_release_provenance(ctx)
+
+        self.assertEqual(inspection.commit_sha, READY_SHA)
+        self.assertEqual(commit_sha, READY_SHA)
+        self.assertTrue(all(finding.status == "ok" for finding in inspection.findings))
+
+    def test_local_and_remote_tag_verification_requires_annotated_expected_sha(self) -> None:
+        tag_object_sha = "b" * 40
+        remote_output = (
+            f"{tag_object_sha}\trefs/tags/v1.2.3\n"
+            f"{READY_SHA}\trefs/tags/v1.2.3^{{}}\n"
+        )
+        with mock.patch(
+            "base_release.release_publish.capture_release_step",
+            side_effect=("tag", READY_SHA, remote_output),
+        ):
+            release_publish.verify_local_annotated_tag(Path("/repo"), "v1.2.3", READY_SHA)
+            release_publish.verify_remote_annotated_tag(Path("/repo"), "v1.2.3", READY_SHA)
+
+        with mock.patch(
+            "base_release.release_publish.capture_release_step",
+            return_value=f"{tag_object_sha}\trefs/tags/v1.2.3\n",
+        ):
+            with self.assertRaisesRegex(ReleaseError, "missing or is not an annotated tag"):
+                release_publish.verify_remote_annotated_tag(Path("/repo"), "v1.2.3", READY_SHA)
+
+    def test_tag_verifiers_accept_a_real_annotated_tag_at_one_full_sha(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            checkout = root / "checkout"
+            remote = root / "remote.git"
+            subprocess.run(["git", "init", "-b", "main", str(checkout)], check=True, stdout=subprocess.DEVNULL)
+            subprocess.run(["git", "config", "user.name", "Base Test"], cwd=checkout, check=True)
+            subprocess.run(["git", "config", "user.email", "base@example.invalid"], cwd=checkout, check=True)
+            checkout.joinpath("README.md").write_text("release fixture\n", encoding="utf-8")
+            subprocess.run(["git", "add", "README.md"], cwd=checkout, check=True)
+            subprocess.run(["git", "commit", "-m", "Initial"], cwd=checkout, check=True, stdout=subprocess.DEVNULL)
+            expected_sha = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=checkout,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            subprocess.run(["git", "init", "--bare", str(remote)], check=True, stdout=subprocess.DEVNULL)
+            subprocess.run(["git", "remote", "add", "origin", str(remote)], cwd=checkout, check=True)
+            subprocess.run(
+                ["git", "tag", "-a", "v1.2.3", expected_sha, "-m", "Release v1.2.3"],
+                cwd=checkout,
+                check=True,
+            )
+            subprocess.run(["git", "push", "origin", "v1.2.3"], cwd=checkout, check=True, stdout=subprocess.DEVNULL)
+
+            release_publish.verify_local_annotated_tag(checkout, "v1.2.3", expected_sha)
+            release_publish.verify_remote_annotated_tag(checkout, "v1.2.3", expected_sha)
+
+    def test_github_release_verification_resolves_same_repository_tag_and_commit(self) -> None:
+        ctx = mock.Mock()
+        ctx.tag_name = "v1.2.3"
+        ctx.manifest_path = Path("/repo/base_manifest.yaml")
+        ctx.release.github.repository = "codeforester/demo"
+        tag_object_sha = "b" * 40
+        with mock.patch(
+            "base_release.release_publish.capture_release_step",
+            side_effect=(
+                "v1.2.3",
+                f"tag\t{tag_object_sha}",
+                f"commit\t{READY_SHA}",
+            ),
+        ) as capture:
+            release_publish.verify_github_release(ctx, READY_SHA)
+
+        commands = [call.args[0] for call in capture.call_args_list]
+        self.assertIn("repos/codeforester/demo/git/ref/tags/v1.2.3", commands[1])
+        self.assertIn(f"repos/codeforester/demo/git/tags/{tag_object_sha}", commands[2])
+
+        with mock.patch(
+            "base_release.release_publish.capture_release_step",
+            side_effect=(
+                "v1.2.3",
+                f"tag\t{tag_object_sha}",
+                f"commit\t{'c' * 40}",
+            ),
+        ):
+            with self.assertRaisesRegex(ReleaseError, "expected commit"):
+                release_publish.verify_github_release(ctx, READY_SHA)
+
     def test_run_release_step_uses_bounded_timeout(self) -> None:
         completed = subprocess.CompletedProcess(["git", "tag"], 0, stdout="")
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -178,7 +178,7 @@ daily project loop commands from the local checkout.
 | `basectl release check --version <version>` | Inspect release readiness without publishing. Supports all five report formats; JSON uses the shared v1 inspection envelope. | `--manifest <path>`, `--format <text\|csv\|tsv\|yaml\|json>` |
 | `basectl release plan --version <version>` | Print the release plan and downstream handoff details. | `--manifest <path>` |
 | `basectl release notes --version <version>` | Extract release notes for the requested version. | `--manifest <path>` |
-| `basectl release publish --version <version>` | Create the annotated Git tag and GitHub Release after checks pass. | `--manifest <path>`, `--dry-run`, `--yes` |
+| `basectl release publish --version <version>` | Create the annotated Git tag and GitHub Release only after the configured repository, origin fetch/push URLs, live remote default branch, and local full `HEAD` SHA match; recheck before tagging and verify the local, pushed, and GitHub tag SHAs. | `--manifest <path>`, `--dry-run`, `--yes` |
 | `basectl docs` | Open the Base documentation home page on GitHub. | `--show-url` |
 | `basectl export-context [project]` | Export a project's `.ai-context/` directory as Markdown or Zip. | `--workspace <path>`, `--format <markdown\|zip>`, `--output <path>`, `--print`, `--list-files` |
 | `basectl prompt list` | List repo-owned Markdown prompts that Base can render for AI-assisted workflows. | none |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -74,10 +74,14 @@ basectl release notes --version X.Y.Z
 ```
 
 Use `check` before publishing to validate the version file, changelog section,
-Git worktree cleanliness, current branch, GitHub CLI authentication, and local
-and remote tag availability. Use `plan` to print the GitHub release target and
-downstream handoff requirements. Use `notes` to print the changelog body
-intended for the GitHub Release.
+Git worktree cleanliness, GitHub CLI authentication, and local and remote tag
+availability. It also requires every `origin` fetch and push URL to identify
+`release.github.repository`, resolves the live remote default branch through
+`git ls-remote --symref`, and requires the checked-out branch and full local
+`HEAD` SHA to match that current remote commit exactly. A stale local
+`origin/<branch>` tracking ref is not accepted as release evidence. Use `plan`
+to print the GitHub release target and downstream handoff requirements. Use
+`notes` to print the changelog body intended for the GitHub Release.
 The JSON check uses the stable shared v1 envelope documented in
 [Inspection JSON](inspection-json.md); readiness blockers stay in `data.findings`
 with `error: null`.
@@ -91,9 +95,13 @@ basectl release publish --version X.Y.Z --yes
 ```
 
 `publish` reuses the release checks, refuses existing tags or GitHub Releases,
-creates an annotated tag, pushes the tag, and creates the GitHub Release from
-the changelog section. It does not update the Homebrew tap; it prints the tap
-handoff checklist when `release.homebrew` is declared.
+and rechecks the repository, branch, and full commit SHA immediately before its
+first mutation. It creates an annotated tag, verifies the local peeled SHA,
+pushes the tag, verifies the remote peeled SHA, and creates the GitHub Release
+with `--verify-tag` in the configured repository. The successful command then
+verifies GitHub's annotated tag object resolves to the same commit SHA. It does
+not update the Homebrew tap; it prints the tap handoff checklist when
+`release.homebrew` is declared.
 
 ## Base Release Checklist
 
@@ -119,7 +127,10 @@ Complete these steps in `basefoundry/base`:
    ```
 
 5. Merge the release-prep PR into `main`.
-6. Sync local `main`.
+6. Sync local `main` and confirm `HEAD` exactly matches the current live
+   `origin/main`. Do not publish from a feature branch, detached checkout,
+   ahead/behind/diverged branch, stale remote-tracking ref, or a checkout whose
+   `origin` does not match `release.github.repository`.
 7. Dry-run the guarded publish command:
 
    ```bash


### PR DESCRIPTION
## Summary
- Require every origin fetch and push URL to match the configured GitHub repository, then resolve the live remote default branch and full SHA without trusting stale tracking refs.
- Require the checked-out branch and local HEAD to match that live remote commit, and repeat the provenance check immediately before creating a tag at the verified SHA.
- Verify the local annotated tag, pushed peeled tag, GitHub Release tag, and GitHub annotated-tag object all resolve to the same commit; create releases with --verify-tag.

## Issue
Fixes #2005

## Validation
- 42 focused release tests plus 8 subtests, including a real temporary annotated tag and bare remote.
- Public release check against this issue branch confirmed origin and live remote SHA, then blocked the non-default branch.
- 5 focused release BATS tests.
- 1,025 Python tests and 892 BATS tests through the complete Base harness.
- Pylint, docs/contract tests, and diff checks.

## Security Notes
Readiness failures happen before release mutations and identify the mismatched repository, branch, or full SHA with recovery guidance. The tag command names the verified commit explicitly, and post-push verification fails closed on lightweight, missing, ambiguous, or mismatched tag objects.