### PR TITLE
fix(ci): make Project Intake metadata advisory

### DIFF
--- a/.github/workflows/project-intake.yml
+++ b/.github/workflows/project-intake.yml
@@ -1,4 +1,4 @@
-name: Project Intake
+name: Project Intake metadata (advisory)
 
 on:
   issues:
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   sync:
-    name: Sync issue Project fields
+    name: Project metadata sync (advisory)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -64,6 +64,13 @@ jobs:
             printf '%s\n' "$output" | grep -Eiq 'rate limit|secondary rate limit|abuse detection|Retry-After|x-ratelimit-reset'
           }
 
+          project_intake_is_transport_failure() {
+            local output="$1"
+
+            printf '%s\n' "$output" | grep -Eiq \
+              'Could not resolve host|connection (reset|refused)|timed out|HTTP 5(02|03|04)|502 Bad Gateway|503 Service Unavailable|504 Gateway Timeout'
+          }
+
           project_intake_is_project_transport_failure() {
             local output="$1"
 
@@ -75,6 +82,23 @@ jobs:
             local output="$1"
 
             printf '%s\n' "$output" | grep -Eiq 'Content already exists in this project'
+          }
+
+          project_intake_record_advisory() {
+            local category="$1"
+            local operation="$2"
+            local detail="${3:-}"
+
+            echo "::warning::Project metadata synchronization unavailable (advisory, non-product condition): category=$category operation=$operation" >&2
+            [[ -z "$detail" ]] || printf '%s\n' "$detail" >&2
+            if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+              {
+                printf '## Project metadata synchronization (advisory)\n\n'
+                printf -- '- Condition: `%s`\n' "$category"
+                printf -- '- Operation: `%s`\n' "$operation"
+                printf '%s\n' '- Core product validation is unaffected; retry the Project Intake workflow after the GitHub service condition clears.'
+              } >>"$GITHUB_STEP_SUMMARY"
+            fi
           }
 
           project_intake_retry_delay_seconds() {
@@ -156,9 +180,14 @@ jobs:
               return 76
             fi
 
-            if project_intake_is_retryable_api_failure "$diagnostic_output"; then
+            if project_intake_is_retryable_api_failure "$diagnostic_output" ||
+              project_intake_is_transport_failure "$diagnostic_output"; then
               retry_delay="$(project_intake_retry_delay_seconds "$diagnostic_output")"
-              echo "::warning::GitHub API pressure during Project Intake: $operation" >&2
+              if project_intake_is_retryable_api_failure "$diagnostic_output"; then
+                echo "::warning::GitHub API pressure during Project Intake: $operation" >&2
+              else
+                echo "::warning::GitHub transport pressure during Project Intake: $operation" >&2
+              fi
               echo "::warning::Waiting ${retry_delay}s and retrying once." >&2
               sleep "$retry_delay"
               stderr_file="$(mktemp)"
@@ -177,6 +206,21 @@ jobs:
               if [[ -n "$error_output" ]]; then
                 [[ -z "$diagnostic_output" ]] || diagnostic_output+=$'\n'
                 diagnostic_output+="$error_output"
+              fi
+              if project_intake_is_auth_failure "$diagnostic_output"; then
+                echo "::error::GitHub authentication failed during Project Intake: $operation" >&2
+                echo "::error::Rotate BASE_PROJECT_TOKEN and rerun this workflow_dispatch for issue #${issue_number:-unknown}." >&2
+                echo "::error::Fix: gh auth token | gh secret set BASE_PROJECT_TOKEN --repo $GITHUB_REPOSITORY" >&2
+                printf '%s\n' "$diagnostic_output" >&2
+                return "$status"
+              fi
+              if project_intake_is_transport_failure "$diagnostic_output"; then
+                project_intake_record_advisory "transport" "$operation" "$diagnostic_output"
+                return 77
+              fi
+              if project_intake_is_retryable_api_failure "$diagnostic_output"; then
+                project_intake_record_advisory "quota" "$operation" "$diagnostic_output"
+                return 77
               fi
               echo "::error::GitHub API retry failed during Project Intake: $operation" >&2
               printf '%s\n' "$diagnostic_output" >&2
@@ -215,8 +259,9 @@ jobs:
               fi
             done
 
-            echo "::error::Project item '$item_id' was not returned after the bounded visibility retry." >&2
-            return 1
+            project_intake_record_advisory "visibility" "list Project items" \
+              "Project item '$item_id' was not returned after the bounded visibility retry."
+            return 77
           }
 
           project_intake_rest_item_after_add() {
@@ -272,11 +317,20 @@ jobs:
               fi
             done
 
-            echo "::error::REST Project item '$display_item_id' was not returned after the bounded visibility retry." >&2
-            return 1
+            project_intake_record_advisory "visibility" "find REST Project item after add" \
+              "REST Project item '$display_item_id' was not returned after the bounded visibility retry."
+            return 77
           }
 
