### PR TITLE
fix(basectl): reuse shared branch and dry-run helpers

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -80,7 +80,7 @@ setup_backup_timestamp() {
 }
 
 setup_is_dry_run() {
-    [[ "${BASE_BASH_LIBS_DRY_RUN-}" == true ]]
+    base_std_is_dry_run
 }
 
 setup_enable_yes() {

--- a/cli/bash/commands/basectl/subcommands/update.sh
+++ b/cli/bash/commands/basectl/subcommands/update.sh
@@ -397,32 +397,19 @@ base_update_homebrew_install() {
 
 base_update_current_branch() {
     local repo="$1"
-    git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null
+    local branch
+
+    base_git_get_current_branch "$repo" branch || return 1
+    [[ -n "$branch" ]] || return 1
+    printf '%s\n' "$branch"
 }
 
 base_update_default_branch() {
     local repo="$1"
     local default_branch
 
-    if default_branch="$(git -C "$repo" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)"; then
-        default_branch="${default_branch#origin/}"
-        if [[ -n "$default_branch" ]]; then
-            printf '%s\n' "$default_branch"
-            return 0
-        fi
-    fi
-
-    if git -C "$repo" show-ref --verify --quiet refs/heads/main; then
-        printf '%s\n' main
-        return 0
-    fi
-
-    if git -C "$repo" show-ref --verify --quiet refs/heads/master; then
-        printf '%s\n' master
-        return 0
-    fi
-
-    return 1
+    base_git_detect_default_branch "$repo" default_branch || return 1
+    printf '%s\n' "$default_branch"
 }
 
 base_update_worktree_clean() {
@@ -535,11 +522,13 @@ base_update_subcommand_main() {
 
     base_std_log_debug "Running 'basectl update' for project '$resolved_project'."
 
+    if [[ "$resolved_project" == base ]] && base_update_is_homebrew_install "$base_home"; then
+        base_update_homebrew_install "$base_home" "$dry_run"
+        return $?
+    fi
+
+    base_update_source_git_library || return 1
     branch="$(base_update_current_branch "$repo")" || {
-        if [[ "$resolved_project" == base ]] && base_update_is_homebrew_install "$base_home"; then
-            base_update_homebrew_install "$base_home" "$dry_run"
-            return $?
-        fi
         base_std_log_error "Project '$resolved_project' repository '$repo' is not a Git repository."
         return 1
     }
@@ -566,7 +555,6 @@ base_update_subcommand_main() {
         return 0
     fi
 
-    base_update_source_git_library || return 1
     before_revision="$(base_update_head_revision "$repo")" || {
         base_std_log_error "Unable to read current revision for project '$resolved_project'."
         return 1

--- a/cli/bash/commands/basectl/tests/setup-common.bats
+++ b/cli/bash/commands/basectl/tests/setup-common.bats
@@ -49,6 +49,29 @@ run_setup_common_script() {
     [ "$output" = "$expected_pythonpath:/opt/example/python" ]
 }
 
+@test "setup_common delegates dry-run truthiness to the shared stdlib" {
+    run_setup_common_script '
+        for value in true 1 yes on; do
+            BASE_BASH_LIBS_DRY_RUN="$value"
+            setup_is_dry_run || {
+                printf "expected dry-run value to be enabled: %s\n" "$value" >&2
+                exit 1
+            }
+        done
+        for value in "" false 0 no off; do
+            BASE_BASH_LIBS_DRY_RUN="$value"
+            if setup_is_dry_run; then
+                printf "expected dry-run value to be disabled: %s\n" "$value" >&2
+                exit 1
+            fi
+        done
+        printf "dry-run truthiness is shared\n"
+    '
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "dry-run truthiness is shared" ]
+}
+
 @test "setup_common parses explicit warning check results" {
     local result_file="$TEST_STATE_DIR/check.result"
 

--- a/cli/bash/commands/basectl/tests/update.bats
+++ b/cli/bash/commands/basectl/tests/update.bats
@@ -457,7 +457,6 @@ EOF
             base_update_current_branch() { printf "%s\n" master; }
             base_update_default_branch() { printf "%s\n" master; }
             base_update_worktree_clean() { return 1; }
-            base_update_source_git_library() { printf "git library should not load\n"; return 99; }
             base_git_update_repo() { printf "git update should not run\n"; return 99; }
             base_update_run_setup() { printf "setup should not run\n"; return 99; }
             base_update_subcommand_main
@@ -465,7 +464,6 @@ EOF
 
     [ "$status" -eq 1 ]
     [[ "$output" == *"Project 'base' repository has tracked local changes."* ]]
-    [[ "$output" != *"git library should not load"* ]]
     [[ "$output" != *"git update should not run"* ]]
     [[ "$output" != *"setup should not run"* ]]
 }
@@ -487,10 +485,12 @@ EOF
     run env \
         HOME="$TEST_HOME" \
         BASE_HOME="$repo" \
+        BASE_BASH_LIBS_DIR="$TEST_TMPDIR/base-bash-libs/lib/bash" \
         BASE_TEST_AFTER_UPDATE="$TEST_TMPDIR/after-update" \
         bash -c '
             source "$BASE_HOME/base_init.sh"
             source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
+            import_base_lib git/lib_git.sh
             base_update_source_git_library() { :; }
             base_git_update_repo() { printf "git update repo=%s branch=%s\n" "$1" "$3"; }
             base_update_head_revision() {
@@ -530,6 +530,34 @@ EOF
     [[ "$output" == *"Project 'base' update only runs on default branch 'main'; current branch is 'feature/example'."* ]]
     [[ "$output" != *"clean should not run"* ]]
     [[ "$output" != *"setup should not run"* ]]
+}
+
+@test "basectl update uses a remote-only default branch" {
+    local repo="$TEST_TMPDIR/repo"
+
+    init_git_repo "$repo"
+    printf 'base\n' > "$repo/data.txt"
+    commit_all "$repo" "Initial commit"
+    git -C "$repo" update-ref refs/remotes/origin/main HEAD
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_TEST_UPDATE_REPO="$repo" \
+        BASE_BASH_LIBS_DIR="$(base_bash_libs_fixture_dir)" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/update.sh"
+            base_update_resolve_project() {
+                printf -v "$3" "%s" base
+                printf -v "$4" "%s" "$BASE_TEST_UPDATE_REPO"
+                printf -v "$5" "%s" "$BASE_TEST_UPDATE_REPO/base_manifest.yaml"
+            }
+            base_update_subcommand_main --dry-run
+        '
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Project 'base' update only runs on default branch 'main'; current branch is 'master'."* ]]
 }
 
 @test "basectl update skips setup for already up-to-date repositories" {


### PR DESCRIPTION
## Summary

- Delegate update branch detection to the shared base-bash-libs Git helpers.
- Delegate setup dry-run detection to the shared stdlib truthiness contract.
- Add regression coverage for remote-only default branches and dry-run values.

## Issue

Fixes #2122

## Validation

- Complete basectl BATS matrix: 750/750 passed.
- ShellCheck, bash syntax, and diff checks passed.
- Full bin/base-test was attempted locally but stopped during Python collection because jsonschema is missing from the test environment.