### PR TITLE
fix: report workspace check record failures

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -66,7 +66,10 @@ the v1.x compatibility window; new automation should use `--debug-wrapper`.
     `workspace clone`, `workspace pull`, `workspace update`, `workspace init`, `workspace configure`,
     and `workspace setup` use text output.
   - `workspace check` presents check-oriented readiness messages; `workspace doctor`
-    presents actionable findings with stable IDs and fix guidance.
+    presents actionable findings with stable IDs and fix guidance. Workspace
+    check-record persistence is optional: failures are reported per project in
+    text and through JSON/YAML `record_warnings` without changing health status
+    or exit semantics.
   - `workspace onboarding` summarizes ready, needs-setup, invalid-manifest,
     missing-required, and missing-optional repository state without cloning
     repositories or running setup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ numeric next development line is tracked in `DEVELOPMENT_VERSION`.
 
 ### Fixed
 
+- Workspace checks now surface each failed latest-check record write, including
+  stable JSON/YAML warnings, while preserving project-health exit semantics and
+  successful records from the same run.
+
 - Prevented rejected `basectl` usage invocations from retaining run bundles,
   logs, or history rows; an explicitly named nonexistent `basectl test` project
   now returns usage status `2`, while accepted-command failures remain

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -43,6 +43,7 @@ from base_projects.workspace_clone_command import should_skip_optional_clone  # 
 from base_projects.workspace_clone_command import workspace_clone_command
 from base_projects.workspace_clone_command import workspace_clone_repo_spec  # pylint: disable=unused-import
 from base_projects.workspace_checks import persist_workspace_check_records
+from base_projects.workspace_checks import workspace_check_record_warning
 from base_projects.workspace_checks import workspace_error_count
 from base_projects.workspace_checks import workspace_project_check_results
 from base_projects.workspace_configure import workspace_configure_from_options