-          issue_json="$(project_intake_gh "view issue" gh api "repos/$GITHUB_REPOSITORY/issues/$issue_number")"
+          if issue_json="$(project_intake_gh "view issue" gh api "repos/$GITHUB_REPOSITORY/issues/$issue_number")"; then
+            :
+          else
+            issue_status=$?
+            if [[ "$issue_status" == "77" ]]; then
+              exit 0
+            fi
+            exit "$issue_status"
+          fi
           issue_state="$(jq -r '.state | ascii_upcase' <<<"$issue_json")"
           issue_url="$(jq -r '.html_url' <<<"$issue_json")"
           issue_id="$(jq -r '.id' <<<"$issue_json")"
@@ -314,7 +368,7 @@ jobs:
                 head -n 1
             )"
             if [[ -z "$project_number" ]]; then
-              echo "::error::GitHub Project '$BASE_PROJECT_TITLE' was not found for owner '$BASE_PROJECT_OWNER'." >&2
+              echo "::error::Project metadata validation failed: GitHub Project '$BASE_PROJECT_TITLE' was not found for owner '$BASE_PROJECT_OWNER'." >&2
               echo "::error::If this Project exists, set BASE_PROJECT_TOKEN with user Project read/write access." >&2
               return 1
             fi
@@ -377,7 +431,7 @@ jobs:
               field_id="$(graphql_field_id_for "$field_name")"
               option_id="$(graphql_option_id_for "$field_name" "$option_name")"
               if [[ -z "$field_id" || -z "$option_id" ]]; then
-                echo "::error::Project field '$field_name' option '$option_name' was not found." >&2
+                echo "::error::Project field validation failed during Project Intake: field '$field_name' option '$option_name' was not found." >&2
                 return 1
               fi
 
@@ -432,7 +486,7 @@ jobs:
               '.status == $status and .priority == $priority and .size == $size and
                .area == $area and .initiative == $initiative' \
               <<<"$refreshed_item_json" >/dev/null; then
-              echo "::error::Project field verification failed after the GraphQL update." >&2
+              echo "::error::Project field validation failed after the GraphQL update." >&2
               return 1
             fi
           }
@@ -458,8 +512,14 @@ jobs:
             local expected_area
             local expected_initiative
             local verified_item_json
+            local command_status
 
-            owner_json="$(project_intake_gh "view REST Project owner" gh api "users/$BASE_PROJECT_OWNER")"
+            if owner_json="$(project_intake_gh "view REST Project owner" gh api "users/$BASE_PROJECT_OWNER")"; then
+              :
+            else
+              command_status=$?
+              return "$command_status"
+            fi
             owner_type="$(jq -r '.type' <<<"$owner_json")"
             case "$owner_type" in
               Organization)
@@ -474,19 +534,29 @@ jobs:
                 ;;
             esac
 
-            projects_json="$(project_intake_gh "list REST Projects" gh api "$owner_api_prefix/projectsV2?per_page=100")"
+            if projects_json="$(project_intake_gh "list REST Projects" gh api "$owner_api_prefix/projectsV2?per_page=100")"; then
+              :
+            else
+              command_status=$?
+              return "$command_status"
+            fi
             project_number="$(
               jq -r --arg title "$BASE_PROJECT_TITLE" \
                 '.[] | select(.title == $title) | .number' <<<"$projects_json" |
                 head -n 1
             )"
             if [[ -z "$project_number" ]]; then
-              echo "::error::REST Project '$BASE_PROJECT_TITLE' was not found for owner '$BASE_PROJECT_OWNER'." >&2
+              echo "::error::Project metadata validation failed during the REST fallback: Project '$BASE_PROJECT_TITLE' was not found for owner '$BASE_PROJECT_OWNER'." >&2
               return 1
             fi
 
-            fields_json="$(project_intake_gh "list REST Project fields" gh api \
-              "$owner_api_prefix/projectsV2/$project_number/fields?per_page=100")"
+            if fields_json="$(project_intake_gh "list REST Project fields" gh api \
+              "$owner_api_prefix/projectsV2/$project_number/fields?per_page=100")"; then
+              :
+            else
+              command_status=$?
+              return "$command_status"
+            fi
             field_ids_csv="$(
               jq -r \
                 '[.[] | select(.name == "Status" or .name == "Priority" or .name == "Size" or
@@ -494,7 +564,7 @@ jobs:
                 <<<"$fields_json"
             )"
             if [[ "$(awk -F, '{print NF}' <<<"$field_ids_csv")" != "5" ]]; then
