### PR TITLE
fix(runtime): preserve inherited run bundle ownership

### DIFF
--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -718,6 +718,11 @@ basectl_finalize_run_bundle() {
         base_std_log_warn "Skipping finalization for an invalid Base run context."
         return 1
     fi
+    # Only the invocation that created the bundle owns its finalization.
+    # Inherited Base children reuse the parent bundle for logs and history but
+    # must not close it while the parent command is still running.
+    [[ "${_basectl_run_bundle_created:-0}" == 1 ]] || return 0
+
     tmp_file="$(mktemp "$run_root/.run.json.XXXXXX")" || return 1
     printf '{"run_id":"%s","owner":"base","status":"%s","exit_code":%s,"started_at":"%s","ended_at":"%s"}\n' \
         "${BASE_CLI_RUN_ID:-$(basename -- "$run_root")}" \

--- a/cli/bash/commands/basectl/tests/runtime-dispatch.bats
+++ b/cli/bash/commands/basectl/tests/runtime-dispatch.bats
@@ -206,7 +206,7 @@ load ./basectl_helpers.bash
 }
 
 
-@test "basectl reuses a validated internal run bundle" {
+@test "basectl reuses a validated internal run bundle without finalizing it" {
     local cache_root="$TEST_TMPDIR/cache"
     local inherited_root="$cache_root/base/runs/parent-run__setup"
 
@@ -235,8 +235,8 @@ load ./basectl_helpers.bash
     [ "$status" -eq 0 ]
     [[ "$output" != *"Ignoring invalid inherited Base run context"* ]]
     grep -Fq '"run_id":"parent-run"' "$inherited_root/run.json"
-    grep -Fq '"status":"ok"' "$inherited_root/run.json"
-    [ ! -e "$inherited_root/tmp" ]
+    grep -Fq '"status":"running"' "$inherited_root/run.json"
+    [ -f "$inherited_root/tmp/private/proof.txt" ]
     [ "$(find "$cache_root/base/runs" -mindepth 1 -maxdepth 1 -type d | wc -l)" -eq 1 ]
 }
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -131,7 +131,9 @@ An inherited run bundle is reused only when its physical path is a non-symlink
 direct child of the active Base cache owner root and its owner, run ID, parent
 ID, primary log, and running metadata agree. Invalid inherited state is scrubbed
 without echoing its values, and the invocation receives a fresh local bundle.
-The same boundary is checked again before finalization.
+The same boundary is checked again before finalization. Only the invocation that
+created a bundle finalizes its metadata and removes its temporary directory;
+inherited Base children reuse the parent bundle without closing it.
 
 Fields should be omitted when unknown instead of guessed.
 


### PR DESCRIPTION
## Summary

Prevent delegated Base child invocations from finalizing an inherited parent run bundle. This removes repeated invalid-context warnings during workspace fan-out while preserving shared logging and history ownership.

## Issue

Fixes #2069

## Validation

- `bats cli/bash/commands/basectl/tests/runtime-dispatch.bats` — 40 passed
- `bats cli/bash/commands/basectl/tests/workspace.bats` — 15 passed
- `BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python PYTHONPATH=/Users/rameshhp/work/base-cli/lib/python:lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest cli/python/base_projects/tests/test_workspace_clone.py -q` — 5 passed
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python BASE_CACHE_DIR=/private/tmp/base-test-run-bundle-2069 ./bin/base-test` — 1115 Python and 899 BATS passed
- ShellCheck and `git diff --check` passed

## Demo Impact

None.

## Notes

Only the invocation that creates a run bundle finalizes it. Inherited children validate the bundle but leave its lifecycle to the parent. No workspace clone, manifest, authentication, or GitHub API semantics change.