### PR TITLE
docs: repair command reference inventory (#2061)

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ The top-level public command inventory remains visible here:
 - `basectl demo [project]`
 - `basectl run [project] <command>`
 - `basectl export-context [project]`
+- `basectl logs [options]`
 - `basectl devcontainer [project]`
 - `basectl devenv-report [project]`
 - `basectl docs`

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -257,8 +257,6 @@ daily project loop commands from the local checkout.
 
 ## Detailed Product Layers And Shipped Commands
 
-+## Product Layers And Shipped Commands
-
 > **Deep reference:** This section is intentionally skippable on a first read.
 > It preserves the detailed command and runtime reference for contributors and
 > evaluators; start with [Quickstart](../README.md#quickstart), then use the focused
@@ -310,6 +308,7 @@ Current implemented commands include:
 - `basectl demo [project]`
 - `basectl run [project] <command>`
 - `basectl export-context [project]`
+- `basectl logs [options]`
 - `basectl devcontainer [project]`
 - `basectl devenv-report [project]`
 - `basectl docs`


### PR DESCRIPTION
Fixes #2061. Removes the stray diff marker from the command-reference heading and adds basectl logs to both command inventory lists. Validation: git diff --check.