-              echo "::error::REST Project field lookup did not resolve all five managed fields." >&2
+              echo "::error::Project field validation failed during the REST fallback: lookup did not resolve all five managed fields." >&2
               return 1
             fi
 
@@ -541,9 +611,14 @@ jobs:
               fi
             fi
 
-            current_item_json="$(project_intake_gh "read REST Project fields" gh api --method GET \
+            if current_item_json="$(project_intake_gh "read REST Project fields" gh api --method GET \
               "$owner_api_prefix/projectsV2/$project_number/items/$item_id" \
-              -f fields="$field_ids_csv")"
+              -f fields="$field_ids_csv")"; then
+              :
+            else
+              command_status=$?
+              return "$command_status"
+            fi
 
             rest_field_id_for() {
               local field_name="$1"
@@ -580,7 +655,7 @@ jobs:
               field_id="$(rest_field_id_for "$field_name")"
               option_id="$(rest_option_id_for "$field_name" "$option_name")"
               if [[ -z "$field_id" || -z "$option_id" ]]; then
-                echo "::error::REST Project field '$field_name' option '$option_name' was not found." >&2
+                echo "::error::Project field validation failed during the REST fallback: field '$field_name' option '$option_name' was not found." >&2
                 return 1
               fi
               updates_json="$(jq -c --argjson id "$field_id" --arg value "$option_id" \
@@ -619,9 +694,14 @@ jobs:
                 --input - <<<"$update_payload" >/dev/null
             fi
 
-            verified_item_json="$(project_intake_gh "verify REST Project fields" gh api --method GET \
+            if verified_item_json="$(project_intake_gh "verify REST Project fields" gh api --method GET \
               "$owner_api_prefix/projectsV2/$project_number/items/$item_id" \
-              -f fields="$field_ids_csv")"
+              -f fields="$field_ids_csv")"; then
+              :
+            else
+              command_status=$?
+              return "$command_status"
+            fi
             if ! jq -e \
               --arg status "$status_value" \
               --arg priority "$expected_priority" \
@@ -637,7 +717,7 @@ jobs:
                value_for("Area") == $area and
                value_for("Initiative") == $initiative' \
               <<<"$verified_item_json" >/dev/null; then
-              echo "::error::Project field verification failed after the REST fallback update." >&2
+              echo "::error::Project field validation failed after the REST fallback update." >&2
               return 1
             fi
           }
@@ -646,11 +726,21 @@ jobs:
             transport="GraphQL"
           else
             graphql_status=$?
+            if [[ "$graphql_status" == "77" ]]; then
+              exit 0
+            fi
             if [[ "$graphql_status" != "75" ]]; then
               exit "$graphql_status"
             fi
-            project_intake_rest_reconcile
-            transport="REST fallback"
+            if project_intake_rest_reconcile; then
+              transport="REST fallback"
+            else
+              rest_status=$?
+              if [[ "$rest_status" == "77" ]]; then
+                exit 0
+              fi
+              exit "$rest_status"
+            fi
           fi
 
           printf 'Synced issue #%s into Project %s via %s.\n' \

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -825,10 +825,14 @@ does not require a secret, never checks out pull-request code, and automatically
 queues default-branch revalidation for matching open pull requests when an
 issue category label changes.
 Set a `BASE_PROJECT_TOKEN` Actions secret with Project write access so that
-workflow can add issue items and apply the repo Project defaults on issue open,
-reopen, and close events. `repo configure` checks for that secret when Project
-support is enabled and prints a `gh secret set BASE_PROJECT_TOKEN` command when
-the required secret is missing.
+advisory `Project Intake metadata` workflow can add issue items and apply the
+repo Project defaults on issue open, reopen, and close events. Quota, transport,
+and delayed-visibility failures are warnings in this metadata workflow and do
+not replace or block required product-validation workflows; authentication,
+Project lookup, field-validation, and exact-readback failures remain errors.
+`repo configure` checks for that secret when Project support is enabled and
+prints a `gh secret set BASE_PROJECT_TOKEN` command when the required secret is
+missing.
 Pass `--no-protect-default-branch` when a repository intentionally skips that
 ruleset. Pass `--no-project` when a repository intentionally skips Base-managed
 Project metadata, or `--project`, `--project-owner`, and

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -160,7 +160,7 @@ repo-local issue creation default. `basectl gh issue create` uses those
 defaults immediately when it creates an issue and adds it to the repo Project.
 
 Base-managed repositories also carry `.github/workflows/project-intake.yml`.
