### PR TITLE
security: enforce secret detection

### DIFF
--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -53,6 +53,12 @@ Every `base-bash-libs` checkout in that workflow uses one immutable GA revision.
 The workflow contract test guards against an RC or mixed dependency pin
 returning across the platform and source-checkout jobs.
 
+The `Security scanners` job is a required merge check. In addition to Bandit,
+pip-audit, and ShellCheck, it runs the checksum-pinned Gitleaks release through
+`tests/scan-secrets.sh`; findings are fully redacted. GitHub secret scanning and
+provider push protection are the repository-native first layer, while Gitleaks
+covers generic patterns unavailable through this repository's GitHub plan.
+
 First-mile Homebrew installation remains mutable by default and logs that
 policy. Managed environments can opt into checksum verification with paired
 installer URL and SHA-256 overrides; the bootstrap documentation records why

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -371,6 +371,26 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y shellcheck
 
+      - name: Install pinned Gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_LINUX_X64_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+        run: |
+          archive="$RUNNER_TEMP/gitleaks.tar.gz"
+          curl --fail --show-error --silent --location \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            --output "$archive"
+          printf '%s  %s\n' "$GITLEAKS_LINUX_X64_SHA256" "$archive" |
+            sha256sum --check -
+          tar -xzf "$archive" -C "$RUNNER_TEMP" gitleaks
+          chmod +x "$RUNNER_TEMP/gitleaks"
+
+      - name: Scan repository history for secrets
+        env:
+          GITLEAKS_BIN: ${{ runner.temp }}/gitleaks
+        run: |
+          ./tests/scan-secrets.sh
+
       - name: Run Bandit
         run: |
           bandit -q -r cli/python lib/python -x '*/tests/*' --severity-level medium

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ numeric next development line is tracked in `DEVELOPMENT_VERSION`.
 
 ### Added
 
+- Enforced repository secret scanning and provider push protection, with a
+  required checksum-pinned Gitleaks history scan for generic patterns and
+  rotate-first maintainer response guidance.
+
 - Added opt-in `--closed-unmerged` cleanup to `basectl gh branch prune` and
   `basectl gh worktree prune`, with explicit PR-state classification and
   retention details for open, closed-unmerged, and no-PR branches.

--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ potential, and engineering evidence, see
 [Product Assessment](docs/product-assessment.md).
 
 Common first-run and product questions are answered in [FAQ.md](FAQ.md).
-Contributions should follow [CONTRIBUTING.md](CONTRIBUTING.md). Release notes
-are tracked in [CHANGELOG.md](CHANGELOG.md).
+Contributions should follow [CONTRIBUTING.md](CONTRIBUTING.md). Report security
+issues and handle detected credentials according to [SECURITY.md](SECURITY.md).
+Release notes are tracked in [CHANGELOG.md](CHANGELOG.md).
 
 ## Source Control And Forge Support
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Report vulnerabilities through GitHub's private vulnerability reporting for
+`basefoundry/base`. Do not open a public issue with exploit details, credentials,
+or secret values. If private reporting is unavailable, contact the maintainers
+without including a live credential and ask for a private channel.
+
+## Secret Detection
+
+Base uses two enforced layers:
+
+- GitHub secret scanning and push protection detect supported provider secrets
+  and block supported secrets before they reach the repository.
+- The required `Security scanners` check runs Gitleaks 8.30.1 over committed
+  history to cover provider and generic secret patterns on pull requests and
+  protected `main` updates.
+
+GitHub non-provider patterns, custom patterns, and validity checks are not
+available for this public repository under its current GitHub feature set.
+Repository administrators can verify the native setting readback without
+displaying alerts or secret values:
+
+```bash
+gh api repos/basefoundry/base \
+  --jq '.security_and_analysis | {
+    secret_scanning,
+    secret_scanning_push_protection,
+    secret_scanning_non_provider_patterns,
+    secret_scanning_validity_checks
+  }'
+```
+
+Run the same fallback scanner locally with the exact supported Gitleaks release:
+
+```bash
+GITLEAKS_BIN=/path/to/gitleaks-8.30.1 ./tests/scan-secrets.sh
+```
+
+The scanner fully redacts findings. For a controlled working-tree or fixture
+check, use `./tests/scan-secrets.sh --dir <path>`. Do not place controlled
+secret-shaped fixtures in the repository history.
+
+Test fixtures should use unmistakably fake, narrowly scoped values. If a false
+positive cannot be rewritten safely, add only its reviewed fingerprint to
+`.gitleaksignore`; do not disable a rule or exclude a broad test directory.
+
+## Responding to a Secret
+
+Treat detection as exposure until proven otherwise:
+
+1. Do not print, quote, copy into an issue, or otherwise redistribute the value.
+2. Revoke or rotate the credential first. Removing Git history does not make a
+   live credential safe.
+3. Determine the affected repositories, commits, logs, artifacts, and access
+   window using provider and GitHub audit evidence.
+4. Remove the value from the current change. Rewrite published history only
+   when the exposure warrants it, and coordinate the force push and downstream
+   clone cleanup with maintainers.
+5. Resolve the GitHub alert with the accurate reason only after rotation and
+   remediation are complete.
+
+Never bypass push protection merely to make a build or release proceed. A fake
+fixture that must exercise detection belongs in an isolated local validation,
+not in the tracked tree.

