### PR TITLE
feat(workspace): summarize clone results

### DIFF
--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -260,7 +260,10 @@ such command directories exist. Optional utility CLIs such as `caff` and
   configured or explicit workspace manifest by delegating to `basectl repo clone`.
   Optional repositories are reported but skipped unless `--include-optional` is
   supplied, `--dry-run` previews the delegated clone work, and explicit
-  `--manifest <path>` takes precedence over `workspace.manifest`.
+  `--manifest <path>` takes precedence over `workspace.manifest`. Interactive
+  output uses a repository/action/result table with present, cloned, skipped,
+  planned, and failed results plus aggregate counts; successful delegated output
+  is suppressed and failure details remain visible.
 - `basectl workspace init <workspace-source>` bootstraps a workspace from a
   workspace configuration repository. The source may be a local path, GitHub URL,
   `owner/repo`, or a short repository name resolved by `--owner <owner>` or

--- a/cli/python/base_projects/tests/test_workspace_clone.py
+++ b/cli/python/base_projects/tests/test_workspace_clone.py
@@ -78,6 +78,11 @@ def invoke_engine(
     return status, stdout.getvalue(), stderr.getvalue()
 
 
+def workspace_clone_row(stdout: str, repo_name: str) -> list[str]:
+    line = next(line for line in stdout.splitlines() if line.startswith(repo_name))
+    return line.split()
+
+
 class WorkspaceCloneTests(unittest.TestCase):
     def test_workspace_clone_dry_run_materializes_missing_required_repositories(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -124,12 +129,17 @@ repos:
 
             self.assertEqual(status, 0)
             self.assertEqual(stderr, "")
-            self.assertIn(f"Workspace clone: {workspace.resolve()} (4 repositories)", stdout)
+            self.assertIn(f"Workspace clone: {workspace.resolve()} (4 manifest repos)", stdout)
             self.assertIn(f"Workspace manifest: {manifest_path.resolve()} (demo-suite)", stdout)
-            self.assertIn(f"CHECK required repository 'base' at '{(workspace / 'base').resolve()}'.", stdout)
-            self.assertIn(f"CLONE required repository 'api' into '{(workspace / 'api').resolve()}'.", stdout)
-            self.assertIn(f"CLONE required repository 'docs' into '{(workspace / 'docs').resolve()}'.", stdout)
-            self.assertIn("SKIP optional repository 'optional-tool' is missing", stdout)
+            self.assertIn("REPOSITORY     ACTION  RESULT", stdout)
+            self.assertIn("base           CHECK   planned", stdout)
+            self.assertIn("api            CLONE   planned", stdout)
+            self.assertIn("docs           CLONE   planned", stdout)
+            self.assertIn("optional-tool  SKIP    skipped", stdout)
+            self.assertIn("pass --include-optional to clone it", stdout)
+            self.assertIn("Workspace clone plan complete: planned=3 skipped=1 failed=0.", stdout)
+            self.assertIn("[DRY-RUN] No repositories were modified.", stdout)
+            self.assertNotIn("fake basectl", stdout)
             self.assertEqual(
                 state_file.read_text(encoding="utf-8").splitlines(),
                 [
@@ -151,6 +161,7 @@ repos:
             home.mkdir()
             base_home.mkdir()
             workspace.mkdir()
+            (workspace / "api").mkdir()
             write_fake_basectl(base_home, state_file)
             write_workspace_manifest(
                 manifest_path,
@@ -183,15 +194,19 @@ repos:
             )
 
             self.assertEqual(status, 1)
-            self.assertIn("Clone failed for repository 'conflict'.", stderr)
-            self.assertIn("simulated clone conflict for codeforester/conflict", stderr)
-            self.assertIn(f"CLONE required repository 'conflict' into '{(workspace / 'conflict').resolve()}'.", stdout)
-            self.assertIn(f"CLONE required repository 'api' into '{(workspace / 'api').resolve()}'.", stdout)
-            self.assertIn(
-                f"CLONE optional repository 'optional-tool' into '{(workspace / 'optional-tool').resolve()}'.",
-                stdout,
+            self.assertEqual(stderr, "")
+            self.assertEqual(
+                workspace_clone_row(stdout, "conflict"),
+                ["conflict", "CLONE", "failed", "(exit", "1)"],
             )
-            self.assertIn("Workspace clone completed with 1 error(s).", stdout)
+            self.assertIn("simulated clone conflict for codeforester/conflict", stdout)
+            self.assertEqual(workspace_clone_row(stdout, "api"), ["api", "CHECK", "present"])
+            self.assertEqual(
+                workspace_clone_row(stdout, "optional-tool"),
+                ["optional-tool", "CLONE", "cloned"],
+            )
+            self.assertIn("Workspace clone completed: present=1 cloned=1 skipped=0 failed=1.", stdout)
+            self.assertNotIn("fake basectl", stdout)
             self.assertEqual(
                 state_file.read_text(encoding="utf-8").splitlines(),
                 [
@@ -237,6 +252,8 @@ repos:
             self.assertEqual(status, 0)
             self.assertEqual(stderr, "")
             self.assertIn(f"Workspace manifest: {manifest_path.resolve()} (demo-suite)", stdout)
+            self.assertEqual(workspace_clone_row(stdout, "api"), ["api", "CLONE", "planned"])
+            self.assertIn("Workspace clone plan complete: planned=1 skipped=0 failed=0.", stdout)
             self.assertEqual(
                 state_file.read_text(encoding="utf-8").splitlines(),
                 [f"repo clone codeforester/api --path {(workspace / 'api').resolve()} --dry-run"],
@@ -276,8 +293,10 @@ repos:
             )
 
         self.assertEqual(status, 1)
-        self.assertIn("resolves outside workspace root", stderr)
-        self.assertIn("Workspace clone completed with 1 error(s).", stdout)
+        self.assertEqual(stderr, "")
+        self.assertEqual(workspace_clone_row(stdout, "api"), ["api", "CLONE", "failed"])
+        self.assertIn("resolves outside workspace root", stdout)
+        self.assertIn("Workspace clone completed: present=0 cloned=0 skipped=0 failed=1.", stdout)
         self.assertFalse(state_file.exists())
 
     def test_workspace_clone_requires_manifest(self) -> None:

--- a/cli/python/base_projects/tests/test_workspace_repository_url.py
+++ b/cli/python/base_projects/tests/test_workspace_repository_url.py
@@ -218,7 +218,6 @@ class WorkspaceRepositoryUrlTests(unittest.TestCase):
                 repo,
                 status.root,
                 dry_run=True,
-                already_exists=False,
             )
 
         self.assertEqual(result.status, "failed")

--- a/cli/python/base_projects/tests/test_workspace_repository_url.py
+++ b/cli/python/base_projects/tests/test_workspace_repository_url.py
@@ -218,11 +218,11 @@ class WorkspaceRepositoryUrlTests(unittest.TestCase):
                 repo,
                 status.root,
                 dry_run=True,
+                already_exists=False,
             )
 
-        self.assertEqual(result, 1)
-        error_call = ctx.log.error.call_args.args
-        rendered_consumers += (error_call[0] % error_call[1:],)
+        self.assertEqual(result.status, "failed")
+        rendered_consumers += (result.detail,)
         for rendered in rendered_consumers:
             with self.subTest(rendered=rendered):
                 self.assertNotIn(sentinel, str(rendered))

--- a/cli/python/base_projects/workspace_clone_command.py
+++ b/cli/python/base_projects/workspace_clone_command.py
@@ -113,7 +113,6 @@ def workspace_clone_command(ctx: base_cli.Context, options: WorkspaceCloneOption
             repo,
             target,
             dry_run=options.dry_run,
-            already_exists=target.exists(),
         )
         counts = update_workspace_clone_counts(counts, result)
         print_workspace_clone_result(target_spec, result, name_width)
@@ -205,8 +204,8 @@ def clone_workspace_repo(
     target: Path,
     *,
     dry_run: bool,
-    already_exists: bool,
 ) -> WorkspaceCloneResult:
+    already_exists = target.exists()
     repo_spec = workspace_clone_repo_spec(repo)
     if repo_spec is None:
         return WorkspaceCloneResult(

--- a/cli/python/base_projects/workspace_clone_command.py
+++ b/cli/python/base_projects/workspace_clone_command.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Literal, Protocol
 
 import base_cli
 from base_projects.command_helpers import ProjectCommandError as ProjectRunnerError
 from base_projects.command_helpers import ProjectUsageError
 from base_projects.command_helpers import github_repo_spec
 from base_projects.command_helpers import run_project_command
-from base_projects.command_helpers import write_project_command_output
 from base_projects.workspace_context import effective_workspace_manifest
 from base_projects.workspace_context import resolve_workspace_manifest
 from base_projects.workspace_context import resolve_workspace_root
@@ -25,6 +25,33 @@ class WorkspaceCloneOptions(Protocol):
     workspace_manifest: str | None
     include_optional: bool
     dry_run: bool
+
+
+WorkspaceCloneAction = Literal["check", "clone", "skip"]
+WorkspaceCloneStatus = Literal["planned", "present", "cloned", "skipped", "failed"]
+
+
+@dataclass(frozen=True)
+class WorkspaceCloneTarget:
+    name: str
+    root: Path
+    action: WorkspaceCloneAction
+
+
+@dataclass(frozen=True)
+class WorkspaceCloneResult:
+    status: WorkspaceCloneStatus
+    detail: str | None = None
+    exit_code: int | None = None
+
+
+@dataclass(frozen=True)
+class WorkspaceCloneCounts:
+    planned: int = 0
+    present: int = 0
+    cloned: int = 0
+    skipped: int = 0
+    failed: int = 0
 
 
 def workspace_clone_command(ctx: base_cli.Context, options: WorkspaceCloneOptions) -> int:
@@ -45,33 +72,66 @@ def workspace_clone_command(ctx: base_cli.Context, options: WorkspaceCloneOption
         return base_cli.ExitCode.FAILURE
 
     basectl = ctx.application_home / "bin" / "basectl"
-    print(f"Workspace clone: {workspace_root} ({len(manifest.repos)} repositories)")
+    name_width = max(len("REPOSITORY"), *(len(repo.name) for repo in manifest.repos))
+    print(f"Workspace clone: {workspace_root} ({len(manifest.repos)} manifest repos)")
     print(f"Workspace manifest: {manifest.path} ({manifest.name})")
+    print()
+    print_workspace_clone_header(name_width)
 
-    errors = 0
+    counts = WorkspaceCloneCounts()
     for repo in manifest.repos:
         try:
             target = resolve_workspace_clone_target(workspace_root, repo.name)
         except ProjectUsageError as exc:
-            ctx.log.error(str(exc))
-            errors += 1
+            target = WorkspaceCloneTarget(repo.name, workspace_root / repo.name, "clone")
+            result = WorkspaceCloneResult("failed", str(exc))
+            counts = update_workspace_clone_counts(counts, result)
+            print_workspace_clone_result(target, result, name_width)
             continue
-        required_label = "required" if repo.required else "optional"
+
         if should_skip_optional_clone(repo, target, options.include_optional):
-            print_optional_clone_skip(repo, target)
+            result = WorkspaceCloneResult(
+                "skipped",
+                f"optional repository is missing at '{target}'; pass --include-optional to clone it",
+            )
+            counts = update_workspace_clone_counts(counts, result)
+            print_workspace_clone_result(
+                WorkspaceCloneTarget(repo.name, target, "skip"),
+                result,
+                name_width,
+            )
             continue
 
-        verb = "CHECK" if target.exists() else "CLONE"
-        preposition = "at" if target.exists() else "into"
-        print(f"{verb} {required_label} repository '{repo.name}' {preposition} '{target}'.")
-        errors += clone_workspace_repo(ctx, basectl, repo, target, dry_run=options.dry_run)
+        target_spec = WorkspaceCloneTarget(
+            repo.name,
+            target,
+            "check" if target.exists() else "clone",
+        )
+        result = clone_workspace_repo(
+            ctx,
+            basectl,
+            repo,
+            target,
+            dry_run=options.dry_run,
+            already_exists=target.exists(),
+        )
+        counts = update_workspace_clone_counts(counts, result)
+        print_workspace_clone_result(target_spec, result, name_width)
 
-    if errors:
-        print(f"Workspace clone completed with {errors} error(s).")
-        return base_cli.ExitCode.FAILURE
+    if options.dry_run:
+        print(
+            "Workspace clone plan complete: "
+            f"planned={counts.planned} skipped={counts.skipped} failed={counts.failed}."
+        )
+        print("[DRY-RUN] No repositories were modified.")
+    else:
+        print(
+            "Workspace clone completed: "
+            f"present={counts.present} cloned={counts.cloned} "
+            f"skipped={counts.skipped} failed={counts.failed}."
+        )
 
-    print("Workspace clone completed.")
-    return base_cli.ExitCode.SUCCESS
+    return base_cli.ExitCode.FAILURE if counts.failed else base_cli.ExitCode.SUCCESS
 
 
 def resolve_workspace_clone_target(workspace_root: Path, repo_name: str) -> Path:
@@ -99,10 +159,42 @@ def should_skip_optional_clone(repo: WorkspaceManifestRepo, target: Path, includ
     return not repo.required and not include_optional and not target.exists()
 
 
+def print_workspace_clone_header(name_width: int) -> None:
+    print(f"{'REPOSITORY':<{name_width}}  {'ACTION':<6}  RESULT")
+
+
 def print_optional_clone_skip(repo: WorkspaceManifestRepo, target: Path) -> None:
+    """Retain the former helper for callers outside the command renderer."""
     print(
         f"SKIP optional repository '{repo.name}' is missing at '{target}'. "
         "Pass --include-optional to clone it."
+    )
+
+
+def print_workspace_clone_result(
+    target: WorkspaceCloneTarget,
+    result: WorkspaceCloneResult,
+    name_width: int,
+) -> None:
+    outcome = result.status
+    if result.exit_code is not None:
+        outcome = f"{outcome} (exit {result.exit_code})"
+    print(f"{target.name:<{name_width}}  {target.action.upper():<6}  {outcome}")
+    if result.detail:
+        for line in result.detail.splitlines():
+            print(f"{'':<{name_width}}  {'':<6}  {line}")
+
+
+def update_workspace_clone_counts(
+    counts: WorkspaceCloneCounts,
+    result: WorkspaceCloneResult,
+) -> WorkspaceCloneCounts:
+    return WorkspaceCloneCounts(
+        planned=counts.planned + (result.status == "planned"),
+        present=counts.present + (result.status == "present"),
+        cloned=counts.cloned + (result.status == "cloned"),
+        skipped=counts.skipped + (result.status == "skipped"),
+        failed=counts.failed + (result.status == "failed"),
     )
 
 
@@ -113,15 +205,17 @@ def clone_workspace_repo(
     target: Path,
     *,
     dry_run: bool,
-) -> int:
+    already_exists: bool,
+) -> WorkspaceCloneResult:
     repo_spec = workspace_clone_repo_spec(repo)
     if repo_spec is None:
-        ctx.log.error(
-            "Repository '%s' has unsupported clone URL '%s'. Only github.com repository URLs are supported.",
-            repo.name,
-            redact_repository_url(repo.url) if repo.url is not None else None,
+        return WorkspaceCloneResult(
+            "failed",
+            ""
+            f"Repository '{repo.name}' has unsupported clone URL "
+            f"'{redact_repository_url(repo.url) if repo.url is not None else None}'. "
+            "Only github.com repository URLs are supported.",
         )
-        return base_cli.ExitCode.FAILURE
 
     command = [str(basectl), "repo", "clone", repo_spec, "--path", str(target)]
     if dry_run:
@@ -133,15 +227,30 @@ def clone_workspace_repo(
             error_context=f"basectl repo clone for repository '{repo.name}'",
         )
     except ProjectRunnerError as exc:
-        ctx.log.error(str(exc))
-        return base_cli.ExitCode.FAILURE
+        return WorkspaceCloneResult("failed", str(exc))
 
-    write_project_command_output(result)
-    if result.returncode == 0:
-        return base_cli.ExitCode.SUCCESS
+    ctx.log.debug(
+        "Clone command for repository '%s' exited with %s; stdout=%r stderr=%r",
+        repo.name,
+        result.returncode,
+        result.stdout,
+        result.stderr,
+    )
+    if result.returncode != 0:
+        return WorkspaceCloneResult(
+            "failed",
+            detail=clone_detail(result.stdout, result.stderr),
+            exit_code=result.returncode,
+        )
 
-    ctx.log.error("Clone failed for repository '%s'.", repo.name)
-    return base_cli.ExitCode.FAILURE
+    if dry_run:
+        return WorkspaceCloneResult("planned")
+    return WorkspaceCloneResult("present" if already_exists else "cloned")
+
+
+def clone_detail(stdout: str, stderr: str) -> str:
+    details = [part.strip() for part in (stderr, stdout) if part.strip()]
+    return "\n".join(details) or "clone failed without diagnostic output"
 
 
 def workspace_clone_repo_spec(repo: WorkspaceManifestRepo) -> str | None:

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -208,7 +208,7 @@ manifest trust.
 | `basectl workspace doctor` | Render actionable workspace diagnostics with stable finding IDs and fix guidance. Uses `workspace.manifest` from user config unless `--manifest` is supplied. | `--workspace <path>`, `--manifest <path>`, `--format <text\|csv\|tsv\|yaml\|json>` |
 | `basectl workspace onboarding` | Summarize expected-repository first-day state and next actions without cloning or setup. Requires a configured or explicit workspace manifest. | `--workspace <path>`, `--manifest <path>`, `--format <text\|csv\|tsv\|yaml\|json>` |
 | `basectl workspace agent-brief` | Report local baseline, agent-guidance, AI-context, environment, and validation evidence for expected and extra Base-managed repositories without mutation or network calls. Requires a configured or explicit workspace manifest. | `--workspace <path>`, `--manifest <path>`, `--format <text\|csv\|tsv\|yaml\|json>` |
-| `basectl workspace clone` | Clone or validate expected repositories from a workspace manifest. Missing-repository materialization is GitHub-only today because this path delegates to `repo clone`. Uses `workspace.manifest` from user config unless `--manifest` is supplied. | `--workspace <path>`, `--manifest <path>`, `--include-optional`, `--dry-run` |
+| `basectl workspace clone` | Clone or validate expected repositories from a workspace manifest. Missing-repository materialization is GitHub-only today because this path delegates to `repo clone`. Uses `workspace.manifest` from user config unless `--manifest` is supplied. Text output uses a stable repository/action/result table with aggregate counts. | `--workspace <path>`, `--manifest <path>`, `--include-optional`, `--dry-run` |
 | `basectl workspace pull` | Explicitly fetch and validate a canonical workspace manifest source before updating the local workspace manifest. Uses `workspace.manifest_source` and `workspace.manifest` from user config unless flags are supplied. | `--source <url-or-path>`, `--manifest <path>`, `--dry-run` |
 | `basectl workspace update` | Run `git pull --ff-only` across present repositories in manifest order, including the active Base checkout when it is the manifest's `base` target. Continues after failures, skips missing optional repositories, treats missing required repositories as failures, and reports updated/unchanged/skipped/failed counts. | `--workspace <path>`, `--manifest <path>`, `--dry-run` |
 | `basectl workspace init <workspace-source>` | Initialize a workspace from a workspace configuration repository, update local workspace config, and optionally materialize member repositories. | `--owner <owner>`, `--path <path>`, `--workspace <path>`, `--manifest <path>`, `--include-optional`, `--dry-run` |
@@ -640,8 +640,12 @@ Use `basectl workspace clone --manifest <path>`, or configure
 `workspace.manifest`, to materialize the missing required GitHub repositories
 from that manifest. The command keeps existing repositories visible, delegates
 each repository operation to `basectl repo clone`, and supports `--dry-run` for
-a no-write preview. Optional repositories are reported but skipped unless
-`--include-optional` is supplied. Workspace manifests may list non-GitHub Git
+a no-write preview. Text output uses a stable repository/action/result table:
+existing repositories are `present`, newly materialized repositories are
+`cloned`, optional omissions are `skipped`, dry-run operations are `planned`,
+and failures include concise details and exit codes. Successful delegated clone
+output is suppressed in normal interactive mode. Optional repositories are
+reported but skipped unless `--include-optional` is supplied. Workspace manifests may list non-GitHub Git
 URLs for reporting, but automatic materialization through `workspace clone` is
 GitHub-only today; clone GitLab, Bitbucket, internal Git, or local repositories
 with ordinary Git first, then let Base discover the local checkout.

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -569,7 +569,12 @@ expose or execute the raw command.
 repositories through `basectl repo clone`. It clones missing required
 repositories by default, skips missing optional repositories unless
 `--include-optional` is supplied, and exits nonzero when any delegated clone or
-checkout validation fails.
+checkout validation fails. Text output uses a stable repository/action/result
+table: existing repositories are `present`, newly materialized repositories are
+`cloned`, optional omissions are `skipped`, dry-run operations are `planned`,
+and failures include concise details and exit codes. Successful delegated clone
+output is suppressed in normal interactive mode, while the completion summary
+reports aggregate present, cloned, skipped, and failed counts.
 
 `basectl workspace configure --manifest <path>` configures present Base-managed
 expected repositories through `basectl repo configure`. It skips missing


### PR DESCRIPTION
## Summary

- render `basectl workspace clone` as a stable repository/action/result table
- report present, cloned, skipped, planned, and failed outcomes with aggregate counts
- suppress successful delegated clone output while preserving failure details and debug diagnostics
- update workspace command documentation and regression coverage

Fixes #2087

## Validation

- `cli/python/base_projects/tests/test_workspace_clone.py` and `test_workspace_repository_url.py`: 10 passed, 26 subtests passed
- `cli/python/base_projects/tests`: 214 passed, 60 subtests passed
- `cli/bash/commands/basectl/tests/workspace.bats`: 15 passed
- `./bin/base-test`: 1,118 Python tests and 899 BATS tests passed
- ShellCheck passed for touched Bash command surfaces
- `git diff --check` passed