### PR TITLE
Fail repo init closed on invalid targets

### DIFF
--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -116,6 +116,7 @@ push and pull request. Unless --no-configure is set, repo init also applies the
 GitHub-side settings handled by repo configure.
 
 For the current checkout, pass its repository name and --path .
+Invalid configured workspace or GitHub defaults fail before any repository action.
 Plain repo init writes local baseline files but does not commit or push them.
 With --pr, repo init requires --issue, commits baseline changes on the canonical
 issue branch, pushes that branch to origin, and opens a pull request.
@@ -366,18 +367,58 @@ base_repo_target_path() {
 
 base_repo_strip_config_value() {
     local value="$1"
+    local quote character previous remainder
+    local result=""
+    local index length escaped=0 closed=0
 
-    value="${value%%#*}"
     base_str_trim value
 
-    case "$value" in
-        \"*\")
-            value="${value#\"}"
-            value="${value%\"}"
+    quote="${value:0:1}"
+    case "$quote" in
+        \"|\')
+            length="${#value}"
+            for ((index = 1; index < length; index++)); do
+                character="${value:index:1}"
+                if [[ "$quote" == \" && "$character" == \\ && "$escaped" == "0" ]]; then
+                    result+="$character"
+                    escaped=1
+                    continue
+                fi
+                if ((escaped)); then
+                    result+="$character"
+                    escaped=0
+                    continue
+                fi
+                if [[ "$quote" == \' && "$character" == \' && "${value:index+1:1}" == \' ]]; then
+                    result+="$character"
+                    ((index++))
+                    continue
+                fi
+                if [[ "$character" == "$quote" ]]; then
+                    closed=1
+                    remainder="${value:index+1}"
+                    break
+                fi
+                result+="$character"
+            done
+            ((closed)) || return 2
+            base_str_trim remainder
+            [[ -z "$remainder" || "$remainder" == \#* ]] || return 2
+            value="$result"
             ;;
-        \'*\')
-            value="${value#\'}"
-            value="${value%\'}"
+        *)
+            length="${#value}"
+            for ((index = 0; index < length; index++)); do
+                character="${value:index:1}"
+                previous=""
+                ((index > 0)) && previous="${value:index-1:1}"
+                if [[ "$character" == "#" && ( -z "$previous" || "$previous" =~ [[:space:]] ) ]]; then
+                    break
+                fi
+                result+="$character"
+            done
+            base_str_trim result
+            value="$result"
             ;;
     esac
 
@@ -419,7 +460,10 @@ base_repo_configured_workspace_root() {
         fi
 
         if ((in_workspace)) && [[ "$line" =~ ^[[:space:]]+root:[[:space:]]*(.*)$ ]]; then
-            value="$(base_repo_strip_config_value "${BASH_REMATCH[1]}")"
+            value="$(base_repo_strip_config_value "${BASH_REMATCH[1]}")" || {
+                base_std_log_error "$config_path: workspace.root has invalid quoted YAML syntax."
+                return 2
+            }
             [[ -n "$value" ]] || {
                 base_std_log_error "$config_path: workspace.root must be a non-empty path."
                 return 2
@@ -458,7 +502,10 @@ base_repo_configured_github_value() {
         fi
 
         if ((in_github)) && [[ "$line" =~ ^[[:space:]]+${key}:[[:space:]]*(.*)$ ]]; then
-            value="$(base_repo_strip_config_value "${BASH_REMATCH[1]}")"
+            value="$(base_repo_strip_config_value "${BASH_REMATCH[1]}")" || {
+                base_std_log_error "$config_path: github.$key has invalid quoted YAML syntax."
+                return 2
+            }
             [[ -n "$value" ]] || {
                 base_std_log_error "$config_path: github.$key must be a non-empty value."
                 return 2

--- a/cli/bash/commands/basectl/subcommands/repo_init.sh
+++ b/cli/bash/commands/basectl/subcommands/repo_init.sh
@@ -320,9 +320,19 @@ base_repo_init_validate() {
         base_repo_init_usage_error "Unsupported repository license '$license_id'. Expected: $(base_repo_license_display)"
         return 2
     fi
-    [[ -n "$path" ]] || path="$(base_repo_default_target_path "$name")"
+    if [[ -z "$path" ]]; then
+        path="$(base_repo_default_target_path "$name")" || return $?
+        [[ -n "$path" ]] || {
+            base_std_log_error "Unable to resolve a non-empty default repository target for '$name'."
+            return 2
+        }
+    fi
     [[ -n "$description" ]] || description="$(base_repo_default_description "$name")"
-    root="$(base_repo_target_path "$path")"
+    root="$(base_repo_target_path "$path")" || return $?
+    [[ -n "$root" ]] || {
+        base_std_log_error "Unable to resolve a non-empty repository target for '$name'."
+        return 2
+    }
     if [[ -n "$issue" ]] && ! base_github_issue_number_is_valid "$issue"; then
         base_repo_init_usage_error "Option '--issue' must be a positive integer."
         return $?

--- a/cli/bash/commands/basectl/tests/repo.bats
+++ b/cli/bash/commands/basectl/tests/repo.bats
@@ -253,8 +253,8 @@ run_repo_command_with_mocks() {
 workspace:
   root: $workspace_root
 github:
-  default_owner: codeforester
-  clone_protocol: ssh
+  default_owner: "codeforester" # repo owner
+  clone_protocol: "ssh" # clone transport
 EOF
 
     cd "$nested_dir"
@@ -290,6 +290,42 @@ EOF
     [ "$status" -eq 0 ]
     [ "$(line_at "$output" 1)" = "[DRY-RUN] Would clone codeforester/base-demo (git@github.com:codeforester/base-demo.git) into $repo_dir." ]
     [ "$(line_at "$output" 2)" = "[DRY-RUN] Would run: gh repo clone codeforester/base-demo $repo_dir" ]
+}
+
+@test "basectl repo clone preserves spaces and hash characters in quoted workspace roots" {
+    local nested_dir="$TEST_TMPDIR/nested/current"
+    local workspace_root="$TEST_TMPDIR/workspace root#one"
+    local repo_dir="$workspace_root/base-demo"
+
+    mkdir -p "$TEST_HOME/.base.d" "$nested_dir" "$workspace_root"
+    cat > "$TEST_HOME/.base.d/config.yaml" <<EOF
+workspace:
+  root: "$workspace_root" # local workspace
+github:
+  default_owner: codeforester
+  clone_protocol: ssh
+EOF
+
+    cd "$nested_dir"
+    run_basectl repo clone base-demo --dry-run
+
+    [ "$status" -eq 0 ]
+    [ "$(line_at "$output" 1)" = "[DRY-RUN] Would clone codeforester/base-demo (git@github.com:codeforester/base-demo.git) into \"$repo_dir\"." ]
+    [ "$(line_at "$output" 2)" = "[DRY-RUN] Would run: gh repo clone codeforester/base-demo \"$repo_dir\"" ]
+}
+
+@test "basectl repo clone fails closed on malformed quoted GitHub defaults" {
+    mkdir -p "$TEST_HOME/.base.d"
+    cat > "$TEST_HOME/.base.d/config.yaml" <<'EOF'
+github:
+  default_owner: "codeforester
+EOF
+
+    run_basectl repo clone base-demo --dry-run
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"github.default_owner has invalid quoted YAML syntax"* ]]
+    [[ "$output" != *"[DRY-RUN] Would clone"* ]]
 }
 
 @test "basectl repo clone supports explicit owner and path dry-run" {
@@ -1341,6 +1377,100 @@ EOF
     [[ "$output" != *"$nested_dir/base-demo"* ]]
     [[ "$output" == *"[DRY-RUN] Would not create or configure a GitHub repository because no GitHub repo was provided or inferred."* ]]
     [ ! -e "$repo_dir" ]
+}
+
+@test "basectl repo init preserves spaces and hash characters in quoted workspace roots" {
+    local nested_dir="$TEST_TMPDIR/nested/current"
+    local workspace_root="$TEST_TMPDIR/workspace root#one"
+    local repo_dir="$workspace_root/base-demo"
+
+    mkdir -p "$TEST_HOME/.base.d" "$nested_dir" "$workspace_root"
+    cat > "$TEST_HOME/.base.d/config.yaml" <<EOF
+workspace:
+  root: "$workspace_root" # local workspace
+EOF
+
+    cd "$nested_dir"
+    run_basectl repo init base-demo --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DRY-RUN] Would create '$repo_dir/README.md'."* ]]
+    [[ "$output" != *"$nested_dir/README.md"* ]]
+    [ ! -e "$repo_dir" ]
+}
+
+@test "basectl repo init fails before dry-run or apply actions when workspace root is relative" {
+    local nested_dir="$TEST_TMPDIR/nested/current"
+
+    mkdir -p "$TEST_HOME/.base.d" "$nested_dir"
+    cat > "$TEST_HOME/.base.d/config.yaml" <<'EOF'
+workspace:
+  root: relative/work
+EOF
+
+    cd "$nested_dir"
+    run_basectl repo init unsafe-target --dry-run
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"workspace.root must be an absolute path or start with '~'"* ]]
+    [[ "$output" != *"[DRY-RUN] Would create"* ]]
+    [ ! -e "$nested_dir/README.md" ]
+    [ ! -e "$nested_dir/base_manifest.yaml" ]
+
+    run_basectl repo init unsafe-target
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"workspace.root must be an absolute path or start with '~'"* ]]
+    [ ! -e "$nested_dir/README.md" ]
+    [ ! -e "$nested_dir/base_manifest.yaml" ]
+}
+
+@test "basectl repo init fails closed when configured workspace root is empty" {
+    local nested_dir="$TEST_TMPDIR/nested/current"
+
+    mkdir -p "$TEST_HOME/.base.d" "$nested_dir"
+    printf 'workspace:\n  root: # missing\n' > "$TEST_HOME/.base.d/config.yaml"
+
+    cd "$nested_dir"
+    run_basectl repo init unsafe-target --dry-run
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"workspace.root must be a non-empty path"* ]]
+    [[ "$output" != *"[DRY-RUN] Would create"* ]]
+    [ ! -e "$nested_dir/README.md" ]
+}
+
+@test "basectl repo init accepts explicit current-directory targets" {
+    local physical_repo_dir
+    local repo_dir="$TEST_TMPDIR/explicit-current"
+
+    mkdir -p "$TEST_HOME/.base.d" "$repo_dir"
+    cat > "$TEST_HOME/.base.d/config.yaml" <<'EOF'
+workspace:
+  root: relative/work
+EOF
+
+    cd "$repo_dir"
+    physical_repo_dir="$(pwd -P)"
+    run_basectl repo init explicit-current --path . --no-configure
+
+    [ "$status" -eq 0 ]
+    [ -f "$repo_dir/README.md" ]
+    [ -f "$repo_dir/base_manifest.yaml" ]
+    [[ "$output" == *"Created '$physical_repo_dir/README.md'."* ]]
+}
+
+@test "basectl repo init rejects an empty path assignment before repo actions" {
+    local nested_dir="$TEST_TMPDIR/nested/current"
+
+    mkdir -p "$nested_dir"
+    cd "$nested_dir"
+    run_basectl repo init unsafe-target --path= --dry-run
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Option '--path' uses unsupported equals syntax"* ]]
+    [[ "$output" != *"[DRY-RUN] Would create"* ]]
+    [ ! -e "$nested_dir/README.md" ]
 }
 
 @test "basectl repo init falls back to BASE_HOME parent when workspace root is not configured" {

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -84,7 +84,11 @@ workspace root:
 
 That keeps `repo init base-demo` stable even when it is run from inside another
 repository or from a nested directory such as `~/work/base/docs`. Use
-`--path <path>` when the new repository should live somewhere else.
+`--path <path>` when the new repository should live somewhere else. Base
+validates configured workspace and GitHub defaults before planning or applying
+any repository action. Invalid, empty, or malformed values fail closed instead
+of falling back to the current directory. Quoted workspace paths may contain
+spaces and `#`; use the explicit `--path .` form to target the current checkout.
 
 Open the generated baseline through a pull request when the target repository
 already exists:


### PR DESCRIPTION
## Summary

- Propagate default workspace-target and target-normalization errors before repository planning or mutation.
- Parse quoted user-config values without treating `#` inside quotes as an inline comment, and reject malformed workspace or GitHub defaults.
- Preserve explicit `--path .` and the documented no-config fallback while covering dry-run and apply behavior.

## Issue

Fixes #2007

## Validation

- `bash -n cli/bash/commands/basectl/subcommands/repo.sh cli/bash/commands/basectl/subcommands/repo_init.sh`
- `shellcheck -x -P /Users/rameshhp/work/base-bash-libs/lib/bash cli/bash/commands/basectl/subcommands/repo.sh cli/bash/commands/basectl/subcommands/repo_init.sh`
- 134 focused repository-command BATS tests
- Full `./bin/base-test`: 1,025 Python tests and 899 BATS tests

## Docs Impact

- Updated `docs/repo-baseline.md` and command help with the fail-closed configuration and explicit-current-directory contract.