### PR TITLE
feat(release): add ecosystem compatibility BOM contract and gate

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -130,7 +130,9 @@ the v1.x compatibility window; new automation should use `--debug-wrapper`.
   `basectl ci setup|check|doctor` remains a deprecated compatibility alias for
   the canonical lifecycle command with `--ci`.
 - `basectl release <check|plan|notes|publish>` - inspect release readiness,
-  print plans/notes, and publish guarded GitHub-side release artifacts.
+  print plans/notes, and publish guarded GitHub-side release artifacts. Pass
+  `--bom <path>` to `check` or `publish` for the cross-repository compatibility
+  gate; `bin/base-release-bom` validates and fingerprints the record.
 - `basectl gh <area> <command>` - manage GitHub issues, PRs, branches, repo
   hygiene, and Project metadata using Base conventions.
   - `basectl gh issue create` defaults to category `enhancement` when

--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -134,6 +134,12 @@ The `basectl release check|plan|notes` commands are read-only inspection
 commands. `basectl release publish` is guarded and creates the annotated tag and
 GitHub Release after checks pass. The Homebrew tap update happens in
 `basefoundry/homebrew-base` after the Base tag and GitHub Release exist.
+Coordinated ecosystem releases additionally pass `--bom <path>` to `release
+check` and `release publish`. The BOM is the authoritative cross-repository
+attestation: required rows must use immutable commits and report passing
+evidence, while moving-source rows are advisory and non-blocking. Validate and
+fingerprint a record with `bin/base-release-bom`; attach the BOM and digest to
+the resulting release evidence.
 Supported macOS tap releases should publish Homebrew bottles before the tap PR
 is merged: run the tap's `Build Base Bottles` workflow from the tap release
 branch, let it upload bottle assets to the tap release `base-vX.Y.Z`, and commit

--- a/bin/base-release-bom
+++ b/bin/base-release-bom
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+base_release_bom_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)" || exit 1
+base_release_bom_pythonpath="$base_release_bom_root/cli/python"
+if [[ -n "${PYTHONPATH:-}" ]]; then
+    base_release_bom_pythonpath="$base_release_bom_pythonpath:$PYTHONPATH"
+fi
+PYTHONPATH="$base_release_bom_pythonpath" exec python3 -m base_release.release_bom_cli "$@"

--- a/cli/bash/commands/basectl/subcommands/release.sh
+++ b/cli/bash/commands/basectl/subcommands/release.sh
@@ -12,7 +12,7 @@ Usage:
   basectl release publish --version <version> [options]
 
 Subcommands:
-  check    Verify release readiness for version, changelog, Git, and GitHub.
+  check    Verify release readiness for version, changelog, Git, GitHub, and an optional BOM.
   plan     Show the release plan without creating tags or releases.
   notes    Print the changelog notes for the target version.
   publish  Tag the release and create the GitHub Release.
@@ -20,6 +20,7 @@ Subcommands:
 Options:
   --version <version>  Release version to inspect.
   --manifest <path>   Use a specific base_manifest.yaml path.
+  --bom <path>         Validate a release BOM during check or publish.
   --format <text|csv|tsv|yaml|json>
                       Select the release check output format.
   --dry-run           Print publish actions without creating tags or releases.
@@ -57,7 +58,7 @@ base_release_leaf_usage() {
     if [[ "$release_command" == "publish" ]]; then
         cat <<EOF
 Usage:
-  basectl release publish --version <version> [--manifest <path>] [--dry-run] [--yes]
+  basectl release publish --version <version> [--manifest <path>] [--bom <path>] [--dry-run] [--yes]
 
 Purpose:
   $purpose
@@ -65,6 +66,7 @@ Purpose:
 Options:
   --version <version>  Release version to publish.
   --manifest <path>    Use a specific base_manifest.yaml path.
+  --bom <path>         Validate a release BOM before publishing.
   --dry-run            Print publish actions without creating tags or releases.
   --yes                Publish without an interactive confirmation prompt.
   -h, --help           Show this help text.
@@ -75,7 +77,7 @@ EOF
     if [[ "$release_command" == "check" ]]; then
         cat <<EOF
 Usage:
-  basectl release check --version <version> [--manifest <path>] [--format <text|csv|tsv|yaml|json>]
+  basectl release check --version <version> [--manifest <path>] [--bom <path>] [--format <text|csv|tsv|yaml|json>]
 
 Purpose:
   $purpose
@@ -83,6 +85,7 @@ Purpose:
 Options:
   --version <version>  Release version to inspect.
   --manifest <path>    Use a specific base_manifest.yaml path.
+  --bom <path>         Validate a release BOM during the readiness check.
   --format <text|csv|tsv|yaml|json> Select the release check output format.
   -h, --help           Show this help text.
 EOF

--- a/cli/bash/commands/basectl/tests/release.bats
+++ b/cli/bash/commands/basectl/tests/release.bats
@@ -33,7 +33,21 @@ load ./basectl_helpers.bash
 @test "basectl release leaves print scoped public help without Python runtime options" {
     local command
 
-    for command in check plan notes; do
+    run_basectl release check --help
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"basectl release check --version <version> [--manifest <path>] [--bom <path>]"* ]]
+    [[ "$output" == *"--bom <path>"* ]]
+    [[ "$output" != *"--dry-run"* ]]
+    [[ "$output" != *"--yes"* ]]
+    [[ "$output" != *"--quiet"* ]]
+    [[ "$output" != *"--debug"* ]]
+    [[ "$output" != *"--environment"* ]]
+    [[ "$output" != *"--config"* ]]
+    [[ "$output" != *"--keep-temp"* ]]
+    [[ "$output" != *"--log-file"* ]]
+
+    for command in plan notes; do
         run_basectl release "$command" --help
 
         [ "$status" -eq 0 ]