-That workflow is a repo-visible fallback for issues created through GitHub UI,
+That workflow is a repo-visible, advisory metadata fallback for issues created through GitHub UI,
 plain `gh issue create`, or external connectors that can bypass
 `basectl gh issue create` and GitHub's hidden Project auto-add filters.
 `basectl repo configure` creates this workflow when it is missing from older
@@ -179,10 +179,14 @@ quota or reports `unknown owner type`, Project Intake falls back to the REST
 Projects API. The fallback resolves organization and user owners explicitly,
 finds the exact issue item, preserves non-empty Priority, Size, Area, and
 Initiative values, applies the open/closed Status policy, and reads back all
-five fields before reporting success. REST and authorization failures remain
-fail-closed. `401 Unauthorized` / `Bad credentials` errors are treated as token
-configuration failures with `BASE_PROJECT_TOKEN` rotation guidance and can be
-rerun through `workflow_dispatch` after the secret is repaired.
+five fields before reporting success. The workflow is named
+`Project Intake metadata (advisory)` and reports quota, transport, and delayed
+visibility conditions as a warning plus step summary while leaving required
+product validation workflows independent. Authentication, missing-Project, and
+field-validation/readback failures remain fail-closed. `401 Unauthorized` /
+`Bad credentials` errors are treated as token configuration failures with
+`BASE_PROJECT_TOKEN` rotation guidance and can be rerun through
+`workflow_dispatch` after the secret is repaired.
 Use `basectl gh project` directly for lower-level Project inspection,
 schema repair, or issue field updates. `basectl gh project issue set-fields`
 checks that the selected Project is linked to the issue's repository before it

--- a/docs/repo-baseline.md
+++ b/docs/repo-baseline.md
@@ -280,7 +280,8 @@ not a replacement for project tests; it is the seed contract that lets
 `basectl test <project>` work immediately.
 
 The generated `.github/workflows/project-intake.yml` handles issue open,
-reopen, close, and manual dispatch events. It is a visible fallback for issues
+reopen, close, and manual dispatch events. It is a visible, advisory metadata
+fallback for issues
 created outside `basectl gh issue create`: the workflow idempotently adds the
 issue to the repo-named Project and sets `Status`, `Priority`, `Size`, `Area`,
 and `Initiative` from the generated defaults. Set a `BASE_PROJECT_TOKEN`
@@ -293,6 +294,12 @@ once after the reported `Retry-After` or rate-limit reset delay when available.
 `401 Unauthorized` / `Bad credentials` errors remain clear token configuration
 failures with `BASE_PROJECT_TOKEN` rotation guidance and can be rerun through
 `workflow_dispatch` after the secret is repaired.
+
+Project Intake is named `Project Intake metadata (advisory)`. Quota, transport,
+and delayed-visibility conditions produce a warning and step summary without
+changing the required product-validation status. Authentication, missing-Project,
+field-validation, and exact-readback failures remain fail-closed so metadata
+contract problems stay visible and actionable.
 
 For older repositories that predate this workflow, rerun
 `basectl repo configure <path> --repo <owner/name>` to create the missing

--- a/templates/project-intake.yml
+++ b/templates/project-intake.yml
@@ -1,4 +1,4 @@
-name: Project Intake
+name: Project Intake metadata (advisory)
 
 on:
   issues:
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   sync:
-    name: Sync issue Project fields
+    name: Project metadata sync (advisory)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -64,6 +64,13 @@ jobs:
             printf '%s\n' "$output" | grep -Eiq 'rate limit|secondary rate limit|abuse detection|Retry-After|x-ratelimit-reset'
           }
 
