### PR TITLE
docs: clarify Homebrew rehearsal scope

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -95,7 +95,8 @@ reference. The filename should answer "what is this about?"
 - [Release Process](release-process.md) defines the Base release ceremony,
   version-file policy, GitHub Release flow, and Homebrew tap follow-up.
 - [Homebrew Upgrade Rehearsal](homebrew-upgrade-rehearsal.md) defines the
-  pre-1.0.0 consumer upgrade proof and records rehearsal results.
+  durable consumer upgrade rehearsal for every release, with pre-1.0 rehearsal
+  records preserved as historical reference.
 - [Testing](testing.md) explains Base's Python, BATS, and hermetic integration
   test layers.
 - [Base Contracts](contracts.md) maps documented behavior contracts to their


### PR DESCRIPTION
## Summary

Correct the documentation map so the Homebrew upgrade rehearsal is described as an ongoing checklist for every release, while preserving pre-1.0 rehearsal records as historical reference.

## Issue

Fixes #2039

## Validation

- `git diff --check`
- Shared documentation test set — 25 passed
- Verified the map wording against `docs/homebrew-upgrade-rehearsal.md`

## Docs Impact

No rehearsal steps changed; only the documentation-map scope description was corrected.