--- a/tests/scan-secrets.sh
+++ b/tests/scan-secrets.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Keep the fallback scanner deterministic across local and hosted validation.
+GITLEAKS_REQUIRED_VERSION="8.30.1"
+readonly GITLEAKS_REQUIRED_VERSION
+
+usage() {
+    cat <<'EOF'
+Usage:
+  tests/scan-secrets.sh
+  tests/scan-secrets.sh --dir <path>
+
+Scan committed repository history by default. Use --dir only for a controlled
+working-tree or fixture scan. Findings are always fully redacted.
+EOF
+}
+
+gitleaks_bin="${GITLEAKS_BIN:-}"
+if [[ -z "$gitleaks_bin" ]]; then
+    gitleaks_bin="$(command -v gitleaks 2>/dev/null || true)"
+fi
+if [[ -z "$gitleaks_bin" || ! -x "$gitleaks_bin" ]]; then
+    printf 'ERROR: gitleaks %s is required for secret scanning.\n' \
+        "$GITLEAKS_REQUIRED_VERSION" >&2
+    printf 'Install that release or set GITLEAKS_BIN to its executable path.\n' >&2
+    exit 1
+fi
+
+version_output=""
+if version_output="$($gitleaks_bin version 2>/dev/null)"; then
+    :
+else
+    printf 'ERROR: Could not determine the gitleaks version.\n' >&2
+    exit 1
+fi
+if [[ "$version_output" != "$GITLEAKS_REQUIRED_VERSION" ]]; then
+    printf 'ERROR: gitleaks %s is required; found %s.\n' \
+        "$GITLEAKS_REQUIRED_VERSION" "$version_output" >&2
+    exit 1
+fi
+
+scan_status=0
+case "${1:-}" in
+    "")
+        "$gitleaks_bin" git --redact=100 --no-banner --no-color --verbose . ||
+            scan_status=$?
+        ;;
+    --dir)
+        if [[ -z "${2:-}" || -n "${3:-}" ]]; then
+            usage >&2
+            exit 2
+        fi
+        if [[ ! -e "$2" ]]; then
+            printf "ERROR: Secret scan path does not exist: %s\n" "$2" >&2
+            exit 1
+        fi
+        "$gitleaks_bin" dir --redact=100 --no-banner --no-color --verbose "$2" ||
+            scan_status=$?
+        ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    *)
+        usage >&2
+        exit 2
+        ;;
+esac
+
+exit "$scan_status"

