### PR TITLE
docs: remove unsupported temp retention setting (#2066)

### DIFF
--- a/docs/base-cli.md
+++ b/docs/base-cli.md
@@ -337,7 +337,6 @@ Standard environment variables:
 | `BASE_CLI_ENVIRONMENT` | active environment | `dev` |
 | `BASE_CLI_LOG_LEVEL` | user stream log level | `info` |
 | `BASE_CLI_KEEP_TEMP` | keep run temp directory | `false` |
-| `BASE_CLI_TEMP_RETENTION_DAYS` | prune retained temp dirs older than N days | `7` |
 
 ### Future Organization Policy
 

--- a/docs/local-config.md
+++ b/docs/local-config.md
@@ -98,7 +98,6 @@ Recognized environment variables include:
 - `BASE_CLI_ENVIRONMENT`
 - `BASE_CLI_LOG_LEVEL`
 - `BASE_CLI_KEEP_TEMP`
-- `BASE_CLI_TEMP_RETENTION_DAYS`
 
 `BASE_CACHE_DIR` separately controls the runtime cache/log/temp root; it is not
 stored in the user config.

--- a/docs/runtime-environment.md
+++ b/docs/runtime-environment.md
@@ -204,7 +204,6 @@ readonly by Base.
 | `BASE_CLI_ENVIRONMENT` | Python CLI config | Selects the CLI environment value used by `base_cli`. |
 | `BASE_CLI_LOG_LEVEL` | Python CLI config | Sets the Python CLI user-stream log level. |
 | `BASE_CLI_KEEP_TEMP` | Python CLI config | Keeps temp directories for inspection when true. |
-| `BASE_CLI_TEMP_RETENTION_DAYS` | Python CLI config | Retention window for pruned temp directories. |
 | `BASE_ACTIVATE_SHELL` | `basectl activate` | Overrides the Bash executable used for the activated runtime shell. |
 | `BASE_ACTIVATE_PRESERVE_CWD` | `basectl activate` | Test/user override equivalent to `--no-cd` when set to `1`. |
 | `BASE_SETUP_PROFILES` | `basectl setup` | Comma-separated setup profiles such as `dev,sre`. |


### PR DESCRIPTION
Fixes #2066. Removes the nonexistent BASE_CLI_TEMP_RETENTION_DAYS setting from all three configuration references, including the base-cli reference table. Validation: git diff --check and repository-wide docs search.