### PR TITLE
fix(security): redact workspace manifest sources

### DIFF
--- a/cli/bash/commands/basectl/basectl.sh
+++ b/cli/bash/commands/basectl/basectl.sh
@@ -793,9 +793,30 @@ basectl_history_record() {
     "$wrapper" --project base base_history.record "${args[@]}" -- basectl "$command" "$@" >/dev/null 2>&1 || true
 }
 
+basectl_debug_display_args() {
+    local redact_next=0 argument
+
+    for argument in "$@"; do
+        if ((redact_next)); then
+            printf ' [REDACTED]'
+            redact_next=0
+            continue
+        fi
+        case "$argument" in
+            --source)
+                printf ' --source'
+                redact_next=1
+                ;;
+            *)
+                printf ' %s' "$argument"
+                ;;
+        esac
+    done
+}
+
 
 basectl_main() {
-    local base_debug=0 keep_temp=0 command="" command_status run_bundle_enabled=1
+    local base_debug=0 keep_temp=0 command="" command_status run_bundle_enabled=1 debug_args
 
     while [[ "${1:-}" == --keep-temp ]]; do
         keep_temp=1
@@ -897,7 +918,8 @@ basectl_main() {
     BASE_CLI_HISTORY_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
     export BASE_CLI_HISTORY_STARTED_AT
     ((base_debug)) && basectl_enable_debug_logging
-    base_std_log_debug "Running basectl command '${command:-<none>}' with args: $*"
+    debug_args="$(basectl_debug_display_args "$@")"
+    base_std_log_debug "Running basectl command '${command:-<none>}' with args:${debug_args}"
 
     case "$command" in
         activate)         basectl_do_activate "$@"; command_status=$? ;;

--- a/cli/bash/commands/basectl/tests/runtime-dispatch.bats
+++ b/cli/bash/commands/basectl/tests/runtime-dispatch.bats
@@ -3,6 +3,27 @@
 load ./basectl_helpers.bash
 
 
+@test "basectl debug logs redact workspace manifest source arguments" {
+    local secret_source='http://user:review-secret@example.invalid/workspace.yaml?token=review-token'
+
+    run env \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_CACHE_DIR="$TEST_TMPDIR/cache" \
+        bash -c '
+            source "$BASE_HOME/cli/bash/commands/basectl/basectl.sh"
+            base_std_log_debug() { printf "%s\\n" "$*"; }
+            basectl_do_setup() { return 0; }
+            basectl_history_record() { :; }
+            basectl_main setup --source "$1" --dry-run
+        ' bash "$secret_source"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--source [REDACTED]"* ]]
+    [[ "$output" != *"review-secret"* ]]
+    [[ "$output" != *"review-token"* ]]
+}
+
+
 @test "basectl run bundle metadata and primary log are private" {
     local cache_root="$TEST_TMPDIR/cache"
     local run_root

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -95,7 +95,12 @@ def main(argv: list[str] | None = None) -> int:
     help="Output format: text, csv, tsv, yaml, or json.",
 )
 @base_cli.option("--manifest", "workspace_manifest", help="Local workspace manifest to read.")
-@base_cli.option("--source", "workspace_manifest_source", help="Canonical workspace manifest source URL or path.")
+@base_cli.option(
+    "--source",
+    "workspace_manifest_source",
+    sensitive=True,
+    help="Canonical workspace manifest source URL or path.",
+)
 @base_cli.option("--path", "workspace_config_path", help="Workspace configuration repository checkout path.")
 @base_cli.option("--owner", "workspace_owner", help="GitHub owner for short workspace repository names.")
 @base_cli.option(

--- a/cli/python/base_projects/tests/test_workspace_pull.py
+++ b/cli/python/base_projects/tests/test_workspace_pull.py
@@ -50,6 +50,27 @@ def invoke_engine(
 
 
 class WorkspacePullTests(unittest.TestCase):
+    def test_workspace_pull_redacts_source_credentials_and_query_values(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            home.mkdir()
+            base_home.mkdir()
+            source = "http://user:review-secret@example.invalid/workspace.yaml?token=review-token"
+
+            status, stdout, stderr = invoke_engine(
+                ["pull", "--source", source, "--manifest", str(root / "workspace.yaml")],
+                base_home,
+                home,
+            )
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stdout, "")
+        self.assertNotIn("review-secret", stderr)
+        self.assertNotIn("review-token", stderr)
+        self.assertIn("http://[REDACTED]@example.invalid/workspace.yaml?token=[REDACTED]", stderr)
+
     def test_workspace_pull_dry_run_reports_source_target_and_change_without_writing(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/cli/python/base_projects/tests/test_workspace_repository_url.py
+++ b/cli/python/base_projects/tests/test_workspace_repository_url.py
@@ -20,6 +20,7 @@ from base_projects.workspace_report_json import workspace_agent_brief_item_to_js
 from base_projects.workspace_report_json import workspace_onboarding_item_to_json
 from base_projects.workspace_report_json import workspace_status_item_to_json
 from base_projects.workspace_repository_url import redact_repository_url
+from base_projects.workspace_repository_url import redact_workspace_source
 from base_projects.workspace_repository_url import repository_url_problem
 from base_projects.workspace_statuses import WorkspaceProjectStatus
 
@@ -45,6 +46,28 @@ def invoke_engine(args: list[str], base_home: Path, home: Path) -> tuple[int, st
 
 
 class WorkspaceRepositoryUrlTests(unittest.TestCase):
+    def test_redact_workspace_source_removes_credentials_and_secret_parameters(self) -> None:
+        cases = (
+            (
+                "https://user:secret@example.test/workspace.yaml?token=review-token&channel=stable",
+                "https://[REDACTED]@example.test/workspace.yaml?token=[REDACTED]&channel=stable",
+            ),
+            (
+                "http://user:secret@example.test/workspace.yaml?token=review-token",
+                "http://[REDACTED]@example.test/workspace.yaml?token=[REDACTED]",
+            ),
+            (
+                "/private/tmp/workspace.yaml?token=review-token&channel=stable",
+                "/private/tmp/workspace.yaml?token=[REDACTED]&channel=stable",
+            ),
+            (
+                "relative/workspace.yaml?api_key=review-key",
+                "relative/workspace.yaml?api_key=[REDACTED]",
+            ),
+        )
+        for source, expected in cases:
+            with self.subTest(source=source):
+                self.assertEqual(redact_workspace_source(source), expected)
     def test_safe_repository_urls_are_unchanged(self) -> None:
         urls = (
             "https://github.com/basefoundry/base.git",

--- a/cli/python/base_projects/workspace_pull.py
+++ b/cli/python/base_projects/workspace_pull.py
@@ -13,6 +13,7 @@ from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_manifest import WorkspaceManifestError
 from base_projects.workspace_manifest import read_workspace_manifest
 from base_projects.workspace_file_url import resolve_workspace_file_url
+from base_projects.workspace_repository_url import redact_workspace_source
 
 
 MAX_WORKSPACE_MANIFEST_SOURCE_BYTES = 2 * 1024 * 1024
@@ -25,7 +26,8 @@ class HTTPSOnlyRedirectHandler(HTTPRedirectHandler):
         redirect = super().redirect_request(req, fp, code, msg, headers, newurl)
         if redirect is not None and urlparse(redirect.full_url).scheme != "https":
             raise WorkspaceManifestError(
-                f"Insecure workspace manifest redirect from '{req.full_url}' to '{redirect.full_url}'. "
+                f"Insecure workspace manifest redirect from '{redact_workspace_source(req.full_url)}' "
+                f"to '{redact_workspace_source(redirect.full_url)}'. "
                 "Use an https:// redirect target."
             )
         return redirect
@@ -51,7 +53,7 @@ def pull_workspace_manifest(source: str, target: Path, *, dry_run: bool) -> Work
         write_manifest_atomically(target, content)
 
     return WorkspaceManifestPullResult(
-        source=source,
+        source=redact_workspace_source(source),
         target=target,
         manifest=manifest,
         status=status,
@@ -77,6 +79,7 @@ def workspace_manifest_change_status(existing_content: bytes | None, content: by
 
 
 def fetch_workspace_manifest_source(source: str) -> bytes:
+    safe_source = redact_workspace_source(source)
     if source[:5].lower() == "file:":
         path = resolve_workspace_file_url(source)
         return read_workspace_manifest_source_file(source, path)
@@ -84,7 +87,7 @@ def fetch_workspace_manifest_source(source: str) -> bytes:
     parsed = urlparse(source)
     if parsed.scheme == "http":
         raise WorkspaceManifestError(
-            f"Insecure workspace manifest source '{source}'. Use https://, file://, or a local path."
+            f"Insecure workspace manifest source '{safe_source}'. Use https://, file://, or a local path."
         )
 
     if parsed.scheme == "https":
@@ -95,7 +98,8 @@ def fetch_workspace_manifest_source(source: str) -> bytes:
                 final_source = response.geturl()
                 if urlparse(final_source).scheme != "https":
                     raise WorkspaceManifestError(
-                        f"Insecure workspace manifest redirect from '{source}' to '{final_source}'. "
+                        f"Insecure workspace manifest redirect from '{safe_source}' "
+                        f"to '{redact_workspace_source(final_source)}'. "
                         "Use an https:// redirect target."
                     )
                 return enforce_workspace_manifest_source_size(
@@ -103,17 +107,19 @@ def fetch_workspace_manifest_source(source: str) -> bytes:
                     response.read(MAX_WORKSPACE_MANIFEST_SOURCE_BYTES + 1),
                 )
         except OSError as exc:
-            raise WorkspaceManifestError(f"Unable to fetch workspace manifest source '{source}': {exc}") from exc
+            raise WorkspaceManifestError(f"Unable to fetch workspace manifest source '{safe_source}': {exc}") from exc
 
     if parsed.scheme:
         raise WorkspaceManifestError(
-            f"Unsupported workspace manifest source '{source}'. Expected a local path, file:// URL, or https:// URL."
+            f"Unsupported workspace manifest source '{safe_source}'. "
+            "Expected a local path, file:// URL, or https:// URL."
         )
 
     return read_workspace_manifest_source_file(source, Path(source).expanduser())
 
 
 def read_workspace_manifest_source_file(source: str, path: Path) -> bytes:
+    safe_source = redact_workspace_source(source)
     try:
         with path.open("rb") as source_file:
             return enforce_workspace_manifest_source_size(
@@ -121,13 +127,14 @@ def read_workspace_manifest_source_file(source: str, path: Path) -> bytes:
                 source_file.read(MAX_WORKSPACE_MANIFEST_SOURCE_BYTES + 1),
             )
     except OSError as exc:
-        raise WorkspaceManifestError(f"Unable to fetch workspace manifest source '{source}': {exc}") from exc
+        raise WorkspaceManifestError(f"Unable to fetch workspace manifest source '{safe_source}': {exc}") from exc
 
 
 def enforce_workspace_manifest_source_size(source: str, content: bytes) -> bytes:
     if len(content) > MAX_WORKSPACE_MANIFEST_SOURCE_BYTES:
+        safe_source = redact_workspace_source(source)
         raise WorkspaceManifestError(
-            f"Workspace manifest source '{source}' exceeds the "
+            f"Workspace manifest source '{safe_source}' exceeds the "
             f"{MAX_WORKSPACE_MANIFEST_SOURCE_BYTES} byte limit."
         )
     return content
@@ -135,7 +142,9 @@ def enforce_workspace_manifest_source_size(source: str, content: bytes) -> bytes
 
 def validate_workspace_manifest_content(content: bytes, source: str) -> WorkspaceManifest:
     if not content:
-        raise WorkspaceManifestError(f"Fetched workspace manifest from '{source}' is empty.")
+        raise WorkspaceManifestError(
+            f"Fetched workspace manifest from '{redact_workspace_source(source)}' is empty."
+        )
 
     temp_path = None
     try:
@@ -144,7 +153,9 @@ def validate_workspace_manifest_content(content: bytes, source: str) -> Workspac
             temp_path = Path(temp_file.name)
         return read_workspace_manifest(temp_path)
     except WorkspaceManifestError as exc:
-        raise WorkspaceManifestError(f"Fetched workspace manifest from '{source}' is invalid: {exc}") from exc
+        raise WorkspaceManifestError(
+            f"Fetched workspace manifest from '{redact_workspace_source(source)}' is invalid: {exc}"
+        ) from exc
     finally:
         if temp_path is not None:
             temp_path.unlink(missing_ok=True)

--- a/cli/python/base_projects/workspace_repository_url.py
+++ b/cli/python/base_projects/workspace_repository_url.py
@@ -9,6 +9,7 @@ from urllib.parse import urlunsplit
 
 from base_cli.redaction import REDACTED
 from base_cli.redaction import is_secret_key
+from base_cli.redaction import redact_text_value
 
 
 SCP_REPOSITORY_URL_RE = re.compile(r"^(?P<userinfo>[^@\s]+)@(?P<location>[^:\s]+:.+)$")
@@ -47,6 +48,20 @@ def redact_repository_url(value: str) -> str:
             redact_url_parameters(parsed.fragment),
         )
     )
+
+
+def redact_workspace_source(value: str) -> str:
+    """Redact credentials and secret URL parameters from a workspace source."""
+    sanitized = redact_text_value(value)
+    if Path(value).is_absolute():
+        return redact_url_suffix_parameters(sanitized)
+
+    sanitized = redact_repository_url(value)
+    if sanitized != REDACTED:
+        return sanitized
+    if "://" not in value:
+        return redact_url_suffix_parameters(redact_text_value(value))
+    return redact_url_suffix_parameters(redact_text_value(value))
 
 
 def repository_url_problem(value: str) -> str | None:


### PR DESCRIPTION
## Summary
- redact workspace manifest source credentials and secret URL parameters in Python errors and results
- mark the workspace `--source` option sensitive for history/argv handling
- redact `--source` values from Bash debug logs and cover the boundary with regression tests

Fixes #2090

## Validation
- `pytest cli/python/base_projects/tests/test_workspace_pull.py cli/python/base_projects/tests/test_workspace_repository_url.py -q`
- `bats cli/bash/commands/basectl/tests/runtime-dispatch.bats`
- `shellcheck cli/bash/commands/basectl/basectl.sh`
- `git diff --check`