--- a/tests/test_secret_scanning_contract.py
+++ b/tests/test_secret_scanning_contract.py
@@ -1,0 +1,109 @@
+import os
+from pathlib import Path
+import subprocess
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCAN_SCRIPT = REPO_ROOT / "tests" / "scan-secrets.sh"
+TESTS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "tests.yml"
+GITLEAKS_VERSION = "8.30.1"
+GITLEAKS_LINUX_X64_SHA256 = (
+    "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+)
+
+
+def _security_steps() -> list[dict]:
+    workflow = yaml.safe_load(TESTS_WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["security"]["steps"]
+    assert isinstance(steps, list)
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _write_gitleaks_mock(tmp_path: Path, *, version: str = GITLEAKS_VERSION) -> Path:
+    mock = tmp_path / "gitleaks"
+    mock.write_text(
+        f"""#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "${{GITLEAKS_MOCK_LOG:?}}"
+if [[ "${{1:-}}" == "version" ]]; then
+    printf '%s\\n' "{version}"
+fi
+""",
+        encoding="utf-8",
+    )
+    mock.chmod(0o755)
+    return mock
+
+
+def _run_scan_script(tmp_path: Path, *args: str, version: str = GITLEAKS_VERSION):
+    mock = _write_gitleaks_mock(tmp_path, version=version)
+    log_path = tmp_path / "gitleaks.log"
+    env = os.environ.copy()
+    env.update({"GITLEAKS_BIN": str(mock), "GITLEAKS_MOCK_LOG": str(log_path)})
+    result = subprocess.run(
+        [str(SCAN_SCRIPT), *args],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=10,
+    )
+    return result, log_path
+
+
+def test_security_workflow_installs_checksum_pinned_gitleaks() -> None:
+    steps = _security_steps()
+    install_step = next(step for step in steps if step.get("name") == "Install pinned Gitleaks")
+    scan_step = next(
+        step for step in steps if step.get("name") == "Scan repository history for secrets"
+    )
+
+    assert install_step["env"] == {
+        "GITLEAKS_VERSION": GITLEAKS_VERSION,
+        "GITLEAKS_LINUX_X64_SHA256": GITLEAKS_LINUX_X64_SHA256,
+    }
+    assert "sha256sum --check -" in install_step["run"]
+    assert "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" in install_step["run"]
+    assert scan_step["env"]["GITLEAKS_BIN"] == "${{ runner.temp }}/gitleaks"
+    assert "./tests/scan-secrets.sh" in scan_step["run"]
+
+
+def test_scan_script_redacts_the_default_history_scan(tmp_path: Path) -> None:
+    result, log_path = _run_scan_script(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert log_path.read_text(encoding="utf-8").splitlines() == [
+        "version",
+        "git --redact=100 --no-banner --no-color --verbose .",
+    ]
+
+
+def test_scan_script_supports_controlled_directory_scans(tmp_path: Path) -> None:
+    fixture_dir = tmp_path / "fixture"
+    fixture_dir.mkdir()
+    result, log_path = _run_scan_script(tmp_path, "--dir", str(fixture_dir))
+
+    assert result.returncode == 0, result.stderr
+    assert log_path.read_text(encoding="utf-8").splitlines() == [
+        "version",
+        f"dir --redact=100 --no-banner --no-color --verbose {fixture_dir}",
+    ]
+
+
+def test_scan_script_rejects_an_unreviewed_gitleaks_version(tmp_path: Path) -> None:
+    result, log_path = _run_scan_script(tmp_path, version="8.31.0")
+
+    assert result.returncode == 1
+    assert f"gitleaks {GITLEAKS_VERSION} is required" in result.stderr
+    assert log_path.read_text(encoding="utf-8") == "version\n"
+
+
+def test_security_policy_is_rotate_first_and_uses_narrow_exceptions() -> None:
+    policy = (REPO_ROOT / "SECURITY.md").read_text(encoding="utf-8")
+
+    assert policy.index("Revoke or rotate the credential first") < policy.index(
+        "Rewrite published history"
+    )
+    assert "reviewed fingerprint" in policy
+    assert "do not disable a rule or exclude a broad test directory" in policy


### PR DESCRIPTION
## Summary

- enable GitHub secret scanning and provider push protection for the repository
- add a checksum-pinned Gitleaks 8.30.1 history scan to the Security scanners job for generic-pattern coverage
- document private reporting, rotate-first response, narrow false-positive handling, and the enforced control model

## Issue

Fixes #2009

## Validation

- live repository readback: secret scanning enabled; push protection enabled
- controlled native push-protection probe: GitHub rejected the fake provider token and no remote branch was created
- full 1,125-commit Gitleaks history scan: no findings
- controlled provider and generic fixtures: both detected with findings fully redacted
- `pytest -q tests/test_secret_scanning_contract.py tests/test_github_workflows.py` (45 passed)
- `shellcheck --severity=warning tests/scan-secrets.sh`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python BASE_CACHE_DIR=/private/tmp/base-train-2009-full ./bin/base-test` (1,038 Python tests and 899 Bats tests passed)
- Pylint and `git diff --check`

## Security Notes

GitHub non-provider patterns, custom patterns, and validity checks are unavailable under the repository's current feature set. The required checksum-pinned Gitleaks history scan supplies the equivalent generic-pattern backstop without weakening native provider push protection. Controlled fixtures used only fake values outside repository history.

## Docs Impact

Adds `SECURITY.md`, links it from the README, and records the change in the changelog.

## AI Context Impact

Updates `.ai-context/WORKFLOWS.md` with the required secret-scanning contract and layered control model.

## Demo Impact

None.
