### PR TITLE
fix(ci): recover Project Intake item visibility races

### DIFF
--- a/.github/workflows/project-intake.yml
+++ b/.github/workflows/project-intake.yml
@@ -71,6 +71,12 @@ jobs:
               'unknown owner type|GraphQL.*rate limit|rate limit.*GraphQL|API rate limit already exceeded'
           }
 
+          project_intake_is_duplicate_item_failure() {
+            local output="$1"
+
+            printf '%s\n' "$output" | grep -Eiq 'Content already exists in this project'
+          }
+
           project_intake_retry_delay_seconds() {
             local output="$1"
             local reset_epoch
@@ -142,6 +148,12 @@ jobs:
               echo "::warning::Falling back to the REST Projects API." >&2
               printf '%s\n' "$diagnostic_output" >&2
               return 75
+            fi
+
+            if project_intake_is_duplicate_item_failure "$diagnostic_output"; then
+              echo "::warning::Project item already exists during Project Intake: $operation" >&2
+              printf '%s\n' "$diagnostic_output" >&2
+              return 76
             fi
 
             if project_intake_is_retryable_api_failure "$diagnostic_output"; then
@@ -217,16 +229,33 @@ jobs:
             local item_json
             local command_status
             local attempt
+            local display_item_id
 
             escaped_issue_title="${issue_title//\"/\\\"}"
+            display_item_id="${item_id:-for issue $issue_number}"
             for attempt in 1 2 3; do
+              if [[ -n "$item_id" ]] &&
+                item_json="$(project_intake_gh "read REST Project item after add" gh api --method GET \
+                  "$owner_api_prefix/projectsV2/$project_number/items/$item_id" \
+                  -f fields="$field_ids_csv")"; then
+                if jq -e --arg item_id "$item_id" '(.id | tostring) == $item_id' <<<"$item_json" >/dev/null; then
+                  printf '%s\n' "$item_json"
+                  return 0
+                fi
+                if (( attempt < 3 )); then
+                  echo "::warning::REST Project item '$display_item_id' is not visible after it was added (attempt $attempt/3); retrying in ${attempt}s." >&2
+                  sleep "$attempt"
+                  continue
+                fi
+              fi
+
               if item_search_json="$(project_intake_gh "find REST Project item after add" gh api --method GET \
                 "$owner_api_prefix/projectsV2/$project_number/items" \
                 -f per_page=100 \
                 -f q="repo:$GITHUB_REPOSITORY is:issue title:\"$escaped_issue_title\"" \
                 -f fields="$field_ids_csv")"; then
                 item_json="$(jq --argjson issue_id "$issue_id" --arg item_id "$item_id" \
-                  '.[] | select((.id | tostring) == $item_id and .content.id == $issue_id)' \
+                  '.[] | select(.content.id == $issue_id and ($item_id == "" or (.id | tostring) == $item_id))' \
                   <<<"$item_search_json")"
                 if [[ -n "$item_json" ]]; then
                   printf '%s\n' "$item_json"
@@ -238,12 +267,12 @@ jobs:
               fi
 
               if (( attempt < 3 )); then
-                echo "::warning::REST Project item '$item_id' is not visible after it was added (attempt $attempt/3); retrying in ${attempt}s." >&2
+                echo "::warning::REST Project item '$display_item_id' is not visible after it was added (attempt $attempt/3); retrying in ${attempt}s." >&2
                 sleep "$attempt"
               fi
             done
 
-            echo "::error::REST Project item '$item_id' was not returned after the bounded visibility retry." >&2
+            echo "::error::REST Project item '$display_item_id' was not returned after the bounded visibility retry." >&2
             return 1
           }
 
@@ -478,20 +507,37 @@ jobs:
             item_json="$(jq --argjson issue_id "$issue_id" '.[] | select(.content.id == $issue_id)' <<<"$item_search_json")"
             item_id="$(jq -r '.id // ""' <<<"$item_json")"
             if [[ -z "$item_id" ]]; then
