### PR TITLE
docs: refresh AI context shipped guardrails

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -143,11 +143,20 @@ the v1.x compatibility window; new automation should use `--debug-wrapper`.
     Project coordinates it reports a partial result.
   - `basectl gh issue start <number>` resolves issue metadata from an explicit
     `--repo`/`-R` selector, then `GH_REPO`, then the origin remote.
+  - `basectl gh auth status` inspects stored GitHub authentication state
+    without displaying token values; `basectl gh auth refresh` refreshes the
+    stored credential and can request repeatable OAuth scopes.
   - `basectl gh pr create` auto-injects `Fixes #<issue>` from Base branch
     names and fails before PR creation when the prefix disagrees with the
     issue's single category label; pass `--no-fixes` to suppress only that body injection. When
     `base_manifest.yaml` declares `github.pr`, it renders the PR body from
     that project policy.
+  - `basectl gh branch prune` previews safe merged-branch cleanup by default;
+    pass `--closed-unmerged` to include branches whose pull requests were
+    closed without merging.
+  - `basectl gh worktree prune` previews safe merged-worktree cleanup by
+    default; pass `--closed-unmerged` to include clean worktrees tied to
+    closed, unmerged pull requests.
   - `basectl gh project doctor --project <title>` - inspect Project metadata
     fields against the Base Project schema.
   - `basectl gh project configure --project <title>` - create or repair the

--- a/.ai-context/PROJECT.md
+++ b/.ai-context/PROJECT.md
@@ -71,6 +71,19 @@ provide deeper evidence. The issue-oriented bundle in #1562 remains planned;
 Base does not yet package issue, branch, history, diagnostics, and context into
 one artifact.
 
+## Recent Shipped Guardrails
+
+- Repository secret scanning and provider push protection are enforced, with a
+  checksum-pinned Gitleaks history scan for generic patterns.
+- Project-originated IDE mutations require explicit
+  `--allow-project-ide-mutations` consent; `--yes` alone does not authorize
+  those changes.
+- `basectl gh branch prune` and `basectl gh worktree prune` support opt-in
+  `--closed-unmerged` handling for clean branches and worktrees tied to closed,
+  unmerged pull requests.
+- `basectl workspace status --format json` exposes a top-level aggregate status
+  using the existing `error`, `warn`, and `ok` precedence.
+
 ## Peer Projects
 
 - `banyanlabs` - a realistic platform engineering learning environment that

--- a/.ai-context/STATUS.md
+++ b/.ai-context/STATUS.md
@@ -50,6 +50,19 @@ The current command surface covers:
   setup
 - Ubuntu/Debian runtime checks, diagnostics, and source-checkout validation
 
+Recent trust and workspace updates are part of the current implementation:
+
+- repository secret scanning and provider push protection are enforced, with a
+  checksum-pinned Gitleaks history scan covering generic patterns
+- project-originated IDE mutations require explicit
+  `--allow-project-ide-mutations` consent; `--yes` alone does not authorize
+  those changes
+- `basectl gh branch prune` and `basectl gh worktree prune` accept opt-in
+  `--closed-unmerged` handling for clean branches and worktrees tied to closed,
+  unmerged pull requests
+- `basectl workspace status --format json` includes a top-level aggregate
+  status using the existing `error`, `warn`, and `ok` precedence
+
 ## Active Development Direction
 
 The `v1.8.0` release is complete. Future work is tracked in GitHub Issues,
@@ -134,6 +147,8 @@ Recent commits on `main` include:
 - documented `base-bash-libs` consumption and post-migration contract
 - formula-name Homebrew audit guidance for Base and `base-bash-libs`
 - setup parallelism evaluation with a conservative setup-plan-first decision
+- repository secret scanning, project IDE-mutation consent, closed-unmerged
+  branch/worktree cleanup, and aggregate workspace status JSON
 
 ## Useful Orientation Links
 


### PR DESCRIPTION
## Summary

Refresh `.ai-context/STATUS.md` and `.ai-context/PROJECT.md` with shipped secret-scanning, IDE-mutation consent, closed-unmerged cleanup, and aggregate workspace-status behavior, and add the missing `basectl gh` auth/branch/worktree commands to `.ai-context/COMMANDS.md`.

## Issue

Fixes #2042

## Validation

- `git diff --check`
- Shared documentation test set — 25 passed
- Verified all four guardrail topics appear in both status/context files
- Verified the three missing `basectl gh` command areas appear in `COMMANDS.md`

## Docs Impact

No command behavior changed; the exported agent context now reflects shipped capabilities and guardrails.