### PR TITLE
docs: align artifact registry example

### DIFF
--- a/docs/artifact-adapter-registry.md
+++ b/docs/artifact-adapter-registry.md
@@ -89,7 +89,6 @@ artifacts:
     version_policy: requested
     check:
       kind: python_import
-      module: pytest
 
   - type: tool
     name: kubectl
@@ -112,8 +111,9 @@ class ArtifactDefinition:
     manager: str
     package: str
     target: str
-    version_policy: str
-    registry_source: str
+    version_policy: str = ""
+    check_kind: str = ""
+    registry_source: str = ""
 ```
 
 `get_artifact_definition(type, name)` should continue to return one


### PR DESCRIPTION
## Summary

Align the Phase 1 artifact-registry example with the shipped validator and `ArtifactDefinition` dataclass by removing the unsupported `module` key and documenting the load-bearing `check_kind` field and defaults.

## Issue

Fixes #2041

## Validation

- `git diff --check`
- Shared documentation test set — 25 passed
- Verified the example against `registry.py` and `artifacts.py`

## Docs Impact

No registry or runtime behavior changed; the documentation now reflects the supported schema.