@@ -317,9 +318,14 @@ def workspace_check_command(
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
+    record_failures = persist_workspace_check_records(results)
+    record_warnings = [workspace_check_record_warning(failure) for failure in record_failures]
+    document = workspace_check_to_json(workspace_root, results, manifest)
+    document["record_warnings"] = record_warnings
+
     if not emit_workspace_report(
         ctx,
-        workspace_check_to_json(workspace_root, results, manifest),
+        document,
         output_format,
         records_key="projects",
         columns=(("PROJECT", "name"), ("STATUS", "status"), ("PATH", "path"), ("MANIFEST", "manifest")),
@@ -327,8 +333,16 @@ def workspace_check_command(
     ):
         return base_cli.ExitCode.USAGE_ERROR
 
-    for project_name, exc in persist_workspace_check_records(results):
-        ctx.log.warning("Could not record workspace check for project '%s': %s", project_name, exc)
+    resolved_output_format = base_cli.resolve_output_format(output_format)
+    if resolved_output_format not in ("json", "yaml"):
+        for warning in record_warnings:
+            ctx.log.warning(
+                "%s Project '%s'; path: '%s'. %s",
+                warning["message"],
+                warning["project"],
+                warning["path"],
+                warning["fix"],
+            )
 
     if any(result.status == "error" for result in results):
         return base_cli.ExitCode.FAILURE

--- a/cli/python/base_projects/tests/test_workspace_checks.py
+++ b/cli/python/base_projects/tests/test_workspace_checks.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest import mock
 
 from base_projects import engine
+from base_projects import workspace_checks
 
 
 def write_manifest(project_root: Path, name: str) -> None:
@@ -168,6 +169,197 @@ class WorkspaceCheckTests(unittest.TestCase):
         self.assertIn("demo", stdout + stderr)
         self.assertEqual(record["command"], "basectl workspace check")
         self.assertEqual(record["status"], "error")
+
+    def test_workspace_check_json_reports_a_false_record_write(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_default_manifest(base_home)
+            write_shell_manifest(workspace / "demo", "demo")
+
+            with mock.patch.object(workspace_checks, "write_check_record", return_value=False):
+                status, stdout, stderr = invoke_engine(
+                    ["check", "--workspace", str(workspace), "--format", "json"],
+                    base_home,
+                    home,
+                )
+
+            expected_path = home / ".base.d" / "demo" / "checks" / "last.json"
+
+        payload = json.loads(stdout)
+        self.assertEqual(status, 0)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(stderr, "")
+        self.assertEqual(
+            payload["record_warnings"],
+            [
+                {
+                    "project": "demo",
+                    "status": "warn",
+                    "message": "Latest check record could not be saved.",
+                    "fix": "Ensure the Base state directory is writable, then rerun the check.",
+                    "path": str(expected_path),
+                }
+            ],
+        )
+
+    def test_workspace_check_text_reports_a_record_write_failure_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_default_manifest(base_home)
+            write_shell_manifest(workspace / "demo", "demo")
+
+            with mock.patch.object(workspace_checks, "write_check_record", return_value=False):
+                status, stdout, stderr = invoke_engine(
+                    ["check", "--workspace", str(workspace)],
+                    base_home,
+                    home,
+                )
+
+            expected_path = home / ".base.d" / "demo" / "checks" / "last.json"
+
+        self.assertEqual(status, 0)
+        self.assertIn("Project: demo [ok]", stdout)
+        self.assertEqual(stderr.count("Latest check record could not be saved."), 1)
+        self.assertIn("Project 'demo'", stderr)
+        self.assertIn(str(expected_path), stderr)
+        self.assertNotIn("Traceback", stderr)
+
+    def test_workspace_check_reports_an_unwritable_record_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_default_manifest(base_home)
+            write_shell_manifest(workspace / "demo", "demo")
+            write_record = workspace_checks.write_check_record
+
+            def reject_record_directory(*args, **kwargs) -> bool:
+                with mock.patch.object(Path, "mkdir", side_effect=PermissionError("read-only")):
+                    return write_record(*args, **kwargs)
+
+            with mock.patch.object(
+                workspace_checks,
+                "write_check_record",
+                side_effect=reject_record_directory,
+            ):
+                status, stdout, stderr = invoke_engine(
+                    ["check", "--workspace", str(workspace), "--format", "json"],
+                    base_home,
+                    home,
+                )
+
+        payload = json.loads(stdout)
+        self.assertEqual(status, 0)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(stderr, "")
+        self.assertEqual([warning["project"] for warning in payload["record_warnings"]], ["demo"])
+
+    def test_workspace_check_preserves_error_exit_when_record_replace_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_default_manifest(base_home)
+            write_manifest(workspace / "demo", "demo")
+            old_record_path = home / ".base.d" / "demo" / "checks" / "last.json"
+            old_record_path.parent.mkdir(parents=True)
+            old_record_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "project": "demo",
+                        "command": "basectl workspace check",
+                        "status": "warn",
+                        "checked_at": "2026-01-01T00:00:00Z",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(Path, "replace", side_effect=OSError("read-only")):
+                status, stdout, stderr = invoke_engine(
+                    ["check", "--workspace", str(workspace), "--format", "json"],
+                    base_home,
+                    home,
+                )
+            retained_record = json.loads(old_record_path.read_text(encoding="utf-8"))
+
+        payload = json.loads(stdout)
+        self.assertEqual(status, 1)
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(stderr, "")
+        self.assertEqual([warning["project"] for warning in payload["record_warnings"]], ["demo"])
+        self.assertEqual(retained_record["checked_at"], "2026-01-01T00:00:00Z")
+        self.assertEqual(retained_record["status"], "warn")
+
+    def test_workspace_check_keeps_successful_records_when_one_write_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            write_default_manifest(base_home)
+            write_shell_manifest(workspace / "alpha", "alpha")
+            write_shell_manifest(workspace / "beta", "beta")
+            write_record = workspace_checks.write_check_record
+
+            def write_partially(
+                path: Path,
+                project: str,
+                result_status: str,
+                checked_at: str,
+                *,
+                command: str,
+            ) -> bool:
+                if project == "beta":
+                    return False
+                return write_record(
+                    path,
+                    project,
+                    result_status,
+                    checked_at,
+                    command=command,
+                )
+
+            with mock.patch.object(
+                workspace_checks,
+                "write_check_record",
+                side_effect=write_partially,
+            ):
+                status, stdout, stderr = invoke_engine(
+                    ["check", "--workspace", str(workspace), "--format", "json"],
+                    base_home,
+                    home,
+                )
+
+            alpha_record = read_last_check(home, "alpha")
+            beta_record_path = home / ".base.d" / "beta" / "checks" / "last.json"
+            beta_record_exists = beta_record_path.exists()
+
+        payload = json.loads(stdout)
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(alpha_record["status"], "ok")
+        self.assertFalse(beta_record_exists)
+        self.assertEqual([warning["project"] for warning in payload["record_warnings"]], ["beta"])
 
     def test_workspace_check_manifest_reports_expected_missing_and_extra_repositories(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -428,6 +620,7 @@ class WorkspaceCheckTests(unittest.TestCase):
         self.assertEqual(payload["workspace"], str(workspace.resolve()))
         self.assertEqual(payload["status"], "error")
         self.assertEqual(payload["project_count"], 1)
+        self.assertEqual(payload["record_warnings"], [])
         self.assertEqual(payload["projects"][0]["name"], "demo")
         self.assertEqual(payload["projects"][0]["status"], "error")
         self.assertEqual(payload["projects"][0]["checks"][0]["id"], "BASE-P050")

--- a/cli/python/base_projects/workspace_checks.py
+++ b/cli/python/base_projects/workspace_checks.py
@@ -21,6 +21,7 @@ from base_projects.workspace_scanner import workspace_manifest_entries
 from base_setup.checks import ArtifactCheck
 from base_setup.checks import checks_status
 from base_setup.checks import doctor_status
+from base_setup.diagnostics import check_record_warning
 from base_setup.diagnostics import write_check_record
 from base_setup.engine import manifest_checks
 from base_setup.engine import pre_venv_manifest_checks
@@ -51,28 +52,40 @@ class WorkspaceProjectCheckResult:
     default_branch: str | None = None
 
 
+@dataclass(frozen=True)
+class WorkspaceCheckRecordFailure:
+    project: str
+    path: Path
+
+
 def workspace_check_timestamp() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def persist_workspace_check_records(
     results: tuple[WorkspaceProjectCheckResult, ...],
-) -> tuple[tuple[str, OSError], ...]:
+) -> tuple[WorkspaceCheckRecordFailure, ...]:
     checked_at = workspace_check_timestamp()
-    failures: list[tuple[str, OSError]] = []
+    failures: list[WorkspaceCheckRecordFailure] = []
     for result in results:
         record_path = base_state_root() / result.name / "checks" / "last.json"
         try:
-            write_check_record(
+            written = write_check_record(
                 record_path,
                 result.name,
                 result.status,
                 checked_at,
                 command=WORKSPACE_CHECK_COMMAND,
             )
-        except OSError as exc:
-            failures.append((result.name, exc))
+        except OSError:
+            written = False
+        if not written:
+            failures.append(WorkspaceCheckRecordFailure(project=result.name, path=record_path))
     return tuple(failures)
+
+
+def workspace_check_record_warning(failure: WorkspaceCheckRecordFailure) -> dict[str, str]:
+    return {"project": failure.project, **check_record_warning(failure.path)}
 
 
 def workspace_project_check_results(

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -37,6 +37,12 @@ a top-level aggregate `status` alongside `workspace`, `project_count`, and
 `projects`. The aggregate uses `error` over `warn` over `ok` precedence; each
 project record retains its existing `status` field.
 
+`basectl workspace check --format json|yaml` also includes a top-level
+`record_warnings` collection. Each warning names the affected project and
+latest-check record path and supplies stable `status`, `message`, and `fix`
+fields. The collection is empty when every record is saved. These optional
+persistence warnings do not alter the diagnostic `status` or command exit code.
+
 The terminal check is made on stdout, so redirecting stdout changes only the
 default `text` presentation. An explicitly selected `--format text` follows
 the same rule. Logging, warnings, and usage errors stay on stderr and never

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -85,7 +85,10 @@ An empty workspace has aggregate status `ok`.
 The latest-check record is optional persistence state. If a check succeeds but
 cannot save that record, the check result remains authoritative and workspace
 status reports the missing record as `-` or `null` until a later check can save
-one.
+one. Text output emits one warning per affected project with the record path;
+JSON and YAML expose the same details in the top-level `record_warnings`
+collection. Persistence warnings do not change the workspace health status or
+command exit code.
 
 With `--manifest <path>`, the same commands also report expected repositories,
 missing required and optional repositories, and discovered Base-managed


### PR DESCRIPTION
## Summary

- propagate failed Boolean workspace check-record writes instead of silently discarding them
- expose stable per-project `record_warnings` in JSON/YAML and one actionable warning in text/delimited output
- preserve diagnostic health status, exit semantics, stale records, and successful writes from the same workspace run

## Issue

Fixes #2006

## Validation

- focused workspace, report, and diagnostic payload matrix (120 passed, 6 subtests passed)
- false-return, unwritable-directory, replacement-failure, stale-record, multi-project, and partial-write regressions
- controlled real unwritable Base state reproduction: valid JSON, one redacted-safe warning, health status and exit 0 preserved
- Pylint on all changed Python modules and tests
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python BASE_CACHE_DIR=/private/tmp/base-train-2006-full ./bin/base-test` (1,043 Python tests and 899 Bats tests passed)

## Security Notes

Warnings contain only the project name and local record path; no check payload or credential data is added. Persistence remains optional and cannot mask or change the actual diagnostic result.

## Docs Impact

Documents the `record_warnings` schema and unchanged health semantics in the workspace manifest and output-format guides; records the fix in the changelog.

## AI Context Impact

Updates `.ai-context/COMMANDS.md` with the workspace check-record persistence contract.

## Demo Impact

None.
