### PR TITLE
docs: correct profile checks example (#2064)

### DIFF
--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -72,7 +72,6 @@ Check commands that return an object include an aggregate `status` and a
 {
   "schema_version": 1,
   "status": "ok",
-  "profiles": [],
   "checks": []
 }
 ```

--- a/tests/test_doctor_findings_docs.py
+++ b/tests/test_doctor_findings_docs.py
@@ -15,12 +15,11 @@ def json_examples() -> list[dict]:
     return examples
 
 
-def test_top_level_diagnostic_json_example_includes_profiles() -> None:
+def test_top_level_diagnostic_json_example_omits_profiles_without_profile_option() -> None:
     example = json_examples()[0]
 
     assert example == {
         "schema_version": 1,
         "status": "ok",
-        "profiles": [],
         "checks": [],
     }


### PR DESCRIPTION
Fixes #2064. Makes the no-profile check JSON example match the actual payload by removing the nonexistent profiles key and updates its contract test. Validation: tests/test_doctor_findings_docs.py (1 passed).