### PR TITLE
fix(release): recover safely after tag push failures

### DIFF
--- a/cli/python/base_release/engine.py
+++ b/cli/python/base_release/engine.py
@@ -16,7 +16,8 @@ from .release_parser import ReleaseUsageError
 from .release_parser import parse_release_args
 from .release_parser import print_usage
 from .release_parser import selected_release_check_format
-from .release_publish import release_publish_recovery_guidance, require_interactive_publish_confirmation
+from .release_publish import inspect_remote_annotated_tag, release_publish_recovery_guidance
+from .release_publish import release_tag_push_recovery_guidance, require_interactive_publish_confirmation
 from .release_publish import run_release_step, verify_github_release
 from .release_publish import verify_local_annotated_tag, verify_remote_annotated_tag
 from .release_publish import write_temp_release_notes
@@ -229,7 +230,14 @@ def release_publish_command(ctx: ReleaseContext, args: ReleaseArguments) -> int:
         cwd=project_root,
     )
     verify_local_annotated_tag(project_root, ctx.tag_name, expected_sha)
-    run_release_step(["git", "push", "origin", ctx.tag_name], cwd=project_root)
+    try:
+        run_release_step(["git", "push", "origin", ctx.tag_name], cwd=project_root)
+    except ReleaseError as exc:
+        remote_tag_state = inspect_remote_annotated_tag(project_root, ctx.tag_name, expected_sha)
+        raise ReleaseError(
+            str(exc),
+            guidance=release_tag_push_recovery_guidance(ctx, title, remote_tag_state),
+        ) from exc
 
     notes_path = None
     try:

--- a/cli/python/base_release/release_publish.py
+++ b/cli/python/base_release/release_publish.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import Literal
 from urllib.parse import quote
 
 import base_cli
@@ -15,6 +16,7 @@ from .release_readiness import last_non_empty_line
 
 RELEASE_STEP_TIMEOUT_SECONDS = 120
 FULL_GIT_SHA_LENGTHS = frozenset((40, 64))
+RemoteTagState = Literal["absent", "intended", "conflict", "unavailable"]
 
 
 def release_publish_recovery_guidance(ctx: ReleaseContext, title: str) -> str:
@@ -39,6 +41,33 @@ def release_publish_recovery_guidance(ctx: ReleaseContext, title: str) -> str:
         "To abandon this release attempt, remove the local and remote tag after confirming no one else is using it:\n"
         f"  git tag -d {shlex.quote(ctx.tag_name)}\n"
         f"  git push origin :refs/tags/{shlex.quote(ctx.tag_name)}"
+    )
+
+
+def release_tag_push_recovery_guidance(ctx: ReleaseContext, title: str, state: RemoteTagState) -> str:
+    """Describe non-destructive recovery after local tag creation and push failure."""
+    tag = shlex.quote(ctx.tag_name)
+    inspect_command = f"git ls-remote --tags origin refs/tags/{tag} 'refs/tags/{tag}^{{}}'"
+    if state == "intended":
+        return (
+            f"The remote tag {ctx.tag_name} is present and resolves to the intended release commit. "
+            "Do not push or delete the tag again. Complete the GitHub Release with the verified tag:\n"
+            f"{release_publish_recovery_guidance(ctx, title)}"
+        )
+    if state == "absent":
+        return (
+            f"The local annotated tag {ctx.tag_name} remains, but the remote tag is absent. "
+            "After resolving the push failure, retry the tag push:\n"
+            f"  git push origin {tag}\n"
+            "Then verify the remote annotated tag before creating the GitHub Release. "
+            "If abandoning the attempt, remove only the local tag:\n"
+            f"  git tag -d {tag}"
+        )
+    return (
+        f"The local annotated tag {ctx.tag_name} remains, but the remote tag state could not be verified safely. "
+        "Do not retry blindly, force-update, or delete any tag. Inspect the exact remote refs first:\n"
+        f"  {inspect_command}\n"
+        "If the remote tag conflicts with the intended commit, stop and resolve it with the repository owner."
     )
 
 
@@ -90,17 +119,37 @@ def verify_local_annotated_tag(root: Path, tag_name: str, expected_sha: str) -> 
 
 
 def verify_remote_annotated_tag(root: Path, tag_name: str, expected_sha: str) -> None:
