### PR TITLE
Fix Base self-demo to use the owning runtime

### DIFF
--- a/cli/bash/commands/basectl/tests/demo.bats
+++ b/cli/bash/commands/basectl/tests/demo.bats
@@ -297,12 +297,40 @@ EOF
     [ -x "$BASE_REPO_ROOT/demo/demo.sh" ]
 }
 
+@test "Base self-demo defaults nested commands to its own Base home" {
+    local fake_bin="$TEST_TMPDIR/fake-bin"
+    local bash_bin_dir
+
+    mkdir -p "$fake_bin"
+    bash_bin_dir="$(dirname "$(command -v bash)")"
+    cat > "$fake_bin/basectl" <<'EOF'
+#!/usr/bin/env bash
+printf 'unexpected PATH basectl invocation\n' >&2
+exit 1
+EOF
+    chmod +x "$fake_bin/basectl"
+
+    run env \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_BASH_LIBS_DIR="${BASE_BASH_LIBS_DIR:-}" \
+        PATH="$bash_bin_dir:$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        bash -c '
+            source "$BASE_HOME/demo/demo.sh"
+            printf "%s\n%s\n" "$BASE_DEMO_BASECTL" "$BASE_DEMO_BASE_WRAPPER"
+        '
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$(printf '%s\n%s' "$BASE_REPO_ROOT/bin/basectl" "$BASE_REPO_ROOT/bin/base-wrapper")" ]
+}
+
 @test "basectl demo base runs the self-demo in non-interactive mode" {
     local python_bin="$TEST_HOME/.base.d/base/.venv/bin/python"
     local fake_bin="$TEST_TMPDIR/fake-bin"
     local state_file="$TEST_TMPDIR/self-demo-state"
+    local bash_bin_dir
 
     mkdir -p "$(dirname "$python_bin")" "$TEST_HOME/.base.d/base/.venv/bin" "$fake_bin"
+    bash_bin_dir="$(dirname "$(command -v bash)")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "base" ]]; then
@@ -353,7 +381,7 @@ EOF
 
     run env \
         HOME="$TEST_HOME" \
-        PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+        PATH="$bash_bin_dir:$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
         BASE_REPO_ROOT="$BASE_REPO_ROOT" \
         BASE_TEST_SELF_DEMO_STATE="$state_file" \
         BASE_DEMO_BASECTL="$fake_bin/basectl" \

--- a/demo/demo.sh
+++ b/demo/demo.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env basectl
+#!/usr/bin/env bash
 # shellcheck shell=bash
 
 if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
@@ -34,8 +34,8 @@ source "$BASE_HOME/base_init.sh" || {
     exit 1
 }
 
-BASE_DEMO_BASECTL="${BASE_DEMO_BASECTL:-basectl}"
-BASE_DEMO_BASE_WRAPPER="${BASE_DEMO_BASE_WRAPPER:-base-wrapper}"
+BASE_DEMO_BASECTL="${BASE_DEMO_BASECTL:-$BASE_HOME/bin/basectl}"
+BASE_DEMO_BASE_WRAPPER="${BASE_DEMO_BASE_WRAPPER:-$BASE_HOME/bin/base-wrapper}"
 BASE_DEMO_NON_INTERACTIVE=0
 
 base_demo_usage() {


### PR DESCRIPTION
## Summary

- run the Base self-demo through the checked-out runtime that owns the script
- keep explicit test overrides available for hermetic fixtures
- add regression coverage for PATH shadowing by an incompatible basectl

## Issue

Fixes #2081

## Validation

- `BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash bats cli/bash/commands/basectl/tests/demo.bats` (12 passed)
- `shellcheck demo/demo.sh`
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python BASE_CACHE_DIR=/private/tmp/base-pr-train-2081 ./bin/base-test` (1,115 pytest tests and 900 BATS tests passed)
- `git diff --check`
- `basectl demo base --dry-run -- --non-interactive`

## Demo Impact

The documented self-demo now resolves nested `basectl` and `base-wrapper` calls from the same Base checkout as `demo/demo.sh`, so an incompatible global `basectl` cannot intercept the run. Explicit `BASE_DEMO_BASECTL` and `BASE_DEMO_BASE_WRAPPER` overrides remain available to tests and integrators.

## Notes

The real demo remains trust-gated by the existing manifest approval boundary; validation did not persist a user-owned trust grant. `.ai-context/` is unchanged because the public command shape and product architecture are unchanged.