### PR TITLE
fix: normalize workspace file URLs

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -81,6 +81,8 @@ the v1.x compatibility window; new automation should use `--debug-wrapper`.
     `workspace pull` mutates only the local workspace manifest after validating
     the source; `workspace init` can clone the workspace configuration repo,
     update `~/.base.d/config.yaml`, and materialize manifest repositories;
+    init and pull share one local `file://` parser that percent-decodes once,
+    accepts empty or `localhost` authority, and rejects remote authorities;
     `workspace update` runs `git pull --ff-only` across present repositories in
     manifest order, including the active Base checkout when it is the
     manifest's `base` target;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ numeric next development line is tracked in `DEVELOPMENT_VERSION`.
 
 ### Fixed
 
+- Workspace init and pull now share one local `file://` parser that decodes
+  spaces, Unicode, and literal percent signs exactly once while rejecting
+  malformed encodings and remote authorities.
+
 - Workspace checks now surface each failed latest-check record write, including
   stable JSON/YAML warnings, while preserving project-health exit semantics and
   successful records from the same run.

--- a/cli/python/base_projects/tests/test_workspace_file_url.py
+++ b/cli/python/base_projects/tests/test_workspace_file_url.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from base_projects.command_helpers import ProjectUsageError
+from base_projects.workspace_file_url import resolve_workspace_file_url
+
+
+class WorkspaceFileUrlTests(unittest.TestCase):
+    def test_file_url_decodes_spaces_unicode_and_literal_percent_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "Base Workspace-雪-%20" / "workspace.yaml"
+
+            resolved = resolve_workspace_file_url(path.as_uri())
+
+        self.assertEqual(resolved, path.resolve(strict=False))
+        self.assertIn("%2520", path.as_uri())
+        self.assertEqual(resolved.parent.name, "Base Workspace-雪-%20")
+
+    def test_file_url_accepts_only_empty_and_localhost_authorities(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "workspace.yaml"
+            local_url = path.as_uri()
+            localhost_url = local_url.replace("file:///", "file://LOCALHOST/", 1)
+
+            self.assertEqual(resolve_workspace_file_url(local_url), path.resolve(strict=False))
+            self.assertEqual(resolve_workspace_file_url(localhost_url), path.resolve(strict=False))
+
+        with self.assertRaisesRegex(ProjectUsageError, "only an empty or localhost authority"):
+            resolve_workspace_file_url("file://files.example.test/private/workspace.yaml")
+
+    def test_file_url_rejects_ambiguous_or_malformed_components(self) -> None:
+        cases = (
+            ("file://[broken/workspace.yaml", "Malformed workspace file URL"),
+            ("file:///private/tmp/workspace%2.yaml", "malformed percent encoding"),
+            ("file:///private/tmp/workspace%FF.yaml", "invalid UTF-8 percent encoding"),
+            ("file:///private/tmp/workspace.yaml?ref=main", "cannot include parameters"),
+            ("file:///private/tmp/workspace.yaml#fragment", "cannot include parameters"),
+            ("file:relative/workspace.yaml", "must be an absolute local path"),
+            ("file:////files.example.test/workspace.yaml", "must be an absolute local path"),
+            ("file:///private/tmp/workspace%00.yaml", "cannot contain a NUL byte"),
+        )
+        for source, expected_message in cases:
+            with self.subTest(source=source):
+                with self.assertRaisesRegex(ProjectUsageError, expected_message):
+                    resolve_workspace_file_url(source)

--- a/cli/python/base_projects/tests/test_workspace_init.py
+++ b/cli/python/base_projects/tests/test_workspace_init.py
@@ -187,6 +187,98 @@ class WorkspaceInitTests(unittest.TestCase):
             ],
         )
 