+          project_intake_is_transport_failure() {
+            local output="$1"
+
+            printf '%s\n' "$output" | grep -Eiq \
+              'Could not resolve host|connection (reset|refused)|timed out|HTTP 5(02|03|04)|502 Bad Gateway|503 Service Unavailable|504 Gateway Timeout'
+          }
+
           project_intake_is_project_transport_failure() {
             local output="$1"
 
@@ -75,6 +82,23 @@ jobs:
             local output="$1"
 
             printf '%s\n' "$output" | grep -Eiq 'Content already exists in this project'
+          }
+
+          project_intake_record_advisory() {
+            local category="$1"
+            local operation="$2"
+            local detail="${3:-}"
+
+            echo "::warning::Project metadata synchronization unavailable (advisory, non-product condition): category=$category operation=$operation" >&2
+            [[ -z "$detail" ]] || printf '%s\n' "$detail" >&2
+            if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+              {
+                printf '## Project metadata synchronization (advisory)\n\n'
+                printf -- '- Condition: `%s`\n' "$category"
+                printf -- '- Operation: `%s`\n' "$operation"
+                printf '%s\n' '- Core product validation is unaffected; retry the Project Intake workflow after the GitHub service condition clears.'
+              } >>"$GITHUB_STEP_SUMMARY"
+            fi
           }
 
           project_intake_retry_delay_seconds() {
@@ -156,9 +180,14 @@ jobs:
               return 76
             fi
 
-            if project_intake_is_retryable_api_failure "$diagnostic_output"; then
+            if project_intake_is_retryable_api_failure "$diagnostic_output" ||
+              project_intake_is_transport_failure "$diagnostic_output"; then
               retry_delay="$(project_intake_retry_delay_seconds "$diagnostic_output")"
-              echo "::warning::GitHub API pressure during Project Intake: $operation" >&2
+              if project_intake_is_retryable_api_failure "$diagnostic_output"; then
+                echo "::warning::GitHub API pressure during Project Intake: $operation" >&2
+              else
+                echo "::warning::GitHub transport pressure during Project Intake: $operation" >&2
+              fi
               echo "::warning::Waiting ${retry_delay}s and retrying once." >&2
               sleep "$retry_delay"
               stderr_file="$(mktemp)"
@@ -177,6 +206,21 @@ jobs:
               if [[ -n "$error_output" ]]; then
                 [[ -z "$diagnostic_output" ]] || diagnostic_output+=$'\n'
                 diagnostic_output+="$error_output"
+              fi
+              if project_intake_is_auth_failure "$diagnostic_output"; then
+                echo "::error::GitHub authentication failed during Project Intake: $operation" >&2
+                echo "::error::Rotate BASE_PROJECT_TOKEN and rerun this workflow_dispatch for issue #${issue_number:-unknown}." >&2
+                echo "::error::Fix: gh auth token | gh secret set BASE_PROJECT_TOKEN --repo $GITHUB_REPOSITORY" >&2
+                printf '%s\n' "$diagnostic_output" >&2
+                return "$status"
+              fi
+              if project_intake_is_transport_failure "$diagnostic_output"; then
+                project_intake_record_advisory "transport" "$operation" "$diagnostic_output"
+                return 77
+              fi
+              if project_intake_is_retryable_api_failure "$diagnostic_output"; then
+                project_intake_record_advisory "quota" "$operation" "$diagnostic_output"
+                return 77
               fi
               echo "::error::GitHub API retry failed during Project Intake: $operation" >&2
               printf '%s\n' "$diagnostic_output" >&2
@@ -215,8 +259,9 @@ jobs:
               fi
             done
 
-            echo "::error::Project item '$item_id' was not returned after the bounded visibility retry." >&2
-            return 1
+            project_intake_record_advisory "visibility" "list Project items" \
+              "Project item '$item_id' was not returned after the bounded visibility retry."
+            return 77
           }
 
           project_intake_rest_item_after_add() {
@@ -272,11 +317,20 @@ jobs:
               fi
             done
 
-            echo "::error::REST Project item '$display_item_id' was not returned after the bounded visibility retry." >&2
-            return 1
+            project_intake_record_advisory "visibility" "find REST Project item after add" \
+              "REST Project item '$display_item_id' was not returned after the bounded visibility retry."
+            return 77
           }
 
-          issue_json="$(project_intake_gh "view issue" gh api "repos/$GITHUB_REPOSITORY/issues/$issue_number")"
+          if issue_json="$(project_intake_gh "view issue" gh api "repos/$GITHUB_REPOSITORY/issues/$issue_number")"; then
+            :
+          else
+            issue_status=$?
+            if [[ "$issue_status" == "77" ]]; then
+              exit 0
+            fi
+            exit "$issue_status"
+          fi
           issue_state="$(jq -r '.state | ascii_upcase' <<<"$issue_json")"
           issue_url="$(jq -r '.html_url' <<<"$issue_json")"
           issue_id="$(jq -r '.id' <<<"$issue_json")"
@@ -314,7 +368,7 @@ jobs:
                 head -n 1
             )"
             if [[ -z "$project_number" ]]; then
-              echo "::error::GitHub Project '$BASE_PROJECT_TITLE' was not found for owner '$BASE_PROJECT_OWNER'." >&2
+              echo "::error::Project metadata validation failed: GitHub Project '$BASE_PROJECT_TITLE' was not found for owner '$BASE_PROJECT_OWNER'." >&2
               echo "::error::If this Project exists, set BASE_PROJECT_TOKEN with user Project read/write access." >&2
               return 1
             fi
@@ -377,7 +431,7 @@ jobs:
               field_id="$(graphql_field_id_for "$field_name")"
               option_id="$(graphql_option_id_for "$field_name" "$option_name")"
               if [[ -z "$field_id" || -z "$option_id" ]]; then