-              added_item_json="$(project_intake_gh "add REST Project item" gh api --method POST \
-                "$owner_api_prefix/projectsV2/$project_number/items" \
-                -f type=Issue -F id="$issue_id")"
-              item_id="$(jq -r '.id // .value.id // ""' <<<"$added_item_json")"
-              if [[ -z "$item_id" ]]; then
-                echo "::error::REST Project item add did not return an item id." >&2
-                return 1
-              fi
-              if item_json="$(project_intake_rest_item_after_add \
-                "$owner_api_prefix" "$project_number" "$item_id" "$field_ids_csv")"; then
-                :
+              if added_item_json="$(project_intake_gh "add REST Project item" gh api --method POST \
+                  "$owner_api_prefix/projectsV2/$project_number/items" \
+                  -f type=Issue -F id="$issue_id")"; then
+                item_id="$(jq -r '.id // .value.id // ""' <<<"$added_item_json")"
+                if [[ -z "$item_id" ]]; then
+                  echo "::error::REST Project item add did not return an item id." >&2
+                  return 1
+                fi
+                if item_json="$(project_intake_rest_item_after_add \
+                  "$owner_api_prefix" "$project_number" "$item_id" "$field_ids_csv")"; then
+                  :
+                else
+                  command_status=$?
+                  return "$command_status"
+                fi
               else
                 command_status=$?
-                return "$command_status"
+                if [[ "$command_status" != "76" ]]; then
+                  return "$command_status"
+                fi
+                if item_json="$(project_intake_rest_item_after_add \
+                  "$owner_api_prefix" "$project_number" "" "$field_ids_csv")"; then
+                  item_id="$(jq -r '.id // ""' <<<"$item_json")"
+                  if [[ -z "$item_id" ]]; then
+                    echo "::error::Existing REST Project item did not return an item id." >&2
+                    return 1
+                  fi
+                else
+                  command_status=$?
+                  return "$command_status"
+                fi
               fi
             fi
 

--- a/templates/project-intake.yml
+++ b/templates/project-intake.yml
@@ -71,6 +71,12 @@ jobs:
               'unknown owner type|GraphQL.*rate limit|rate limit.*GraphQL|API rate limit already exceeded'
           }
 
+          project_intake_is_duplicate_item_failure() {
+            local output="$1"
+
+            printf '%s\n' "$output" | grep -Eiq 'Content already exists in this project'
+          }
+
           project_intake_retry_delay_seconds() {
             local output="$1"
             local reset_epoch
@@ -142,6 +148,12 @@ jobs:
               echo "::warning::Falling back to the REST Projects API." >&2
               printf '%s\n' "$diagnostic_output" >&2
               return 75
+            fi
+
+            if project_intake_is_duplicate_item_failure "$diagnostic_output"; then
+              echo "::warning::Project item already exists during Project Intake: $operation" >&2
+              printf '%s\n' "$diagnostic_output" >&2
+              return 76
             fi
 
             if project_intake_is_retryable_api_failure "$diagnostic_output"; then
@@ -217,16 +229,33 @@ jobs:
             local item_json
             local command_status
             local attempt
+            local display_item_id
 
             escaped_issue_title="${issue_title//\"/\\\"}"
+            display_item_id="${item_id:-for issue $issue_number}"
             for attempt in 1 2 3; do
+              if [[ -n "$item_id" ]] &&
+                item_json="$(project_intake_gh "read REST Project item after add" gh api --method GET \
+                  "$owner_api_prefix/projectsV2/$project_number/items/$item_id" \
+                  -f fields="$field_ids_csv")"; then
+                if jq -e --arg item_id "$item_id" '(.id | tostring) == $item_id' <<<"$item_json" >/dev/null; then
+                  printf '%s\n' "$item_json"
+                  return 0
+                fi
+                if (( attempt < 3 )); then
+                  echo "::warning::REST Project item '$display_item_id' is not visible after it was added (attempt $attempt/3); retrying in ${attempt}s." >&2
+                  sleep "$attempt"
+                  continue
+                fi
+              fi
+
               if item_search_json="$(project_intake_gh "find REST Project item after add" gh api --method GET \
                 "$owner_api_prefix/projectsV2/$project_number/items" \
                 -f per_page=100 \
                 -f q="repo:$GITHUB_REPOSITORY is:issue title:\"$escaped_issue_title\"" \
                 -f fields="$field_ids_csv")"; then
                 item_json="$(jq --argjson issue_id "$issue_id" --arg item_id "$item_id" \
-                  '.[] | select((.id | tostring) == $item_id and .content.id == $issue_id)' \
+                  '.[] | select(.content.id == $issue_id and ($item_id == "" or (.id | tostring) == $item_id))' \
                   <<<"$item_search_json")"
                 if [[ -n "$item_json" ]]; then
                   printf '%s\n' "$item_json"
@@ -238,12 +267,12 @@ jobs:
               fi
 
               if (( attempt < 3 )); then
