### PR TITLE
docs: align execution model commands with help (#2062)

### DIFF
--- a/docs/execution-model.md
+++ b/docs/execution-model.md
@@ -174,14 +174,18 @@ list is `basectl --help`; this list summarizes the shipped public surface:
 - `activate`
 - `test`
 - `build`
-- `base_std_run`
+- `run`
 - `demo`
+- `trust`
+- `ci` (deprecated compatibility alias)
 - `repo`
 - `release`
 - `logs`
 - `history`
 - `docs`
 - `export-context`
+- `devcontainer`
+- `devenv-report`
 - `prompt`
 - `workspace`
 - `onboard`


### PR DESCRIPTION
Fixes #2062. Replaces the phantom base_std_run entry with run and documents trust, deprecated ci, devcontainer, and devenv-report in the execution-model command list. Validation: git diff --check and current basectl --help parity review.