-                echo "::error::Project field '$field_name' option '$option_name' was not found." >&2
+                echo "::error::Project field validation failed during Project Intake: field '$field_name' option '$option_name' was not found." >&2
                 return 1
               fi
 
@@ -432,7 +486,7 @@ jobs:
               '.status == $status and .priority == $priority and .size == $size and
                .area == $area and .initiative == $initiative' \
               <<<"$refreshed_item_json" >/dev/null; then
-              echo "::error::Project field verification failed after the GraphQL update." >&2
+              echo "::error::Project field validation failed after the GraphQL update." >&2
               return 1
             fi
           }
@@ -458,8 +512,14 @@ jobs:
             local expected_area
             local expected_initiative
             local verified_item_json
+            local command_status
 
-            owner_json="$(project_intake_gh "view REST Project owner" gh api "users/$BASE_PROJECT_OWNER")"
+            if owner_json="$(project_intake_gh "view REST Project owner" gh api "users/$BASE_PROJECT_OWNER")"; then
+              :
+            else
+              command_status=$?
+              return "$command_status"
+            fi
             owner_type="$(jq -r '.type' <<<"$owner_json")"
             case "$owner_type" in
               Organization)
@@ -474,19 +534,29 @@ jobs:
                 ;;
             esac
 
-            projects_json="$(project_intake_gh "list REST Projects" gh api "$owner_api_prefix/projectsV2?per_page=100")"
+            if projects_json="$(project_intake_gh "list REST Projects" gh api "$owner_api_prefix/projectsV2?per_page=100")"; then
+              :
+            else
+              command_status=$?
+              return "$command_status"
+            fi
             project_number="$(
               jq -r --arg title "$BASE_PROJECT_TITLE" \
                 '.[] | select(.title == $title) | .number' <<<"$projects_json" |
                 head -n 1
             )"
             if [[ -z "$project_number" ]]; then
-              echo "::error::REST Project '$BASE_PROJECT_TITLE' was not found for owner '$BASE_PROJECT_OWNER'." >&2
+              echo "::error::Project metadata validation failed during the REST fallback: Project '$BASE_PROJECT_TITLE' was not found for owner '$BASE_PROJECT_OWNER'." >&2
               return 1
             fi
 
-            fields_json="$(project_intake_gh "list REST Project fields" gh api \
-              "$owner_api_prefix/projectsV2/$project_number/fields?per_page=100")"
+            if fields_json="$(project_intake_gh "list REST Project fields" gh api \
+              "$owner_api_prefix/projectsV2/$project_number/fields?per_page=100")"; then
+              :
+            else
+              command_status=$?
+              return "$command_status"
+            fi
             field_ids_csv="$(
               jq -r \
                 '[.[] | select(.name == "Status" or .name == "Priority" or .name == "Size" or
@@ -494,7 +564,7 @@ jobs:
                 <<<"$fields_json"
             )"
             if [[ "$(awk -F, '{print NF}' <<<"$field_ids_csv")" != "5" ]]; then
-              echo "::error::REST Project field lookup did not resolve all five managed fields." >&2
+              echo "::error::Project field validation failed during the REST fallback: lookup did not resolve all five managed fields." >&2
               return 1
             fi
 
@@ -541,9 +611,14 @@ jobs:
               fi
             fi
 
-            current_item_json="$(project_intake_gh "read REST Project fields" gh api --method GET \
+            if current_item_json="$(project_intake_gh "read REST Project fields" gh api --method GET \
               "$owner_api_prefix/projectsV2/$project_number/items/$item_id" \
-              -f fields="$field_ids_csv")"
+              -f fields="$field_ids_csv")"; then
+              :
+            else
+              command_status=$?
+              return "$command_status"
+            fi
 
             rest_field_id_for() {
               local field_name="$1"
@@ -580,7 +655,7 @@ jobs:
               field_id="$(rest_field_id_for "$field_name")"
               option_id="$(rest_option_id_for "$field_name" "$option_name")"
               if [[ -z "$field_id" || -z "$option_id" ]]; then
-                echo "::error::REST Project field '$field_name' option '$option_name' was not found." >&2
+                echo "::error::Project field validation failed during the REST fallback: field '$field_name' option '$option_name' was not found." >&2
                 return 1
               fi
               updates_json="$(jq -c --argjson id "$field_id" --arg value "$option_id" \
@@ -619,9 +694,14 @@ jobs:
                 --input - <<<"$update_payload" >/dev/null
             fi
 
-            verified_item_json="$(project_intake_gh "verify REST Project fields" gh api --method GET \
+            if verified_item_json="$(project_intake_gh "verify REST Project fields" gh api --method GET \
               "$owner_api_prefix/projectsV2/$project_number/items/$item_id" \
-              -f fields="$field_ids_csv")"
+              -f fields="$field_ids_csv")"; then
+              :
+            else
+              command_status=$?
+              return "$command_status"
+            fi
             if ! jq -e \
               --arg status "$status_value" \
               --arg priority "$expected_priority" \