-                echo "::warning::REST Project item '$item_id' is not visible after it was added (attempt $attempt/3); retrying in ${attempt}s." >&2
+                echo "::warning::REST Project item '$display_item_id' is not visible after it was added (attempt $attempt/3); retrying in ${attempt}s." >&2
                 sleep "$attempt"
               fi
             done
 
-            echo "::error::REST Project item '$item_id' was not returned after the bounded visibility retry." >&2
+            echo "::error::REST Project item '$display_item_id' was not returned after the bounded visibility retry." >&2
             return 1
           }
 
@@ -478,20 +507,37 @@ jobs:
             item_json="$(jq --argjson issue_id "$issue_id" '.[] | select(.content.id == $issue_id)' <<<"$item_search_json")"
             item_id="$(jq -r '.id // ""' <<<"$item_json")"
             if [[ -z "$item_id" ]]; then
-              added_item_json="$(project_intake_gh "add REST Project item" gh api --method POST \
-                "$owner_api_prefix/projectsV2/$project_number/items" \
-                -f type=Issue -F id="$issue_id")"
-              item_id="$(jq -r '.id // .value.id // ""' <<<"$added_item_json")"
-              if [[ -z "$item_id" ]]; then
-                echo "::error::REST Project item add did not return an item id." >&2
-                return 1
-              fi
-              if item_json="$(project_intake_rest_item_after_add \
-                "$owner_api_prefix" "$project_number" "$item_id" "$field_ids_csv")"; then
-                :
+              if added_item_json="$(project_intake_gh "add REST Project item" gh api --method POST \
+                  "$owner_api_prefix/projectsV2/$project_number/items" \
+                  -f type=Issue -F id="$issue_id")"; then
+                item_id="$(jq -r '.id // .value.id // ""' <<<"$added_item_json")"
+                if [[ -z "$item_id" ]]; then
+                  echo "::error::REST Project item add did not return an item id." >&2
+                  return 1
+                fi
+                if item_json="$(project_intake_rest_item_after_add \
+                  "$owner_api_prefix" "$project_number" "$item_id" "$field_ids_csv")"; then
+                  :
+                else
+                  command_status=$?
+                  return "$command_status"
+                fi
               else
                 command_status=$?
-                return "$command_status"
+                if [[ "$command_status" != "76" ]]; then
+                  return "$command_status"
+                fi
+                if item_json="$(project_intake_rest_item_after_add \
+                  "$owner_api_prefix" "$project_number" "" "$field_ids_csv")"; then
+                  item_id="$(jq -r '.id // ""' <<<"$item_json")"
+                  if [[ -z "$item_id" ]]; then
+                    echo "::error::Existing REST Project item did not return an item id." >&2
+                    return 1
+                  fi
+                else
+                  command_status=$?
+                  return "$command_status"
+                fi
               fi
             fi
 

--- a/tests/github_workflow_test_support.py
+++ b/tests/github_workflow_test_support.py
@@ -271,7 +271,7 @@ project_intake_mock_rest_item() {
     --arg size "$(project_intake_mock_value size)" \
     --arg area "$(project_intake_mock_value area)" \
     --arg initiative "$(project_intake_mock_value initiative)" \
-    '{id:101,fields:[
+    '{id:101,content:{id:1311,number:1311,title:"Project Intake test issue"},fields:[
       {id:10,name:"Status",value:{name:{raw:$status}}},
       {id:11,name:"Priority",value:{name:{raw:$priority}}},
       {id:12,name:"Size",value:{name:{raw:$size}}},
@@ -396,7 +396,16 @@ JSON
       printf '403 Forbidden: REST item read failed\\n' >&2
       exit 1
     fi
-    project_intake_mock_rest_item
+    count_file="${PROJECT_INTAKE_STATE:?}/rest-item-get-count"
+    count=0
+    [[ ! -f "$count_file" ]] || count="$(cat "$count_file")"
+    count=$((count + 1))
+    printf '%s\\n' "$count" > "$count_file"
+    if [[ "${PROJECT_INTAKE_REST_ITEM_GET_DELAYED:-0}" == "1" && "$count" == "1" ]]; then
+      printf '{}\\n'
+    else
+      project_intake_mock_rest_item
+    fi
     ;;
   api\\ --method\\ GET\\ *projectsV2/1/items*)
     if [[ "${PROJECT_INTAKE_REST_FAIL_OPERATION:-}" == "find" ]]; then
