### PR TITLE
docs: add README proof and comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![Lint](https://github.com/basefoundry/base/actions/workflows/pylint.yml/badge.svg)
 ![Platform: macOS + Ubuntu/Debian](https://img.shields.io/badge/platform-macOS%20%2B%20Ubuntu%2FDebian-lightgrey)
 ![Version](https://img.shields.io/badge/version-1.8.0-blue)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
 > Base is an AI-ready GitHub workspace control plane for repository setup, local
 > development, and verified pull requests.
@@ -51,6 +52,57 @@ running the exact `basectl trust allow base --manifest-sha256 ...` command it
 provides. This path lets you inspect and verify Base before adding it to shell
 startup files. See [Start Here](#start-here) for the demo walkthrough and install
 choices.
+
+## See Base Run
+
+The shortest proof is the real self-demo:
+
+```bash
+basectl demo base -- --non-interactive
+```
+
+This excerpt is from that manifest-declared run; local paths are shortened so
+the workflow is easy to scan:
+
+```text
+$ basectl demo base -- --non-interactive
+
+Base Self-Demo
+
+== Step 1: Runtime Contract ==
+
+BASE_PROJECT=base
+
+== Step 2: Manifest Contract ==
+
+11:demo:
+12:  script: ./demo/demo.sh
+
+== Step 4: Check And Doctor ==
+
+Base CLI environment and project 'base' check passed.
+Base doctor found no blocking issues for project 'base'.
+
+== Step 6: Run And Test Delegation ==
+
+[DRY-RUN] Would run command test for project base: ./bin/base-test
+[DRY-RUN] Would run tests for project base: ./bin/base-test
+
+Base self-demo complete.
+```
+
+[Play the full asciinema-compatible capture](docs/assets/base-self-demo.cast).
+
+### Tool Comparison
+
+| Tool | Primary responsibility | Base relationship |
+|---|---|---|
+| Base | Repository contracts, readiness, trust, onboarding, and handoff | Owns the local operating contract across participating repositories |
+| [mise](docs/tool-boundaries.md) | Machine and project bootstrap, tool versions, environments, and tasks | Base delegates; choose mise when convergence is the primary outcome |
+| [mani](docs/tool-boundaries.md) | Git repository inventory, synchronization, worktrees, filters, and tasks | Base coexists; choose mani when repository-set management is the primary need |
+
+See [Tool Boundaries](docs/tool-boundaries.md) for the maintained comparison,
+including where Base should delegate, integrate, or stay out of the way.
 
 ## Contents
 

--- a/docs/assets/base-self-demo.cast
+++ b/docs/assets/base-self-demo.cast
@@ -1,0 +1,9 @@
+{"version":2,"width":100,"height":30,"timestamp":1788250088,"env":{"SHELL":"/bin/bash","TERM":"xterm-256color"}}
+[0.2,"o","$ ./bin/basectl demo base -- --non-interactive\r\n"]
+[0.4,"o","\r\nBase Self-Demo\r\n\r\nThis walkthrough exercises the current Base project workflow using the Base repo itself.\r\nIt is intentionally local, inspectable, and safe to run repeatedly.\r\n"]
+[0.7,"o","\r\n== Step 1: Runtime Contract ==\r\n\r\nBASE_PROJECT=base\r\n"]
+[1.0,"o","\r\n== Step 2: Manifest Contract ==\r\n\r\nBase declares its test and demo contracts in base_manifest.yaml.\r\n\r\n11:demo:\r\n12:  script: ./demo/demo.sh\r\n"]
+[1.4,"o","\r\n== Step 3: Project Discovery ==\r\n\r\nbase\t<workspace>/base\r\nbase-demo\t<workspace>/base-demo\r\n"]
+[1.8,"o","\r\n== Step 4: Check And Doctor ==\r\n\r\nBase CLI environment and project 'base' check passed.\r\nBase doctor found no blocking issues for project 'base'.\r\n"]
+[2.3,"o","\r\n== Step 5: Base Wrapper ==\r\n\r\nbase\t<workspace>/base\t<workspace>/base/base_manifest.yaml\t...\r\n"]
+[2.7,"o","\r\n== Step 6: Run And Test Delegation ==\r\n\r\n[DRY-RUN] Would run command test for project base: ./bin/base-test\r\n[DRY-RUN] Would run tests for project base: ./bin/base-test\r\n\r\nBase self-demo complete.\r\n"]


### PR DESCRIPTION
## Summary

Add a visible self-demo proof, an asciinema-compatible terminal capture, a compact Base/mise/mani comparison, and a current Apache-2.0 badge near the README top.

## Issue

Fixes #2026

## Validation

- `git diff --check`
- `jq` validation of `docs/assets/base-self-demo.cast` as asciinema v2 JSONL
- focused documentation and contract tests: 23 passed
- README version-badge BATS check: passed
- verified the transcript sequence and output against a real Base self-demo run, with local paths shortened in the committed artifact

## Docs Impact

The existing historical license-transition note remains in place near the License section. The detailed tool-boundary reference remains the source of truth for the comparison.