@@ -637,7 +717,7 @@ jobs:
                value_for("Area") == $area and
                value_for("Initiative") == $initiative' \
               <<<"$verified_item_json" >/dev/null; then
-              echo "::error::Project field verification failed after the REST fallback update." >&2
+              echo "::error::Project field validation failed after the REST fallback update." >&2
               return 1
             fi
           }
@@ -646,11 +726,21 @@ jobs:
             transport="GraphQL"
           else
             graphql_status=$?
+            if [[ "$graphql_status" == "77" ]]; then
+              exit 0
+            fi
             if [[ "$graphql_status" != "75" ]]; then
               exit "$graphql_status"
             fi
-            project_intake_rest_reconcile
-            transport="REST fallback"
+            if project_intake_rest_reconcile; then
+              transport="REST fallback"
+            else
+              rest_status=$?
+              if [[ "$rest_status" == "77" ]]; then
+                exit 0
+              fi
+              exit "$rest_status"
+            fi
           fi
 
           printf 'Synced issue #%s into Project %s via %s.\n' \

--- a/tests/github_workflow_test_support.py
+++ b/tests/github_workflow_test_support.py
@@ -342,7 +342,18 @@ case "$*" in
     fi
     ;;
   project\\ field-list*)
-    cat <<'JSON'
+    if [[ "${PROJECT_INTAKE_MISSING_FIELD_OPTION:-0}" == "1" ]]; then
+      cat <<'JSON'
+{"fields":[
+  {"name":"Status","id":"F_status","options":[{"name":"Backlog","id":"O_backlog"},{"name":"Done","id":"O_done"}]},
+  {"name":"Priority","id":"F_priority","options":[{"name":"P2","id":"O_p2"}]},
+  {"name":"Size","id":"F_size","options":[{"name":"S","id":"O_s"}]},
+  {"name":"Area","id":"F_area","options":[]},
+  {"name":"Initiative","id":"F_initiative","options":[{"name":"Adoption Polish","id":"O_adoption"}]}
+]}
+JSON
+    else
+      cat <<'JSON'
 {"fields":[
   {"name":"Status","id":"F_status","options":[{"name":"Backlog","id":"O_backlog"},{"name":"Done","id":"O_done"}]},
   {"name":"Priority","id":"F_priority","options":[{"name":"P2","id":"O_p2"}]},
@@ -351,6 +362,7 @@ case "$*" in
   {"name":"Initiative","id":"F_initiative","options":[{"name":"Adoption Polish","id":"O_adoption"}]}
 ]}
 JSON
+    fi
     ;;
   project\\ item-edit*)
     printf '%s\\n' "$*" >> "${PROJECT_INTAKE_STATE:?}/edits.log"
@@ -372,6 +384,16 @@ JSON
     project_intake_mock_write_option "$field_id" "$option_id"
     ;;
   "api users/basefoundry")
+    if [[ "${PROJECT_INTAKE_REST_FAIL_OPERATION:-}" == "owner" ]]; then
+      printf 'API rate limit already exceeded\\n' >&2
+      printf 'Retry-After: 7\\n' >&2
+      exit 1
+    fi
+    if [[ "${PROJECT_INTAKE_REST_FAIL_OPERATION:-}" == "transport-owner" ]]; then
+      printf '503 Service Unavailable\\n' >&2
+      printf 'Retry-After: 3\\n' >&2
+      exit 1
+    fi
     printf '{"login":"basefoundry","type":"%s"}\\n' "${PROJECT_INTAKE_OWNER_TYPE:-Organization}"
     ;;
   api\\ *projectsV2\\?per_page=100)

--- a/tests/test_project_intake_workflow.py
+++ b/tests/test_project_intake_workflow.py
@@ -39,6 +39,8 @@ def test_project_intake_requires_base_project_token() -> None:
     sync_job = workflow["jobs"]["sync"]
     run_command = project_intake_run_command()
 
+    assert workflow["name"] == "Project Intake metadata (advisory)"
+    assert sync_job["name"] == "Project metadata sync (advisory)"
     assert sync_job["env"]["GH_TOKEN"] == "${{ secrets.BASE_PROJECT_TOKEN }}"
     assert "github.token" not in run_command
     assert "BASE_PROJECT_TOKEN secret is required for Project Intake." in run_command