@@ -411,13 +420,19 @@ JSON
     if [[ "${PROJECT_INTAKE_ITEM_EXISTS:-1}" == "1" ||
           ( -f "${PROJECT_INTAKE_STATE:?}/rest-item-added" &&
             "${PROJECT_INTAKE_ITEM_NEVER_VISIBLE:-0}" != "1" &&
-            ( "${PROJECT_INTAKE_DELAYED_ITEM_VISIBILITY:-0}" != "1" || "$count" != "2" ) ) ]]; then
+            ( "${PROJECT_INTAKE_DELAYED_ITEM_VISIBILITY:-0}" != "1" || "$count" != "2" ) ) ||
+          ( -f "${PROJECT_INTAKE_STATE:?}/rest-item-duplicate" && "$count" -ge 3 ) ]]; then
       printf '[{"id":101,"content":{"id":1311,"number":1311,"title":"Project Intake test issue"}}]\\n'
     else
       printf '[]\\n'
     fi
     ;;
   api\\ --method\\ POST\\ *projectsV2/1/items*)
+    if [[ "${PROJECT_INTAKE_REST_DUPLICATE_ADD:-0}" == "1" ]]; then
+      : > "${PROJECT_INTAKE_STATE:?}/rest-item-duplicate"
+      printf 'Content already exists in this project (HTTP 422)\\n' >&2
+      exit 1
+    fi
     : > "${PROJECT_INTAKE_STATE:?}/rest-item-added"
     if [[ "${PROJECT_INTAKE_REST_ADD_RESPONSE:-nested}" == "top-level" ]]; then
       printf '{"id":101}\\n'

--- a/tests/test_project_intake_workflow.py
+++ b/tests/test_project_intake_workflow.py
@@ -242,7 +242,7 @@ def test_project_intake_rest_fallback_accepts_live_add_response_after_delay(
         PROJECT_INTAKE_GRAPHQL_FAILURE="quota",
         PROJECT_INTAKE_ITEM_EXISTS="0",
         PROJECT_INTAKE_REST_ADD_RESPONSE="top-level",
-        PROJECT_INTAKE_DELAYED_ITEM_VISIBILITY="1",
+        PROJECT_INTAKE_REST_ITEM_GET_DELAYED="1",
     )
 
     assert result.returncode == 0, result.stderr
@@ -251,7 +251,27 @@ def test_project_intake_rest_fallback_accepts_live_add_response_after_delay(
     assert (tmp_path / "sleep.log").read_text(encoding="utf-8") == "1\n"
     gh_log = (tmp_path / "gh.log").read_text(encoding="utf-8")
     assert gh_log.count("api --method POST orgs/basefoundry/projectsV2/1/items") == 1
+    assert gh_log.count("api --method GET orgs/basefoundry/projectsV2/1/items/101 -f") == 4
+    assert (tmp_path / "rest-item-get-count").read_text(encoding="utf-8") == "4\n"
+
+
+def test_project_intake_rest_fallback_recovers_duplicate_add_after_search_race(
+    tmp_path: Path,
+) -> None:
+    result = run_project_intake_script(
+        tmp_path,
+        PROJECT_INTAKE_GRAPHQL_FAILURE="quota",
+        PROJECT_INTAKE_ITEM_EXISTS="0",
+        PROJECT_INTAKE_REST_DUPLICATE_ADD="1",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "already exists during Project Intake" in result.stderr
+    assert "via REST fallback" in result.stdout
+    gh_log = (tmp_path / "gh.log").read_text(encoding="utf-8")
+    assert gh_log.count("api --method POST orgs/basefoundry/projectsV2/1/items") == 1
     assert gh_log.count("api --method GET orgs/basefoundry/projectsV2/1/items -f") == 3
+    assert not (tmp_path / "rest-item-added").exists()
 
 
 def test_project_intake_rest_failures_remain_fail_closed(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #2089

## Summary
- read a newly added REST Project item by its returned item ID before relying on title-search indexing
- recover the specific duplicate-item response with bounded lookup and field verification
- extend workflow fixtures and regression coverage for delayed visibility and duplicate-add races

## Validation
- BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python PYTHONPATH=/Users/rameshhp/work/base-cli/lib/python:lib/python:cli/python python -m pytest tests/test_project_intake_workflow.py -q (18 passed)
- git diff --check

`.ai-context/` unchanged: this is internal CI resilience and does not change the product shape or public command surface.