@@ -53,7 +67,7 @@ load ./basectl_helpers.bash
     run_basectl release publish --help
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"basectl release publish --version <version> [--manifest <path>] [--dry-run] [--yes]"* ]]
+    [[ "$output" == *"basectl release publish --version <version> [--manifest <path>] [--bom <path>] [--dry-run] [--yes]"* ]]
     [[ "$output" == *"--dry-run"* ]]
     [[ "$output" == *"--yes"* ]]
     [[ "$output" != *"--quiet"* ]]
@@ -116,5 +130,5 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"release_commands=check plan notes publish"* ]]
     [[ "$output" == *"release_check_options=--version --manifest"* ]]
-    [[ "$output" == *"release_publish_options=--version --manifest --dry-run --yes"* ]]
+    [[ "$output" == *"release_publish_options=--version --manifest --bom --dry-run --yes"* ]]
 }

--- a/cli/python/base_release/engine.py
+++ b/cli/python/base_release/engine.py
@@ -120,6 +120,7 @@ def build_release_context(ctx: base_cli.Context, args: ReleaseArguments) -> Rele
         tag_name=f"{release.tag_prefix}{args.version}",
         version_file=project_root / release.version_file,
         changelog=project_root / release.changelog,
+        bom_path=(manifest_path.parent / args.bom_path).resolve() if args.bom_path else None,
     )
 
 

