### PR TITLE
fix(workspace): contain mutating commands within workspace root

### DIFF
--- a/cli/python/base_projects/tests/test_workspace_configure.py
+++ b/cli/python/base_projects/tests/test_workspace_configure.py
@@ -87,6 +87,88 @@ def invoke_engine(
 
 
 class WorkspaceConfigureTests(unittest.TestCase):
+    def test_workspace_configure_manifest_rejects_repository_target_outside_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            outside = root / "outside"
+            base_home = root / "base"
+            state_file = root / "basectl-calls"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            workspace.mkdir()
+            outside.mkdir()
+            base_home.mkdir()
+            (workspace / "api").symlink_to(outside, target_is_directory=True)
+            write_fake_basectl(base_home, state_file)
+            write_workspace_manifest(
+                manifest_path,
+                """
+schema_version: 1
+workspace:
+  name: demo-suite
+repos:
+  - name: api
+    url: https://github.com/basefoundry/api.git
+""",
+            )
+
+            with mock.patch("base_projects.workspace_configure.subprocess.run") as run:
+                status, stdout, stderr = invoke_engine(
+                    [
+                        "configure",
+                        "--workspace",
+                        str(workspace),
+                        "--manifest",
+                        str(manifest_path),
+                    ],
+                    base_home,
+                    home,
+                )
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        self.assertIn("SKIP Repository 'api'", stdout)
+        self.assertIn("resolves outside workspace root", stdout)
+        self.assertIn("Workspace configure completed: configured=0 skipped=1 failed=1.", stdout)
+        self.assertFalse(state_file.exists())
+        run.assert_not_called()
+
+    def test_workspace_configure_discovery_rejects_repository_target_outside_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            outside = root / "outside"
+            base_home = root / "base"
+            state_file = root / "basectl-calls"
+            home.mkdir()
+            workspace.mkdir()
+            outside.mkdir()
+            base_home.mkdir()
+            (workspace / "api").symlink_to(outside, target_is_directory=True)
+            (outside / "base_manifest.yaml").write_text(
+                "project:\n  name: api\nartifacts: []\n",
+                encoding="utf-8",
+            )
+            write_fake_basectl(base_home, state_file)
+
+            with mock.patch("base_projects.workspace_configure.subprocess.run") as run:
+                status, stdout, stderr = invoke_engine(
+                    ["configure", "--workspace", str(workspace)],
+                    base_home,
+                    home,
+                )
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        self.assertIn("SKIP Repository 'api'", stdout)
+        self.assertIn("resolves outside workspace root", stdout)
+        self.assertIn("Workspace configure completed: configured=0 skipped=1 failed=1.", stdout)
+        self.assertFalse(state_file.exists())
+        run.assert_not_called()
+
     def test_workspace_configure_dry_run_scans_base_managed_repositories(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/cli/python/base_projects/tests/test_workspace_setup.py
+++ b/cli/python/base_projects/tests/test_workspace_setup.py
@@ -43,6 +43,53 @@ repos:
 
 
 class WorkspaceSetupTests(unittest.TestCase):
+    def test_workspace_setup_rejects_repository_target_outside_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            workspace = root / "workspace"
+            outside = root / "outside"
+            manifest_path = root / "workspace.yaml"
+            state_path = root / "basectl-calls"
+            home.mkdir()
+            base_home.mkdir()
+            workspace.mkdir()
+            outside.mkdir()
+            (workspace / "api").symlink_to(outside, target_is_directory=True)
+            write_fake_basectl(base_home, state_path)
+            manifest_path.write_text(
+                """schema_version: 1
+workspace:
+  name: demo-suite
+repos:
+  - name: api
+""",
+                encoding="utf-8",
+            )
+
+            with mock.patch("base_projects.workspace_setup.subprocess.run") as run:
+                status, stdout, stderr = invoke_engine(
+                    [
+                        "setup",
+                        "--workspace",
+                        str(workspace),
+                        "--manifest",
+                        str(manifest_path),
+                        "--yes",
+                    ],
+                    base_home,
+                    home,
+                )
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        self.assertIn("SKIP repository 'api'", stdout)
+        self.assertIn("resolves outside workspace root", stdout)
+        self.assertIn("Workspace setup completed: setup=0 skipped=1 failed=1.", stdout)
+        self.assertFalse(state_path.exists())
+        run.assert_not_called()
+
     def test_workspace_setup_dry_run_preserves_manifest_order_and_classifies_targets(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/cli/python/base_projects/tests/test_workspace_update.py
+++ b/cli/python/base_projects/tests/test_workspace_update.py
@@ -11,7 +11,8 @@ from contextlib import redirect_stdout
 from pathlib import Path
 from unittest import mock
 
-from base_projects import engine
+from base_projects import engine, workspace_update
+from base_projects.workspace_manifest import WorkspaceManifestRepo
 
 
 def write_workspace_manifest(path: Path) -> None:
@@ -34,6 +35,67 @@ repos:
 
 
 class WorkspaceUpdateTests(unittest.TestCase):
+    def test_workspace_update_rejects_repository_target_outside_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            base_home = root / "base"
+            workspace = root / "workspace"
+            outside = root / "outside"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            workspace.mkdir()
+            outside.mkdir()
+            (workspace / "api").symlink_to(outside, target_is_directory=True)
+            manifest_path.write_text(
+                """schema_version: 1
+workspace:
+  name: demo-suite
+repos:
+  - name: api
+""",
+                encoding="utf-8",
+            )
+
+            with mock.patch("base_projects.workspace_update.subprocess.run") as run:
+                status, stdout, stderr = invoke_engine(
+                    [
+                        "update",
+                        "--workspace",
+                        str(workspace),
+                        "--manifest",
+                        str(manifest_path),
+                    ],
+                    base_home,
+                    home,
+                )
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        self.assertIn("SKIP    skipped", stdout)
+        self.assertIn("resolves outside workspace root", stdout)
+        self.assertIn("Workspace update completed: updated=0 unchanged=0 skipped=1 failed=1.", stdout)
+        run.assert_not_called()
+
+    def test_workspace_update_allows_repository_symlink_inside_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            workspace = root / "workspace"
+            repository = workspace / "repository"
+            workspace.mkdir()
+            repository.mkdir()
+            (workspace / "api").symlink_to(repository, target_is_directory=True)
+
+            target = workspace_update.workspace_update_manifest_target(
+                workspace,
+                WorkspaceManifestRepo(name="api"),
+            )
+
+        self.assertEqual(target.root, repository.resolve())
+        self.assertEqual(target.action, "pull")
+        self.assertFalse(target.fatal)
+
     def test_workspace_update_dry_run_preserves_order_and_includes_active_base(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/cli/python/base_projects/workspace_clone_command.py
+++ b/cli/python/base_projects/workspace_clone_command.py
@@ -11,7 +11,9 @@ from base_projects.command_helpers import ProjectUsageError
 from base_projects.command_helpers import github_repo_spec
 from base_projects.command_helpers import run_project_command
 from base_projects.workspace_context import effective_workspace_manifest
+from base_projects.workspace_context import WorkspacePathOutsideRootError
 from base_projects.workspace_context import resolve_workspace_manifest
+from base_projects.workspace_context import resolve_workspace_repo_root
 from base_projects.workspace_context import resolve_workspace_root
 from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_manifest import WorkspaceManifestError
@@ -142,14 +144,10 @@ def workspace_clone_command(ctx: base_cli.Context, options: WorkspaceCloneOption
 
 
 def resolve_workspace_clone_target(workspace_root: Path, repo_name: str) -> Path:
-    target = (workspace_root / repo_name).resolve(strict=False)
     try:
-        target.relative_to(workspace_root)
-    except ValueError as exc:
-        raise ProjectUsageError(
-            f"Repository '{repo_name}' resolves outside workspace root '{workspace_root}'."
-        ) from exc
-    return target
+        return resolve_workspace_repo_root(workspace_root, repo_name)
+    except WorkspacePathOutsideRootError as exc:
+        raise ProjectUsageError(str(exc)) from exc
 
 
 def require_workspace_clone_manifest(ctx: base_cli.Context, workspace_manifest: str | None) -> WorkspaceManifest:

--- a/cli/python/base_projects/workspace_configure.py
+++ b/cli/python/base_projects/workspace_configure.py
@@ -11,6 +11,7 @@ import base_cli
 from base_projects import workspace_context
 from base_projects.command_helpers import github_repo_spec
 from base_projects.workspace_context import resolve_workspace_manifest
+from base_projects.workspace_context import WorkspacePathOutsideRootError
 from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_manifest import WorkspaceManifestError
 from base_projects.workspace_manifest import WorkspaceManifestRepo
@@ -27,6 +28,7 @@ class WorkspaceConfigureTarget:
     root: Path
     repo_spec: str | None
     skip_reason: str | None = None
+    fatal: bool = False
 
 
 @dataclass(frozen=True)
@@ -94,10 +96,23 @@ def workspace_configure_targets(
 
     targets: list[WorkspaceConfigureTarget] = []
     for entry in workspace_manifest_entries(workspace_root):
-        root = entry.path.parent.resolve()
+        repo_name = entry.path.parent.name
+        try:
+            root = workspace_context.resolve_workspace_repo_root(workspace_root, repo_name)
+        except WorkspacePathOutsideRootError as exc:
+            targets.append(
+                WorkspaceConfigureTarget(
+                    name=repo_name,
+                    root=entry.path.parent,
+                    repo_spec=None,
+                    skip_reason=str(exc),
+                    fatal=True,
+                )
+            )
+            continue
         targets.append(
             WorkspaceConfigureTarget(
-                name=root.name,
+                name=repo_name,
                 root=root,
                 repo_spec=github_origin_repo_spec(root),
             )
@@ -109,7 +124,16 @@ def workspace_configure_manifest_target(
     workspace_root: Path,
     repo: WorkspaceManifestRepo,
 ) -> WorkspaceConfigureTarget:
-    root = (workspace_root / repo.name).resolve()
+    try:
+        root = workspace_context.resolve_workspace_repo_root(workspace_root, repo.name)
+    except WorkspacePathOutsideRootError as exc:
+        return WorkspaceConfigureTarget(
+            name=repo.name,
+            root=workspace_root / repo.name,
+            repo_spec=None,
+            skip_reason=str(exc),
+            fatal=True,
+        )
     if not root.exists():
         return WorkspaceConfigureTarget(
             name=repo.name,
@@ -142,7 +166,11 @@ def configure_workspace_target(
 ) -> WorkspaceConfigureCounts:
     if target.skip_reason is not None:
         print(f"SKIP {target.skip_reason}.")
-        return WorkspaceConfigureCounts(counts.configured, counts.skipped + 1, counts.failed)
+        return WorkspaceConfigureCounts(
+            counts.configured,
+            counts.skipped + 1,
+            counts.failed + int(target.fatal),
+        )
     if target.repo_spec is None:
         print(f"SKIP repository '{target.name}' has no supported GitHub origin remote.")
         return WorkspaceConfigureCounts(counts.configured, counts.skipped + 1, counts.failed)

--- a/cli/python/base_projects/workspace_context.py
+++ b/cli/python/base_projects/workspace_context.py
@@ -8,6 +8,10 @@ from base_projects.workspace_manifest import read_workspace_manifest
 from base_projects.workspace_scanner import ProjectDiscoveryError
 
 
+class WorkspacePathOutsideRootError(ValueError):
+    """Raised when a manifest repository resolves outside its workspace."""
+
+
 def resolve_workspace_root(ctx: base_cli.Context, workspace: str | None) -> Path:
     if workspace:
         return Path(workspace).expanduser().resolve()
@@ -16,6 +20,19 @@ def resolve_workspace_root(ctx: base_cli.Context, workspace: str | None) -> Path
     if ctx.application_home is None:
         raise ProjectDiscoveryError("BASE_HOME is required to discover workspace projects.")
     return ctx.application_home.parent.resolve()
+
+
+def resolve_workspace_repo_root(workspace_root: Path, repo_name: str) -> Path:
+    """Resolve a manifest repository path while enforcing the workspace boundary."""
+    resolved_workspace_root = workspace_root.expanduser().resolve(strict=False)
+    resolved_repo_root = (resolved_workspace_root / repo_name).resolve(strict=False)
+    try:
+        resolved_repo_root.relative_to(resolved_workspace_root)
+    except ValueError as exc:
+        raise WorkspacePathOutsideRootError(
+            f"Repository '{repo_name}' resolves outside workspace root '{resolved_workspace_root}'"
+        ) from exc
+    return resolved_repo_root
 
 
 def effective_workspace_manifest(ctx: base_cli.Context, workspace_manifest: str | None) -> str | None:

--- a/cli/python/base_projects/workspace_setup.py
+++ b/cli/python/base_projects/workspace_setup.py
@@ -10,6 +10,7 @@ from typing import Any, Literal
 import base_cli
 from base_projects import workspace_context
 from base_projects.workspace_context import resolve_workspace_manifest
+from base_projects.workspace_context import WorkspacePathOutsideRootError
 from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_manifest import WorkspaceManifestError
 from base_projects.workspace_manifest import WorkspaceManifestRepo
@@ -137,7 +138,19 @@ def workspace_setup_manifest_target(
     workspace_root: Path,
     repo: WorkspaceManifestRepo,
 ) -> WorkspaceSetupTarget:
-    root = (workspace_root / repo.name).resolve()
+    try:
+        root = workspace_context.resolve_workspace_repo_root(workspace_root, repo.name)
+    except WorkspacePathOutsideRootError as exc:
+        return WorkspaceSetupTarget(
+            name=repo.name,
+            root=workspace_root / repo.name,
+            manifest_path=None,
+            project_name=None,
+            action="skip",
+            reason=str(exc),
+            required=repo.required,
+            fatal=True,
+        )
     manifest_path = root / "base_manifest.yaml"
 
     if not root.is_dir():

--- a/cli/python/base_projects/workspace_update.py
+++ b/cli/python/base_projects/workspace_update.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 import base_cli
 from base_projects import workspace_context
 from base_projects.workspace_context import resolve_workspace_manifest
+from base_projects.workspace_context import WorkspacePathOutsideRootError
 from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_manifest import WorkspaceManifestRepo
 from base_projects.workspace_manifest import WorkspaceManifestError
@@ -138,7 +139,17 @@ def workspace_update_manifest_target(
     workspace_root: Path,
     repo: WorkspaceManifestRepo,
 ) -> WorkspaceUpdateTarget:
-    root = (workspace_root / repo.name).resolve()
+    try:
+        root = workspace_context.resolve_workspace_repo_root(workspace_root, repo.name)
+    except WorkspacePathOutsideRootError as exc:
+        return WorkspaceUpdateTarget(
+            name=repo.name,
+            root=workspace_root / repo.name,
+            action="skip",
+            reason=str(exc),
+            required=repo.required,
+            fatal=True,
+        )
 
     if not root.is_dir():
         return WorkspaceUpdateTarget(


### PR DESCRIPTION
## Summary

- add a shared resolved-path containment check for workspace repository targets
- route workspace clone, update, setup, and configure (manifest and discovery modes) through the same guard
- fail closed before subprocess execution when a repository symlink resolves outside the workspace
- add regression coverage for escaping symlinks, in-root symlinks, and no-subprocess guarantees

## Issue

Fixes #2099

## Validation

- `env -u BASE_HOME -u BASE_CACHE_DIR BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q cli/python/base_projects/tests/test_workspace_clone.py cli/python/base_projects/tests/test_workspace_update.py cli/python/base_projects/tests/test_workspace_setup.py cli/python/base_projects/tests/test_workspace_configure.py` (27 passed)
- `env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python BASE_CACHE_DIR=/private/tmp/base-issue-2099-gate TZ=UTC ./bin/base-test` (1,134 Python tests and 901 BATS tests passed)
- focused Pylint (clean)
- Bandit medium-severity scan (clean)
- `git diff --check` (clean)

## Security Notes

Repository targets are resolved after symlink evaluation and checked with `relative_to` against the resolved workspace root. An escaping target is reported as a failed skip and is never passed to `git`, `basectl setup`, or `basectl repo configure`; symlinks that remain inside the workspace retain existing behavior.