-    output = capture_release_step(
-        [
-            "git",
-            "ls-remote",
-            "--tags",
-            "origin",
-            f"refs/tags/{tag_name}",
-            f"refs/tags/{tag_name}^{{}}",
-        ],
-        cwd=root,
-    )
+    state = inspect_remote_annotated_tag(root, tag_name, expected_sha)
+    if state == "intended":
+        return
+    if state == "unavailable":
+        raise ReleaseError(f"Unable to verify remote tag {tag_name} safely on origin.")
+    if state == "conflict":
+        raise ReleaseError(
+            f"Remote tag {tag_name} is missing or is not an annotated tag on origin, "
+            "or resolves to a conflicting commit."
+        )
+    raise ReleaseError(f"Remote tag {tag_name} is missing or is not an annotated tag on origin.")
+
+
+def inspect_remote_annotated_tag(root: Path, tag_name: str, expected_sha: str) -> RemoteTagState:
+    try:
+        output = capture_release_step(
+            [
+                "git",
+                "ls-remote",
+                "--tags",
+                "origin",
+                f"refs/tags/{tag_name}",
+                f"refs/tags/{tag_name}^{{}}",
+            ],
+            cwd=root,
+        )
+    except ReleaseError:
+        return "unavailable"
+
+    if not output.strip():
+        return "absent"
     tag_object_sha: str | None = None
     peeled_sha: str | None = None
     for line in output.splitlines():
@@ -113,11 +162,8 @@ def verify_remote_annotated_tag(root: Path, tag_name: str, expected_sha: str) ->
         elif ref_name == f"refs/tags/{tag_name}^{{}}":
             peeled_sha = normalized
     if tag_object_sha is None or peeled_sha is None:
-        raise ReleaseError(f"Remote tag {tag_name} is missing or is not an annotated tag on origin.")
-    if peeled_sha != expected_sha:
-        raise ReleaseError(
-            f"Remote annotated tag {tag_name} resolves to {peeled_sha}, expected release commit {expected_sha}."
-        )
+        return "conflict"
+    return "intended" if peeled_sha == expected_sha else "conflict"
 
 
 def verify_github_release(ctx: ReleaseContext, expected_sha: str) -> None:

--- a/cli/python/base_release/tests/test_engine.py
+++ b/cli/python/base_release/tests/test_engine.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+# Keep the release engine's end-to-end matrix together for readable workflow coverage.
+# pylint: disable=too-many-lines
+
 import io
 import json
 import os