@@ -72,6 +74,9 @@ def test_project_intake_classifies_rate_limits_and_auth_failures() -> None:
     assert "project_intake_is_project_transport_failure()" in run_command
     assert "unknown owner type" in run_command
     assert "Falling back to the REST Projects API." in run_command
+    assert "project_intake_is_transport_failure()" in run_command
+    assert "project_intake_record_advisory()" in run_command
+    assert "advisory, non-product condition" in run_command
     assert 'project_intake_gh "update REST Project fields" gh api --method PATCH' in run_command
 
 
@@ -105,6 +110,39 @@ def test_project_intake_auth_failures_do_not_retry(tmp_path: Path) -> None:
     assert "retrying once" not in result.stderr
     assert not (tmp_path / "sleep.log").exists()
     assert (tmp_path / "issue-view-count").read_text(encoding="utf-8") == "1\n"
+
+
+def test_project_intake_persistent_quota_is_advisory_and_does_not_fail_product_ci(
+    tmp_path: Path,
+) -> None:
+    summary_path = tmp_path / "summary.md"
+    result = run_project_intake_script(
+        tmp_path,
+        PROJECT_INTAKE_GRAPHQL_FAILURE="quota",
+        PROJECT_INTAKE_REST_FAIL_OPERATION="owner",
+        GITHUB_STEP_SUMMARY=str(summary_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "category=quota" in result.stderr
+    assert "Core product validation is unaffected" in summary_path.read_text(encoding="utf-8")
+    assert (tmp_path / "sleep.log").read_text(encoding="utf-8") == "7\n"
+    assert "Synced issue" not in result.stdout
+
+
+def test_project_intake_transport_failure_is_advisory_after_retry(tmp_path: Path) -> None:
+    summary_path = tmp_path / "summary.md"
+    result = run_project_intake_script(
+        tmp_path,
+        PROJECT_INTAKE_GRAPHQL_FAILURE="quota",
+        PROJECT_INTAKE_REST_FAIL_OPERATION="transport-owner",
+        GITHUB_STEP_SUMMARY=str(summary_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "category=transport" in result.stderr
+    assert "Core product validation is unaffected" in summary_path.read_text(encoding="utf-8")
+    assert (tmp_path / "sleep.log").read_text(encoding="utf-8") == "3\n"
 
 
 def test_project_intake_falls_back_to_rest_for_graphql_quota_exhaustion(
@@ -192,17 +230,31 @@ def test_project_intake_retries_graphql_item_visibility_after_add(tmp_path: Path
     assert gh_log.count("project item-list") == 3
 
 
-def test_project_intake_fails_closed_when_graphql_item_never_becomes_visible(
+def test_project_intake_graphql_item_never_visible_is_advisory(
     tmp_path: Path,
 ) -> None:
+    summary_path = tmp_path / "summary.md"
     result = run_project_intake_script(
         tmp_path,
         PROJECT_INTAKE_ITEM_NEVER_VISIBLE="1",
+        GITHUB_STEP_SUMMARY=str(summary_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "category=visibility" in result.stderr
+    assert "Core product validation is unaffected" in summary_path.read_text(encoding="utf-8")
+    assert (tmp_path / "sleep.log").read_text(encoding="utf-8") == "1\n2\n"
+    assert "Synced issue" not in result.stdout
+
+
+def test_project_intake_field_validation_remains_fail_closed(tmp_path: Path) -> None:
+    result = run_project_intake_script(
+        tmp_path,
+        PROJECT_INTAKE_MISSING_FIELD_OPTION="1",
     )
 
     assert result.returncode != 0
-    assert "bounded visibility retry" in result.stderr
-    assert (tmp_path / "sleep.log").read_text(encoding="utf-8") == "1\n2\n"
+    assert "Project field validation failed" in result.stderr
     assert "Synced issue" not in result.stdout
 
 


### PR DESCRIPTION
## Summary

- classify quota, transport, and delayed-visibility failures as advisory non-product conditions
- keep authentication, Project lookup, field-validation, and exact-readback failures fail-closed
- add warning and step-summary diagnostics, synchronized workflow/template coverage, and focused fixtures

## Issue

Fixes #2114

## Validation

- `pytest -q tests/test_project_intake_workflow.py tests/test_github_workflows.py` (61 passed)
- full Python source-checkout suite (1,145 passed)
- full clean Bats source-checkout suite (901 passed)
- `git diff --check`

## Non-goals

- no removal of Project metadata synchronization
- no changes to required product-test workflows
- no hiding of authentication or Project contract failures

## Docs Impact

Updated GitHub workflow, repository baseline, and command-reference guidance.

## AI Context

Implementation and validation were performed in the canonical issue worktree; no production Project state was modified.