### PR TITLE
fix(runtime): keep inherited history parent-owned

### DIFF
--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -952,7 +952,13 @@ basectl_main() {
             }
         else
             if basectl_finalize_run_bundle "$command_status"; then
-                basectl_history_record "$command" "$command_status" "$history_scope" "${history_args[@]}"
+                # Only the invocation that owns the bundle writes its
+                # completion record. Inherited Base children share the
+                # parent's log and lifecycle; recording them with the parent
+                # bundle would mark it complete before the parent returns.
+                if [[ "${_basectl_run_bundle_created:-0}" == 1 ]]; then
+                    basectl_history_record "$command" "$command_status" "$history_scope" "${history_args[@]}"
+                fi
             else
                 basectl_scrub_inherited_run_context
             fi

--- a/cli/bash/commands/basectl/tests/runtime-dispatch.bats
+++ b/cli/bash/commands/basectl/tests/runtime-dispatch.bats
@@ -206,7 +206,7 @@ load ./basectl_helpers.bash
 }
 
 
-@test "basectl reuses a validated internal run bundle without finalizing it" {
+@test "basectl reuses a validated internal run bundle without finalizing or recording it" {
     local cache_root="$TEST_TMPDIR/cache"
     local inherited_root="$cache_root/base/runs/parent-run__setup"
 
@@ -224,11 +224,12 @@ load ./basectl_helpers.bash
         BASE_BASH_LIBS_PRIMARY_LOG="$inherited_root/logs/primary.log" \
         BASE_CLI_HISTORY_PARENT_RUN_ID=parent-run \
         BASE_CLI_HISTORY_SCOPE=internal \
+        BASE_TEST_STATE_DIR="$TEST_STATE_DIR" \
         bash -c '
             source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
             base_std_log_debug() { :; }
             basectl_do_setup() { return 0; }
-            basectl_history_record() { :; }
+            basectl_history_record() { touch "$BASE_TEST_STATE_DIR/history-recorded"; }
             basectl_main setup
         '
 
@@ -237,6 +238,7 @@ load ./basectl_helpers.bash
     grep -Fq '"run_id":"parent-run"' "$inherited_root/run.json"
     grep -Fq '"status":"running"' "$inherited_root/run.json"
     [ -f "$inherited_root/tmp/private/proof.txt" ]
+    [ ! -e "$TEST_STATE_DIR/history-recorded" ]
     [ "$(find "$cache_root/base/runs" -mindepth 1 -maxdepth 1 -type d | wc -l)" -eq 1 ]
 }
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -124,8 +124,10 @@ A history record should include:
 ```
 
 Primary records use `scope: "primary"` and represent the command the user
-invoked. Delegated records use `scope: "internal"` and carry that invocation's
-`run_id` in `parent_run_id`.
+invoked. Inherited Base children do not write separate completion records;
+their delegated output remains in the parent's primary log and their lifecycle
+remains owned by the parent invocation. Legacy `scope: "internal"` records may
+still exist in older history indexes and are ignored by public history views.
 
 An inherited run bundle is reused only when its physical path is a non-symlink
 direct child of the active Base cache owner root and its owner, run ID, parent


### PR DESCRIPTION
## Summary

- Keep completion history ownership with the invocation that created the run bundle.
- Prevent inherited Base children from marking the parent bundle complete.
- Clarify the delegated-history contract and add regression coverage.

## Issue

Fixes #2083

Follow-up to #2080.

## Validation

- `bats --print-output-on-failure cli/bash/commands/basectl/tests/runtime-dispatch.bats` — 40 passed
- `bats --print-output-on-failure cli/bash/commands/basectl/tests/workspace.bats` — 15 passed
- Workspace clone tests — 5 passed
- Real workspace dry-run fan-out — 0 inherited-context warnings, 1 primary history row, 1 run bundle
- `./bin/base-test` — 1,115 Python and 899 BATS passed
- ShellCheck and `git diff --check` passed

## Docs Impact

Updated `docs/observability.md` to document that inherited Base children do not write separate completion records or mutate the parent lifecycle.

Workspace clone semantics and repository materialization behavior are unchanged.