+    def test_workspace_init_decodes_file_url_paths_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            workspace = root / "workspace"
+            source = root / "Base Workspace-雪-%20"
+            state_file = root / "basectl-calls"
+            home.mkdir()
+            base_home.mkdir()
+            workspace.mkdir()
+            source.mkdir()
+            write_workspace_manifest(source / "workspace.yaml")
+            write_fake_basectl(base_home, state_file)
+            source_url = source.as_uri()
+
+            status, stdout, stderr = invoke_engine(
+                [
+                    "init",
+                    source_url,
+                    "--workspace",
+                    str(workspace),
+                    "--dry-run",
+                ],
+                base_home,
+                home,
+            )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn(f"Workspace source: {source_url}", stdout)
+        self.assertIn(f"Workspace config repo: {source.resolve()}", stdout)
+        self.assertIn(f"Workspace manifest: {(source / 'workspace.yaml').resolve()} (demo-suite)", stdout)
+
+    def test_workspace_init_accepts_localhost_file_url_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            workspace = root / "workspace"
+            source = root / "base-workspace"
+            state_file = root / "basectl-calls"
+            home.mkdir()
+            base_home.mkdir()
+            workspace.mkdir()
+            source.mkdir()
+            write_workspace_manifest(source / "workspace.yaml")
+            write_fake_basectl(base_home, state_file)
+            source_url = source.as_uri().replace("file:///", "file://localhost/", 1)
+
+            status, stdout, stderr = invoke_engine(
+                ["init", source_url, "--workspace", str(workspace), "--dry-run"],
+                base_home,
+                home,
+            )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn(f"Workspace config repo: {source.resolve()}", stdout)
+
+    def test_workspace_init_rejects_remote_and_malformed_file_urls(self) -> None:
+        cases = (
+            (
+                "file://files.example.test/private/workspace",
+                "support only an empty or localhost authority",
+            ),
+            (
+                "file:///private/tmp/Base%2Workspace",
+                "malformed percent encoding",
+            ),
+        )
+        for source_url, expected_message in cases:
+            with self.subTest(source_url=source_url):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    root = Path(tmpdir)
+                    home = root / "home"
+                    base_home = root / "base"
+                    workspace = root / "workspace"
+                    home.mkdir()
+                    base_home.mkdir()
+                    workspace.mkdir()
+
+                    status, stdout, stderr = invoke_engine(
+                        ["init", source_url, "--workspace", str(workspace), "--dry-run"],
+                        base_home,
+                        home,
+                    )
+
+                self.assertEqual(status, 2)
+                self.assertEqual(stdout, "")
+                self.assertIn(expected_message, stderr)
+
     def test_workspace_init_writes_config_and_clones_repositories_under_workspace_root(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/cli/python/base_projects/tests/test_workspace_pull.py
+++ b/cli/python/base_projects/tests/test_workspace_pull.py
@@ -157,7 +157,7 @@ class WorkspacePullTests(unittest.TestCase):
             root = Path(tmpdir)
             home = root / "home"
             base_home = root / "base"
-            source = root / "canonical.yaml"
+            source = root / "Canonical Workspace-雪-%20.yaml"
             target = root / "workspace.yaml"
             home.mkdir()
             base_home.mkdir()
@@ -175,6 +175,63 @@ class WorkspacePullTests(unittest.TestCase):
         self.assertEqual(target_content, WORKSPACE_MANIFEST)
         self.assertIn(f"Source: {source.as_uri()}", stdout)
         self.assertIn("Status: created", stdout)
+
+    def test_workspace_pull_accepts_localhost_file_url_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            source = root / "canonical.yaml"
+            target = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            source.write_text(WORKSPACE_MANIFEST, encoding="utf-8")
+            source_url = source.as_uri().replace("file:///", "file://localhost/", 1)
+
+            status, stdout, stderr = invoke_engine(
+                ["pull", "--source", source_url, "--manifest", str(target)],
+                base_home,
+                home,
+            )
+            target_content = target.read_text(encoding="utf-8") if target.exists() else ""
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(target_content, WORKSPACE_MANIFEST)
+        self.assertIn(f"Source: {source_url}", stdout)
+
+    def test_workspace_pull_rejects_remote_and_malformed_file_urls(self) -> None:
+        cases = (
+            (
+                "file://files.example.test/private/workspace.yaml",
+                "support only an empty or localhost authority",
+            ),
+            (
+                "file:///private/tmp/Base%2Workspace.yaml",
+                "malformed percent encoding",
+            ),
+        )
+        for source_url, expected_message in cases:
+            with self.subTest(source_url=source_url):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    root = Path(tmpdir)
+                    home = root / "home"
+                    base_home = root / "base"
+                    target = root / "workspace.yaml"
+                    home.mkdir()
+                    base_home.mkdir()
+
+                    status, stdout, stderr = invoke_engine(
+                        ["pull", "--source", source_url, "--manifest", str(target)],
+                        base_home,
+                        home,
+                    )
+                    target_exists = target.exists()
+
+                self.assertEqual(status, 2)
+                self.assertEqual(stdout, "")
+                self.assertFalse(target_exists)
+                self.assertIn(expected_message, stderr)
 
     def test_workspace_pull_rejects_cleartext_http_source_before_fetching(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_projects/workspace_file_url.py
+++ b/cli/python/base_projects/workspace_file_url.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import unquote
+from urllib.parse import urlparse
+
+from base_projects.command_helpers import ProjectUsageError
+
+
+INVALID_PERCENT_ESCAPE_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
+LOCAL_FILE_URL_AUTHORITIES = frozenset(("", "localhost"))
+
+
+def resolve_workspace_file_url(source: str) -> Path:
+    try:
+        parsed = urlparse(source)
+    except ValueError as exc:
+        raise ProjectUsageError("Malformed workspace file URL.") from exc
+
+    if parsed.scheme.lower() != "file":
+        raise ProjectUsageError("Workspace source is not a file:// URL.")
+    if parsed.netloc.lower() not in LOCAL_FILE_URL_AUTHORITIES:
+        raise ProjectUsageError(
+            "Workspace file URLs support only an empty or localhost authority. "
+            "Use file:///absolute/path or file://localhost/absolute/path."
+        )
+    if parsed.params or parsed.query or parsed.fragment:
+        raise ProjectUsageError(
+            "Workspace file URLs cannot include parameters, a query, or a fragment. "
+            "Percent-encode those characters when they belong to the path."
+        )
+    if INVALID_PERCENT_ESCAPE_RE.search(parsed.path):
+        raise ProjectUsageError(
+            "Workspace file URL path contains malformed percent encoding. "
+            "Encode a literal percent sign as %25."
+        )
+
+    try:
+        decoded_path = unquote(parsed.path, encoding="utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise ProjectUsageError(
+            "Workspace file URL path contains invalid UTF-8 percent encoding."
+        ) from exc
+    if not decoded_path.startswith("/") or decoded_path.startswith("//"):
+        raise ProjectUsageError(
+            "Workspace file URL path must be an absolute local path. Use file:///absolute/path."
+        )
+    if "\x00" in decoded_path:
+        raise ProjectUsageError("Workspace file URL path cannot contain a NUL byte.")
+
+    return Path(decoded_path).expanduser().resolve(strict=False)

--- a/cli/python/base_projects/workspace_init.py
+++ b/cli/python/base_projects/workspace_init.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Protocol
-from urllib.parse import urlparse
 
 import base_cli
 from base_cli_adapters.config import load_user_config
@@ -15,6 +14,7 @@ from base_projects.command_helpers import github_repo_spec
 from base_projects.command_helpers import run_project_command
 from base_projects.command_helpers import write_project_command_output
 from base_projects.workspace_context import resolve_workspace_manifest
+from base_projects.workspace_file_url import resolve_workspace_file_url
 from base_projects.workspace_manifest import WorkspaceManifestError
 from base_projects.workspace_scanner import ProjectDiscoveryError
 
@@ -105,11 +105,10 @@ def resolve_workspace_init_source(
     owner: str | None,
 ) -> WorkspaceInitSource:
     source_path = Path(workspace_source).expanduser()
-    if workspace_source.startswith("file://"):
-        parsed = urlparse(workspace_source)
+    if workspace_source[:5].lower() == "file:":
         return WorkspaceInitSource(
             display=workspace_source,
-            local_path=Path(parsed.path).expanduser().resolve(strict=False),
+            local_path=resolve_workspace_file_url(workspace_source),
         )
     if is_workspace_init_path_source(workspace_source) or source_path.exists():
         return WorkspaceInitSource(

--- a/cli/python/base_projects/workspace_pull.py
+++ b/cli/python/base_projects/workspace_pull.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from urllib.parse import unquote, urlparse
+from urllib.parse import urlparse
 from urllib.request import HTTPRedirectHandler
 from urllib.request import Request
 from urllib.request import build_opener
@@ -12,6 +12,7 @@ from urllib.request import build_opener
 from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_manifest import WorkspaceManifestError
 from base_projects.workspace_manifest import read_workspace_manifest
+from base_projects.workspace_file_url import resolve_workspace_file_url
 
 
 MAX_WORKSPACE_MANIFEST_SOURCE_BYTES = 2 * 1024 * 1024
@@ -76,6 +77,10 @@ def workspace_manifest_change_status(existing_content: bytes | None, content: by
 
 
 def fetch_workspace_manifest_source(source: str) -> bytes:
+    if source[:5].lower() == "file:":
+        path = resolve_workspace_file_url(source)
+        return read_workspace_manifest_source_file(source, path)
+
     parsed = urlparse(source)
     if parsed.scheme == "http":
         raise WorkspaceManifestError(
@@ -100,11 +105,7 @@ def fetch_workspace_manifest_source(source: str) -> bytes:
         except OSError as exc:
             raise WorkspaceManifestError(f"Unable to fetch workspace manifest source '{source}': {exc}") from exc
 
-    if parsed.scheme == "file":
-        path = Path(unquote(parsed.path)).expanduser()
-        return read_workspace_manifest_source_file(source, path)
-
-    if parsed.scheme and parsed.scheme not in {"", "file"}:
+    if parsed.scheme:
         raise WorkspaceManifestError(
             f"Unsupported workspace manifest source '{source}'. Expected a local path, file:// URL, or https:// URL."
         )

--- a/docs/local-config.md
+++ b/docs/local-config.md
@@ -138,8 +138,10 @@ edit that value to make commands such as
 uses it as the canonical manifest source unless the command supplies
 `--source <url-or-path>`. Supported sources are local paths, `file://` URLs, and
 `https://` raw file URLs. Cleartext `http://` sources are rejected by default.
-Pull validates fetched content as a workspace manifest before updating
-`workspace.manifest`.
+Local file URLs decode percent-encoded UTF-8 paths exactly once and support only
+an empty or `localhost` authority; remote authorities and malformed escapes are
+rejected. Pull validates fetched content as a workspace manifest before
+updating `workspace.manifest`.
 
 `workspace.root` and `workspace.manifest` must be absolute paths or start with
 `~`. `workspace.manifest_source` must be a non-empty string when provided.

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -237,9 +237,11 @@ Teams can also configure a canonical manifest source in
 `workspace.manifest_source` and refresh the local manifest with the explicit
 `basectl workspace pull` command. Pull supports local paths, `file://` URLs,
 and raw `https://` file URLs; cleartext `http://` sources are rejected by
-default. Remote source fetching is therefore an explicit manifest-file update,
-not passive workspace discovery, and it does not clone, pull, reset, or rewrite
-project repositories.
+default. Local file URLs percent-decode the path exactly once, accept only an
+empty or `localhost` authority, and reject malformed escapes or remote
+authorities. Remote source fetching is therefore an explicit manifest-file
+update, not passive workspace discovery, and it does not clone, pull, reset, or
+rewrite project repositories.
 
 ### Update Existing Checkouts
 
@@ -390,9 +392,11 @@ basectl workspace init base-workspace --owner basefoundry --path ~/work/base-wor
 ```
 
 The positional argument is a workspace source, not the workspace name. The
-source can be a local path, a GitHub URL, `owner/repo`, or a short repository
-name resolved by `--owner <owner>` or `github.default_owner`. `--path` controls
-where the workspace configuration repository is checked out or read.
+source can be a local path or local `file://` URL, a GitHub URL, `owner/repo`,
+or a short repository name resolved by `--owner <owner>` or
+`github.default_owner`. Init uses the same one-time percent decoding and
+empty-or-`localhost` authority policy as workspace pull. `--path` controls where
+the workspace configuration repository is checked out or read.
 `--workspace` controls where member repositories are cloned. If neither
 `--workspace` nor configured `workspace.root` is available, init uses the parent
 of the workspace configuration repo path as the workspace root.


### PR DESCRIPTION
## Summary

- centralize local workspace `file://` parsing for init and pull
- percent-decode UTF-8 paths exactly once, preserving encoded literal percent signs through normalization
- accept only empty and `localhost` authorities and reject remote, malformed, ambiguous, query, fragment, relative, and NUL-bearing forms as usage errors

## Issue

Fixes #2008

## Validation

- all Base Projects tests (214 passed, 60 subtests passed)
- spaces, Unicode, literal percent, empty authority, localhost, remote authority, malformed escape, invalid UTF-8, query, fragment, relative path, ambiguous double-slash path, and NUL regressions
- actual public `basectl workspace init` and `workspace pull` resolved `Base%20Workspace-%E9%9B%AA-%2520` to `Base Workspace-雪-%20`
- actual public init and pull both rejected a remote file authority with the same actionable usage error and exit 2
- Pylint on all changed Python modules and tests
- `git diff --check`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python BASE_CACHE_DIR=/private/tmp/base-train-2008-full ./bin/base-test` (1,051 Python tests and 899 Bats tests passed)

## Security Notes

Remote authorities, userinfo, query/fragment components, ambiguous network-like paths, malformed escapes, invalid UTF-8, and decoded NUL bytes fail before filesystem access. Diagnostics do not echo rejected authority content.

## Docs Impact

Documents the shared local-file URL contract in workspace manifest and local configuration guidance; records the fix in the changelog.

## AI Context Impact

Updates `.ai-context/COMMANDS.md` with the shared parser and authority boundary.

## Demo Impact

None.
