### PR TITLE
refactor(history): remove obsolete child log selector

### DIFF
--- a/cli/python/base_history/record.py
+++ b/cli/python/base_history/record.py
@@ -7,12 +7,7 @@ import os
 from datetime import datetime, timezone
 
 import base_cli
-from base_cli_adapters.history import HISTORY_PATH
-from base_cli_adapters.history import optional_int
-from base_cli_adapters.history import optional_string
-from base_cli_adapters.history import parse_finished_history_record_line
 from base_cli_adapters.history import utc_now
-from base_cli_adapters.paths import base_cache_root
 from base_cli_adapters.history import write_primary_record
 
 
@@ -59,36 +54,6 @@ def parse_timestamp(value: str) -> datetime:
         return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
     except ValueError as exc:
         raise SystemExit(f"Invalid --started-at timestamp: {value}") from exc
-
-
-def child_log_path(run_id: str, exit_code: int) -> str | None:
-    history_path = base_cache_root() / HISTORY_PATH
-    if not history_path.is_file():
-        return None
-
-    candidates: list[tuple[int, str, str]] = []
-    try:
-        with history_path.open("r", encoding="utf-8", errors="replace") as handle:
-            for line in handle:
-                payload = parse_finished_history_record_line(line)
-                if payload is None or payload.get("parent_run_id") != run_id:
-                    continue
-                log_path = optional_string(payload.get("log_path"))
-                if log_path is None:
-                    continue
-                child_exit_code = optional_int(payload.get("exit_code"))
-                failed = payload.get("status") == "error" or (child_exit_code is not None and child_exit_code != 0)
-                candidates.append((int(failed), optional_string(payload.get("ended_at")) or "", log_path))
-    except OSError:
-        return None
-
-    if not candidates:
-        return None
-    failed_candidates = [candidate for candidate in candidates if candidate[0]]
-    selected = max(failed_candidates or candidates, key=lambda candidate: candidate[:2])
-    if exit_code == 0 and selected[0]:
-        selected = max(candidates, key=lambda candidate: candidate[1])
-    return selected[2]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Remove the uncalled `child_log_path()` legacy selector from `base_history.record`.
- Remove its five now-unused history/cache parsing imports.
- Preserve owner-aware primary history writes with `log_path=None`.

The focused module now reports 95% coverage without counting the obsolete 26-line, 13-branch selector.

## Issue

Fixes #2052

## Validation

- Repository search confirms no remaining `child_log_path` reference in `base_history.record`
- Focused history suite (23 passed, 2 subtests)
- Pylint on `base_history.record`
- Full Python coverage suite and ratchet (1,115 passed, 327 subtests; 90.42% statements, 80.50% branches, 87.98% combined)
- `./bin/base-test` with supported sibling source overrides (1,115 Python tests, 327 subtests, and 899 BATS tests passed)

## Demo Impact

None. Internal dead-code cleanup; no user-facing behavior changes.

## Notes

Documentation and AI context are not applicable because the removed helper had no callers and the current history contract is unchanged.

## Checklist

- [x] Branch name follows `<category>/<issue>-<YYYYMMDD>-<slug>`, and the prefix matches the issue's single standard category label.
- [x] PR is scoped to one issue, unless a documented multi-issue exception applies.
- [x] PR body explains what changed and how it was validated.
- [x] Validation commands were run from the current checkout or worktree, or unavailable checks are explained.
- [x] Relevant BATS and Python tests pass.
- [x] Bug fixes include regression proof or a documented reproduction when practical.
- [x] Documentation is updated when behavior or user-facing commands change.
- [x] AI context is updated in `.ai-context/`, or the PR body explains why it is not applicable.
- [x] PR includes `Fixes #<issue>` or `Closes #<issue>` when it should close the issue.
- [x] `Demo Impact` is meaningful for `needs-demo` work, or explicitly says `None.`