--- a/cli/python/base_release/release_bom.py
+++ b/cli/python/base_release/release_bom.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+$")
+RESULTS = {"passed", "failed", "not_tested"}
+SOURCE_MODES = {"release", "tag", "moving"}
+
+
+class ReleaseBomError(ValueError):
+    """Raised when a release BOM is malformed or fails its release gate."""
+
+
+def load_bom(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ReleaseBomError(f"could not read BOM {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ReleaseBomError(f"BOM {path} is not valid JSON: {exc.msg}") from exc
+    if not isinstance(value, dict):
+        raise ReleaseBomError("BOM document must be a JSON object")
+    return value
+
+
+# pylint: disable=too-many-branches,too-many-statements
+def validate_bom(
+    document: dict[str, Any],
+    *,
+    expected_repository: str | None = None,
+    expected_version: str | None = None,
+    expected_commit: str | None = None,
+) -> None:
+    if document.get("schema_version") != 1:
+        raise ReleaseBomError("schema_version must be 1")
+
+    release = _mapping(document, "release")
+    _repository(release, "repository", "release")
+    release_version = _string(release, "version", "release.version")
+    release_tag = _string(release, "tag", "release.tag")
+    release_commit = _commit(release, "commit", "release.commit")
+    if not TAG_RE.fullmatch(release_tag) or release_tag != f"v{release_version}":
+        raise ReleaseBomError("release.tag must be v<release.version>")
+    if expected_repository is not None and release["repository"] != expected_repository:
+        raise ReleaseBomError(
+            f"release.repository {release['repository']!r} does not match {expected_repository!r}"
+        )
+    if expected_version is not None and release_version != expected_version:
+        raise ReleaseBomError(
+            f"release.version {release_version!r} does not match {expected_version!r}"
+        )
+    if expected_commit is not None and release_commit != expected_commit:
+        raise ReleaseBomError("release.commit does not match the reviewed release commit")
+
+    components = document.get("components")
+    if not isinstance(components, list) or not components:
+        raise ReleaseBomError("components must be a non-empty array")
+    component_repositories: set[str] = set()
+    for index, component in enumerate(components):
+        path = f"components[{index}]"
+        row = _mapping_value(component, path)
+        repository = _repository(row, "repository", path)
+        if repository in component_repositories:
+            raise ReleaseBomError(f"{path}.repository is duplicated: {repository}")
+        component_repositories.add(repository)
+        _string(row, "version", f"{path}.version")
+        source_mode = _string(row, "source_mode", f"{path}.source_mode")
+        if source_mode not in SOURCE_MODES:
+            raise ReleaseBomError(f"{path}.source_mode must be one of: {', '.join(sorted(SOURCE_MODES))}")
+        commit = _commit(row, "commit", path)
+        required = _boolean(row, "required", path)
+        _string(row, "api_schema_version", f"{path}.api_schema_version")
+        platforms = row.get("platforms")
+        if not isinstance(platforms, list) or not platforms or not all(
+            isinstance(platform, str) and platform.strip() for platform in platforms
+        ):
+            raise ReleaseBomError(f"{path}.platforms must be a non-empty array of strings")
+        result = _string(row, "result", f"{path}.result")
+        if result not in RESULTS:
+            raise ReleaseBomError(f"{path}.result must be one of: {', '.join(sorted(RESULTS))}")
+        evidence = _string(row, "evidence", f"{path}.evidence")
+        if required:
+            if source_mode == "moving":
+                raise ReleaseBomError(f"{path} cannot require a moving source")
+            if result != "passed":
+                raise ReleaseBomError(f"{path} is required but result is {result!r}")
+            if not evidence:
+                raise ReleaseBomError(f"{path}.evidence is required")
+        if source_mode == "moving" and row.get("tag") is not None:
+            raise ReleaseBomError(f"{path}.tag must be omitted for moving sources")
+        if source_mode != "moving":
+            tag = _string(row, "tag", f"{path}.tag")
+            if not TAG_RE.fullmatch(tag):
+                raise ReleaseBomError(f"{path}.tag must be an immutable vX.Y.Z tag")
+        if commit != commit.lower():
+            raise ReleaseBomError(f"{path}.commit must use lowercase hexadecimal")
+
+    combinations = document.get("combinations")
+    if not isinstance(combinations, list) or not combinations:
+        raise ReleaseBomError("combinations must be a non-empty array")
+    required_combination = False
+    for index, combination in enumerate(combinations):
+        path = f"combinations[{index}]"
+        row = _mapping_value(combination, path)
+        _string(row, "name", f"{path}.name")
+        participants = row.get("participants")
+        if not isinstance(participants, list) or not participants:
+            raise ReleaseBomError(f"{path}.participants must be a non-empty array")
+        if not all(isinstance(participant, str) for participant in participants):
+            raise ReleaseBomError(f"{path}.participants must contain repository strings")
+        unknown = sorted(set(participants) - component_repositories)
+        if unknown:
+            raise ReleaseBomError(f"{path}.participants references unknown components: {unknown}")
+        _string(row, "platform", f"{path}.platform")
+        required = _boolean(row, "required", path)
+        result = _string(row, "result", f"{path}.result")
+        if result not in RESULTS:
+            raise ReleaseBomError(f"{path}.result must be one of: {', '.join(sorted(RESULTS))}")
+        evidence = _string(row, "evidence", f"{path}.evidence")
+        if required:
+            required_combination = True
+            if result != "passed":
+                raise ReleaseBomError(f"{path} is required but result is {result!r}")
+            if not evidence:
+                raise ReleaseBomError(f"{path}.evidence is required")
+    if not required_combination:
+        raise ReleaseBomError("at least one required combination must be declared")
+
+
+def validate_bom_file(
+    path: Path,
+    *,
+    expected_repository: str | None = None,
+    expected_version: str | None = None,
+    expected_commit: str | None = None,
+) -> None:
+    validate_bom(
+        load_bom(path),
+        expected_repository=expected_repository,
+        expected_version=expected_version,
+        expected_commit=expected_commit,
+    )
+
+
+def canonical_bom_bytes(document: dict[str, Any]) -> bytes:
+    return (json.dumps(document, sort_keys=True, separators=(",", ":"), ensure_ascii=True) + "\n").encode(
+        "utf-8"
+    )
+
+
+def bom_digest(document: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_bom_bytes(document)).hexdigest()
+
+
+def _mapping(document: dict[str, Any], key: str) -> dict[str, Any]:
+    return _mapping_value(document.get(key), key)
+
+
+def _mapping_value(value: Any, path: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ReleaseBomError(f"{path} must be an object")
+    return value
+
+
+def _string(row: dict[str, Any], key: str, path: str) -> str:
+    value = row.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ReleaseBomError(f"{path} must be a non-empty string")
+    return value
+
+
+def _repository(row: dict[str, Any], key: str = "repository", path: str = "") -> str:
+    value = _string(row, key, f"{path + '.' if path else ''}{key}")
+    if "/" not in value or value.startswith("/") or value.endswith("/"):
+        raise ReleaseBomError(f"{path + '.' if path else ''}{key} must use owner/name format")
+    return value
+
+
+def _commit(row: dict[str, Any], key: str, path: str) -> str:
+    value = _string(row, key, f"{path}.{key}")
+    if not FULL_SHA_RE.fullmatch(value.lower()):
+        raise ReleaseBomError(f"{path}.{key} must be a full 40-character SHA")
+    return value
+
+
+def _boolean(row: dict[str, Any], key: str, path: str) -> bool:
+    value = row.get(key)
+    if not isinstance(value, bool):
+        raise ReleaseBomError(f"{path}.{key} must be a boolean")
+    return value

--- a/cli/python/base_release/release_bom_cli.py
+++ b/cli/python/base_release/release_bom_cli.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .release_bom import ReleaseBomError, bom_digest, load_bom, validate_bom
+
+EXIT_SUCCESS = 0
+EXIT_FAILURE = 1
+
+
+def assemble(args: argparse.Namespace) -> dict:
+    try:
+        components = [load_bom(path) for path in args.component]
+        combinations = [json.loads(value) for value in args.combination]
+    except (ReleaseBomError, json.JSONDecodeError) as exc:
+        raise ReleaseBomError(f"cannot assemble BOM inputs: {exc}") from exc
+    document = {
+        "schema_version": 1,
+        "release": {
+            "repository": args.repository,
+            "version": args.version,
+            "tag": f"v{args.version}",
+            "commit": args.commit,
+        },
+        "components": components,
+        "combinations": combinations,
+    }
+    validate_bom(
+        document,
+        expected_repository=args.repository,
+        expected_version=args.version,
+        expected_commit=args.commit,
+    )
+    return document
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="base-release-bom")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    validate_parser = subparsers.add_parser("validate", help="validate a release BOM")
+    validate_parser.add_argument("path", type=Path)
+    validate_parser.add_argument("--repository")
+    validate_parser.add_argument("--version")
+    validate_parser.add_argument("--commit")
+    digest_parser = subparsers.add_parser("digest", help="print the canonical BOM SHA-256")
+    digest_parser.add_argument("path", type=Path)
+    assemble_parser = subparsers.add_parser("assemble", help="assemble and validate a release BOM")
+    assemble_parser.add_argument("--repository", required=True)
+    assemble_parser.add_argument("--version", required=True)
+    assemble_parser.add_argument("--commit", required=True)
+    assemble_parser.add_argument("--component", action="append", type=Path, required=True)
+    assemble_parser.add_argument(
+        "--combination",
+        action="append",
+        required=True,
+        help="JSON object describing one provider/consumer combination",
+    )
+    assemble_parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        if args.command == "validate":
+            document = load_bom(args.path)
+            validate_bom(
+                document,
+                expected_repository=args.repository,
+                expected_version=args.version,
+                expected_commit=args.commit,
+            )
+            print(f"release BOM is valid: {args.path}")
+            print(f"sha256: {bom_digest(document)}")
+        elif args.command == "digest":
+            document = load_bom(args.path)
+            print(bom_digest(document))
+        else:
+            assembled = assemble(args)
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(json.dumps(assembled, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            print(f"release BOM assembled and validated: {args.output}")
+            print(f"sha256: {bom_digest(assembled)}")
+    except ReleaseBomError as exc:
+        print(f"release BOM check: {exc}", file=sys.stderr)
+        return EXIT_FAILURE
+    return EXIT_SUCCESS
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/python/base_release/release_model.py
+++ b/cli/python/base_release/release_model.py
@@ -21,6 +21,7 @@ class ReleaseContext:
     tag_name: str
     version_file: Path
     changelog: Path
+    bom_path: Path | None = None
 
 
 @dataclass(frozen=True)

--- a/cli/python/base_release/release_parser.py
+++ b/cli/python/base_release/release_parser.py
@@ -17,6 +17,7 @@ class ReleaseArguments:
     command: str
     version: str
     manifest_path: Path | None
+    bom_path: Path | None = None
     output_format: str = "text"
     dry_run: bool = False
     yes: bool = False
@@ -26,6 +27,7 @@ class ReleaseArguments:
 class ReleaseOptionState:
     version: str | None = None
     manifest_path: Path | None = None
+    bom_path: Path | None = None
     output_format: str = "text"
     dry_run: bool = False
     yes: bool = False
@@ -52,6 +54,7 @@ def parse_release_args(arguments: tuple[str, ...]) -> ReleaseArguments:
         command=command,
         version=state.version,
         manifest_path=state.manifest_path,
+        bom_path=state.bom_path,
         output_format=state.output_format,
         dry_run=state.dry_run,
         yes=state.yes,
@@ -73,6 +76,10 @@ def parse_release_option(
         return index + 2
     if arg == "--manifest":
         state.manifest_path = Path(read_release_option_value(arguments, index, "--manifest")).expanduser()
+        return index + 2
+    if arg == "--bom":
+        require_bom_option(command)
+        state.bom_path = Path(read_release_option_value(arguments, index, "--bom")).expanduser()
         return index + 2
     if arg == "--format":
         require_check_option(command, "--format")
@@ -111,6 +118,11 @@ def require_check_option(command: str, option_name: str) -> None:
         raise ReleaseUsageError(f"Option '{option_name}' is only supported by release check.")
 
 
+def require_bom_option(command: str) -> None:
+    if command not in {"check", "publish"}:
+        raise ReleaseUsageError("Option '--bom' is only supported by release check and release publish.")
+
+
 def selected_release_check_format(arguments: tuple[str, ...]) -> str:
     if not arguments or arguments[0] != "check":
         return "text"
@@ -127,10 +139,10 @@ def print_usage(file: TextIO = sys.stdout) -> None:
     command = base_cli.delegated_display_command("base_release")
     print(
         f"""Usage:
-  {command} check --version <version> [--manifest <path>] [--format <text|csv|tsv|yaml|json>]
+  {command} check --version <version> [--manifest <path>] [--bom <path>] [--format <text|csv|tsv|yaml|json>]
   {command} plan --version <version> [--manifest <path>]
   {command} notes --version <version> [--manifest <path>]
-  {command} publish --version <version> [--manifest <path>] [--dry-run] [--yes]
+  {command} publish --version <version> [--manifest <path>] [--bom <path>] [--dry-run] [--yes]
 
 Purpose:
   Inspect release readiness and guarded GitHub publishing for a Base-managed

--- a/cli/python/base_release/release_readiness.py
+++ b/cli/python/base_release/release_readiness.py
@@ -9,6 +9,7 @@ from typing import Callable
 
 from base_setup.git_remote_parse import parse_origin_remote
 
+from .release_bom import ReleaseBomError, validate_bom_file
 from .release_model import ReleaseContext, ReleaseError, ReleaseFinding
 
 CHANGELOG_HEADER_RE = re.compile(r"^##\s+(?:\[(?P<bracket>[^\]]+)\]|(?P<plain>\S+))(?:\s+-.*)?$")
@@ -28,17 +29,36 @@ def release_findings(
     gh_cli_finding_func: Callable[[], ReleaseFinding] | None = None,
 ) -> tuple[ReleaseFinding, ...]:
     gh_check = gh_cli_finding_func or gh_cli_finding
+    provenance = inspect_release_provenance(ctx)
     findings: list[ReleaseFinding] = [
         ReleaseFinding("ok", "manifest", f"Release metadata found in {ctx.manifest_path}."),
         version_file_finding(ctx),
         changelog_finding(ctx),
         git_worktree_finding(ctx.manifest_path.parent),
-        *inspect_release_provenance(ctx).findings,
+        *provenance.findings,
+        bom_finding(ctx, provenance.commit_sha),
         gh_check(),
         local_tag_finding(ctx.manifest_path.parent, ctx.tag_name),
         remote_tag_finding(ctx.manifest_path.parent, ctx.tag_name),
     ]
     return tuple(findings)
+
+
+def bom_finding(ctx: ReleaseContext, reviewed_commit: str | None) -> ReleaseFinding:
+    if ctx.bom_path is None:
+        return ReleaseFinding("ok", "bom", "No release BOM was requested for this check.")
+    if not ctx.bom_path.is_file():
+        return ReleaseFinding("error", "bom", f"Release BOM is missing: {ctx.bom_path}")
+    try:
+        validate_bom_file(
+            ctx.bom_path,
+            expected_repository=ctx.release.github.repository,
+            expected_version=ctx.version,
+            expected_commit=reviewed_commit,
+        )
+    except ReleaseBomError as exc:
+        return ReleaseFinding("error", "bom", str(exc))
+    return ReleaseFinding("ok", "bom", f"Release BOM is valid: {ctx.bom_path}.")
 
 
 def inspect_release_provenance(ctx: ReleaseContext) -> ReleaseProvenanceInspection:

--- a/cli/python/base_release/tests/test_release_bom.py
+++ b/cli/python/base_release/tests/test_release_bom.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from base_release.release_bom import ReleaseBomError, bom_digest, validate_bom
+from base_release.release_bom import load_bom, validate_bom_file
+
+
+SHA = "a" * 40
+BASE_SHA = "b" * 40
+
+
+def valid_bom() -> dict:
+    return {
+        "schema_version": 1,
+        "release": {
+            "repository": "basefoundry/base-bash-libs",
+            "version": "2.1.0",
+            "tag": "v2.1.0",
+            "commit": SHA,
+        },
+        "components": [
+            {
+                "repository": "basefoundry/base-bash-libs",
+                "version": "2.1.0",
+                "tag": "v2.1.0",
+                "commit": SHA,
+                "source_mode": "release",
+                "api_schema_version": "2",
+                "platforms": ["macos-14", "ubuntu-24.04"],
+                "required": True,
+                "result": "passed",
+                "evidence": "run://tests/validate.sh",
+            },
+            {
+                "repository": "basefoundry/base",
+                "version": "1.8.0",
+                "tag": "v1.8.0",
+                "commit": BASE_SHA,
+                "source_mode": "release",
+                "api_schema_version": "manifest-1",
+                "platforms": ["macos-14", "ubuntu-24.04"],
+                "required": True,
+                "result": "passed",
+                "evidence": "run://base-release-check",
+            },
+            {
+                "repository": "basefoundry/base-cli",
+                "version": "0.4.3",
+                "commit": "c" * 40,
+                "source_mode": "moving",
+                "api_schema_version": "0.4",
+                "platforms": ["python-3.12"],
+                "required": False,
+                "result": "not_tested",
+                "evidence": "advisory://moving-source",
+            },
+        ],
+        "combinations": [
+            {
+                "name": "released-base-bash-libs-with-base",
+                "participants": ["basefoundry/base-bash-libs", "basefoundry/base"],
+                "platform": "ubuntu-24.04",
+                "required": True,
+                "result": "passed",
+                "evidence": "run://ecosystem-release-train/123",
+            }
+        ],
+    }
+
+
+def test_valid_bom_accepts_required_releases_and_advisory_moving_rows() -> None:
+    validate_bom(valid_bom(), expected_repository="basefoundry/base-bash-libs", expected_version="2.1.0")
+
+
+def test_required_moving_source_is_rejected() -> None:
+    document = valid_bom()
+    document["components"][2]["required"] = True
+    with pytest.raises(ReleaseBomError, match="cannot require a moving source"):
+        validate_bom(document)
+
+
+def test_required_failed_combination_is_rejected() -> None:
+    document = valid_bom()
+    document["combinations"][0]["result"] = "failed"
+    with pytest.raises(ReleaseBomError, match="required but result is 'failed'"):
+        validate_bom(document)
+
+
+def test_commit_and_version_mismatch_are_rejected() -> None:
+    document = valid_bom()
+    with pytest.raises(ReleaseBomError, match="does not match '2.2.0'"):
+        validate_bom(document, expected_version="2.2.0")
+    with pytest.raises(ReleaseBomError, match="reviewed release commit"):
+        validate_bom(document, expected_commit="d" * 40)
+
+
+def test_digest_is_stable_for_mapping_order() -> None:
+    document = valid_bom()
+    reordered = json.loads(json.dumps(document))
+    reordered["release"] = {key: document["release"][key] for key in reversed(document["release"])}
+    assert bom_digest(document) == bom_digest(reordered)
+
+
+def test_duplicate_component_and_unknown_participant_are_rejected() -> None:
+    duplicate = valid_bom()
+    duplicate["components"].append(copy.deepcopy(duplicate["components"][0]))
+    with pytest.raises(ReleaseBomError, match="duplicated"):
+        validate_bom(duplicate)
+
+    unknown = valid_bom()
+    unknown["combinations"][0]["participants"].append("basefoundry/unknown")
+    with pytest.raises(ReleaseBomError, match="unknown components"):
+        validate_bom(unknown)
+
+
+def test_checked_in_fixtures_cover_valid_and_mutable_documents() -> None:
+    fixture_root = Path(__file__).resolve().parents[4] / "tests" / "fixtures"
+    validate_bom_file(
+        fixture_root / "release-bom-valid.json",
+        expected_repository="basefoundry/base-bash-libs",
+        expected_version="2.1.0",
+    )
+    with pytest.raises(ReleaseBomError, match="release.tag must be v<release.version>"):
+        validate_bom(load_bom(fixture_root / "release-bom-invalid-mutable.json"))

--- a/docs/release-bom.md
+++ b/docs/release-bom.md
@@ -1,0 +1,59 @@
+# Ecosystem release BOM
+
+Base owns the cross-repository compatibility BOM contract. Repository-local
+release policies remain authoritative for their own versioning, artifacts, and
+publication, while the BOM records the exact combination that was tested.
+
+The contract is versioned at
+[`docs/schemas/release-bom.schema.json`](schemas/release-bom.schema.json). A
+release BOM contains:
+
+- the releasing repository, SemVer version, immutable tag, and full commit;
+- one row per participating repository with its API/schema contract, supported
+  platforms, source mode, required/advisory status, result, and evidence; and
+- one or more provider/consumer combinations with the platform, required flag,
+  result, and reproducible evidence.
+
+Required rows must use an immutable release or tag source, report `passed`, and
+include evidence. Moving-source rows are allowed only as advisory rows and do
+not block a release. The validator also rejects duplicate repositories, missing
+participants, mutable release identities, and version or commit mismatches.
+
+Validate and fingerprint a BOM locally:
+
+```bash
+bin/base-release-bom validate path/to/release-bom.json \
+  --repository basefoundry/base \
+  --version 1.9.0 \
+  --commit <reviewed-full-sha>
+bin/base-release-bom digest path/to/release-bom.json
+```
+
+The release coordinator can assemble the complete record from repository-owned
+component rows and explicit combination results. Each combination is a JSON
+object; required combinations must already report `passed`:
+
+```bash
+bin/base-release-bom assemble \
+  --repository basefoundry/base-bash-libs --version 2.1.0 \
+  --commit <reviewed-full-sha> \
+  --component /private/tmp/base-bash-libs-row.json \
+  --component /private/tmp/base-row.json \
+  --combination '{"name":"release-stack","participants":["basefoundry/base-bash-libs","basefoundry/base"],"platform":"ubuntu-24.04","required":true,"result":"passed","evidence":"run://123"}' \
+  --output /private/tmp/base-ecosystem-2.1.0.json
+```
+
+The release assistant can enforce the same gate:
+
+```bash
+basectl release check --version 1.9.0 \
+  --manifest base_manifest.yaml \
+  --bom path/to/release-bom.json
+```
+
+`release publish` accepts the same `--bom` option and refuses to publish when
+the BOM is missing, invalid, or does not match the reviewed release identity.
+Release workflows should attach the validated BOM and the printed SHA-256 as
+release evidence. A BOM is intentionally opt-in for existing manifests so
+historical releases remain inspectable; a repository entering the governed
+release train should pass `--bom` from its release workflow.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -68,6 +68,7 @@ The inspection commands are read-only:
 
 ```bash
 basectl release check --version X.Y.Z
+basectl release check --version X.Y.Z --bom path/to/release-bom.json
 basectl release check --version X.Y.Z --format json
 basectl release plan --version X.Y.Z
 basectl release notes --version X.Y.Z
@@ -89,9 +90,9 @@ with `error: null`.
 Publishing is guarded:
 
 ```bash
-basectl release publish --version X.Y.Z --dry-run
+basectl release publish --version X.Y.Z --bom path/to/release-bom.json --dry-run
 basectl release publish --version X.Y.Z
-basectl release publish --version X.Y.Z --yes
+basectl release publish --version X.Y.Z --bom path/to/release-bom.json --yes
 ```
 
 `publish` reuses the release checks, refuses existing tags or GitHub Releases,

--- a/docs/schemas/release-bom.schema.json
+++ b/docs/schemas/release-bom.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://basefoundry.org/schemas/release-bom-v1.json",
+  "title": "Base ecosystem release BOM",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "release", "components", "combinations"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "release": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "version", "tag", "commit"],
+      "properties": {
+        "repository": {"type": "string", "pattern": "^[^/\\s]+/[^/\\s]+$"},
+        "version": {"type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"},
+        "tag": {"type": "string", "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"},
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"}
+      }
+    },
+    "components": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/component"}
+    },
+    "combinations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/combination"}
+    }
+  },
+  "$defs": {
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "version", "commit", "source_mode", "api_schema_version", "platforms", "required", "result", "evidence"],
+      "properties": {
+        "repository": {"type": "string", "pattern": "^[^/\\s]+/[^/\\s]+$"},
+        "version": {"type": "string", "minLength": 1},
+        "tag": {"type": "string", "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"},
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "source_mode": {"enum": ["release", "tag", "moving"]},
+        "api_schema_version": {"type": "string", "minLength": 1},
+        "platforms": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "required": {"type": "boolean"},
+        "result": {"enum": ["passed", "failed", "not_tested"]},
+        "evidence": {"type": "string", "minLength": 1}
+      }
+    },
+    "combination": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "participants", "platform", "required", "result", "evidence"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "participants": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "platform": {"type": "string", "minLength": 1},
+        "required": {"type": "boolean"},
+        "result": {"enum": ["passed", "failed", "not_tested"]},
+        "evidence": {"type": "string", "minLength": 1}
+      }
+    }
+  }
+}

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -770,14 +770,17 @@ _base_basectl_completion() {
             if ((COMP_CWORD == 2)); then
                 _base_basectl_completion_compgen "check plan notes publish" "$cur"
             elif [[ "${COMP_WORDS[2]:-}" == "check" ]]; then
-                _base_basectl_completion_compgen "--version --manifest --format -h --help" "$cur"
+                _base_basectl_completion_compgen "--version --manifest --bom --format -h --help" "$cur"
             else
                 case "${COMP_WORDS[2]:-}" in
-                    check|plan|notes)
+                    check)
+                        _base_basectl_completion_compgen "--version --manifest --bom -h --help" "$cur"
+                        ;;
+                    plan|notes)
                         _base_basectl_completion_compgen "--version --manifest -h --help" "$cur"
                         ;;
                     publish)
-                        _base_basectl_completion_compgen "--version --manifest --dry-run --yes -h --help" "$cur"
+                        _base_basectl_completion_compgen "--version --manifest --bom --dry-run --yes -h --help" "$cur"
                         ;;
                 esac
             fi

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -867,6 +867,7 @@ _base_basectl_completion() {
                     _arguments '2:release command:(check plan notes publish)' \
                         '--version[Release version]:version:' \
                         '--manifest[Use a specific manifest]:path:_files' \
+                        '--bom[Validate an ecosystem release BOM]:path:_files' \
                         '--format[Output format]:format:(text csv tsv yaml json)' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
@@ -880,6 +881,7 @@ _base_basectl_completion() {
                     _arguments '2:release command:(check plan notes publish)' \
                         '--version[Release version]:version:' \
                         '--manifest[Use a specific manifest]:path:_files' \
+                        '--bom[Validate an ecosystem release BOM]:path:_files' \
                         '--dry-run[Print publish actions without creating tags or releases]' \
                         '--yes[Publish without an interactive confirmation prompt]' \
                         '(-h --help)'{-h,--help}'[Show help text]'

--- a/tests/fixtures/release-bom-invalid-mutable.json
+++ b/tests/fixtures/release-bom-invalid-mutable.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "release": {
+    "repository": "basefoundry/base-bash-libs",
+    "version": "2.1.0",
+    "tag": "main",
+    "commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "components": [],
+  "combinations": []
+}

--- a/tests/fixtures/release-bom-valid.json
+++ b/tests/fixtures/release-bom-valid.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "release": {
+    "repository": "basefoundry/base-bash-libs",
+    "version": "2.1.0",
+    "tag": "v2.1.0",
+    "commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "components": [
+    {
+      "repository": "basefoundry/base-bash-libs",
+      "version": "2.1.0",
+      "tag": "v2.1.0",
+      "commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "source_mode": "release",
+      "api_schema_version": "2",
+      "platforms": ["macos-14", "ubuntu-24.04"],
+      "required": true,
+      "result": "passed",
+      "evidence": "run://tests/validate.sh"
+    },
+    {
+      "repository": "basefoundry/base",
+      "version": "1.8.0",
+      "tag": "v1.8.0",
+      "commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "source_mode": "release",
+      "api_schema_version": "manifest-1",
+      "platforms": ["macos-14", "ubuntu-24.04"],
+      "required": true,
+      "result": "passed",
+      "evidence": "run://base-release-check"
+    }
+  ],
+  "combinations": [
+    {
+      "name": "released-base-bash-libs-with-base",
+      "participants": ["basefoundry/base-bash-libs", "basefoundry/base"],
+      "platform": "ubuntu-24.04",
+      "required": true,
+      "result": "passed",
+      "evidence": "run://ecosystem-release-train/123"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add the versioned ecosystem release BOM schema and deterministic validator, digest, and assembler.
- Add `bin/base-release-bom`, valid and invalid fixtures, and release-BOM documentation.
- Add `--bom path/to/release-bom.json` enforcement to Base release check and publish.
- Keep Bash and Zsh completion metadata aligned with the public release options.

## Related issues

Fixes #2125
Parent: basefoundry/base#2115

The dependent implementation PRs are merged:

- base-bash-libs #440
- base-cli #335
- base-demo #282

## Validation

- Final hosted Base validation is green on commit `acdcb762` across Python 3.10-3.13, BATS, Ubuntu source checkout, macOS smoke, integration, security, and pylint gates.
- Focused BOM and release tests pass locally.
- The standalone BOM wrapper does not require the Base CLI package.
- The valid fixture produces deterministic digest `effb953bcf46140fcee5d69696d70ac1b093dc1892c7e399fcf9a3b6999e1e44`.
- The v2.1.0 rehearsal fails closed while its required four-repository combination remains `not_tested`.

## Release status

No tag or release has been published. The v2.1.0 candidate still needs immutable passing evidence for the required four-repository combination before publication.