@@ -527,6 +530,77 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertIn("git push origin :refs/tags/v1.2.3", stderr)
 
 
+    def test_publish_push_failure_reports_local_tag_recovery_when_remote_is_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = self.manifest_factory.write_release(root)
+
+            def fail_push(command: list[str], *, cwd: Path | None = None) -> None:
+                del cwd
+                if command[:3] == ["git", "push", "origin"]:
+                    raise ReleaseError("Release command failed: git push origin v1.2.3: network unavailable")
+
+            with (
+                mock.patch("base_release.engine.release_findings", return_value=READY_FINDINGS),
+                mock.patch(
+                    "base_release.engine.github_release_finding",
+                    return_value=ReleaseFinding("ok", "github_release", "GitHub Release is available."),
+                    create=True,
+                ),
+                mock.patch("base_release.engine.require_release_provenance", return_value=READY_SHA),
+                mock.patch("base_release.engine.verify_local_annotated_tag"),
+                mock.patch("base_release.engine.inspect_remote_annotated_tag", return_value="absent") as inspect,
+                mock.patch("base_release.engine.run_release_step", side_effect=fail_push, create=True),
+            ):
+                status, stdout, stderr = run_engine(
+                    ["publish", "--yes", "--version", "1.2.3", "--manifest", str(manifest_path)],
+                    root,
+                )
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stdout, "")
+        inspect.assert_called_once_with(root.resolve(), "v1.2.3", READY_SHA)
+        self.assertIn("local annotated tag v1.2.3 remains", stderr)
+        self.assertIn("remote tag is absent", stderr)
+        self.assertIn("git push origin v1.2.3", stderr)
+        self.assertIn("git tag -d v1.2.3", stderr)
+        self.assertNotIn("refs/tags/v1.2.3", stderr)
+
+
+    def test_publish_push_timeout_checks_remote_and_guides_github_recovery(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = self.manifest_factory.write_release(root)
+
+            def timeout_push(command: list[str], *, cwd: Path | None = None) -> None:
+                del cwd
+                if command[:3] == ["git", "push", "origin"]:
+                    raise ReleaseError("Release command timed out after 120 seconds: git push origin v1.2.3")
+
+            with (
+                mock.patch("base_release.engine.release_findings", return_value=READY_FINDINGS),
+                mock.patch(
+                    "base_release.engine.github_release_finding",
+                    return_value=ReleaseFinding("ok", "github_release", "GitHub Release is available."),
+                    create=True,
+                ),
+                mock.patch("base_release.engine.require_release_provenance", return_value=READY_SHA),
+                mock.patch("base_release.engine.verify_local_annotated_tag"),
+                mock.patch("base_release.engine.inspect_remote_annotated_tag", return_value="intended") as inspect,
+                mock.patch("base_release.engine.run_release_step", side_effect=timeout_push, create=True),
+            ):
+                status, stdout, stderr = run_engine(
+                    ["publish", "--yes", "--version", "1.2.3", "--manifest", str(manifest_path)],
+                    root,
+                )
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stdout, "")
+        inspect.assert_called_once_with(root.resolve(), "v1.2.3", READY_SHA)
+        self.assertIn("remote tag v1.2.3 is present and resolves to the intended release commit", stderr)
+        self.assertIn("gh release create v1.2.3 --verify-tag --repo codeforester/demo", stderr)
+
+
     def test_publish_fails_when_readiness_has_errors(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -836,6 +910,35 @@ class ReleaseHelperTests(unittest.TestCase):
         ):
             with self.assertRaisesRegex(ReleaseError, "missing or is not an annotated tag"):
                 release_publish.verify_remote_annotated_tag(Path("/repo"), "v1.2.3", READY_SHA)
+
+    def test_inspect_remote_annotated_tag_classifies_safe_recovery_states(self) -> None:
+        tag_object_sha = "b" * 40
+        intended_output = (
+            f"{tag_object_sha}\trefs/tags/v1.2.3\n"
+            f"{READY_SHA}\trefs/tags/v1.2.3^{{}}\n"
+        )
+        with mock.patch("base_release.release_publish.capture_release_step", return_value=intended_output):
+            self.assertEqual(
+                release_publish.inspect_remote_annotated_tag(Path("/repo"), "v1.2.3", READY_SHA), "intended"
+            )
+        with mock.patch("base_release.release_publish.capture_release_step", return_value=""):
+            self.assertEqual(
+                release_publish.inspect_remote_annotated_tag(Path("/repo"), "v1.2.3", READY_SHA), "absent"
+            )
+        with mock.patch(
+            "base_release.release_publish.capture_release_step",
+            return_value=f"{tag_object_sha}\trefs/tags/v1.2.3\n",
+        ):
+            self.assertEqual(
+                release_publish.inspect_remote_annotated_tag(Path("/repo"), "v1.2.3", READY_SHA), "conflict"
+            )
+        with mock.patch(
+            "base_release.release_publish.capture_release_step",
+            side_effect=ReleaseError("network unavailable"),
+        ):
+            self.assertEqual(
+                release_publish.inspect_remote_annotated_tag(Path("/repo"), "v1.2.3", READY_SHA), "unavailable"
+            )
 
     def test_tag_verifiers_accept_a_real_annotated_tag_at_one_full_sha(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- inspect remote annotated-tag state when local tag creation succeeds but `git push` fails or times out
- distinguish absent, intended, conflicting, and unverifiable remote state
- provide copy-ready, non-destructive recovery guidance for retrying, completing, or abandoning a release
- preserve existing post-push GitHub Release recovery and add failure/timeout/state-matrix coverage

Fixes #2091

## Validation
- `pytest cli/python/base_release/tests -q`
- `pylint --rcfile=.pylintrc cli/python/base_release/engine.py cli/python/base_release/release_publish.py`
- `git diff --check`