### PR TITLE
refactor(basectl): use shared yes-no prompts

### DIFF
--- a/.github/workflows/base-check.yml
+++ b/.github/workflows/base-check.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: b4243765726c133499feeabdc50154f99c0fec12
+          ref: 6792c29e546ed7a6230046e4d54bfa1474cd3b13
           path: .base/base-bash-libs
 
       - name: Checkout base-cli source

--- a/.github/workflows/base-demo-e2e.yml
+++ b/.github/workflows/base-demo-e2e.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: b4243765726c133499feeabdc50154f99c0fec12
+          ref: 6792c29e546ed7a6230046e4d54bfa1474cd3b13
           path: .dependencies/base-bash-libs
 
       - name: Expose dependency checkouts as Base siblings

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: b4243765726c133499feeabdc50154f99c0fec12
+          ref: 6792c29e546ed7a6230046e4d54bfa1474cd3b13
           path: .dependencies/base-bash-libs
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: b4243765726c133499feeabdc50154f99c0fec12
+          ref: 6792c29e546ed7a6230046e4d54bfa1474cd3b13
           path: .dependencies/base-bash-libs
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -215,7 +215,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: b4243765726c133499feeabdc50154f99c0fec12
+          ref: 6792c29e546ed7a6230046e4d54bfa1474cd3b13
           path: .dependencies/base-bash-libs
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -279,7 +279,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: b4243765726c133499feeabdc50154f99c0fec12
+          ref: 6792c29e546ed7a6230046e4d54bfa1474cd3b13
           path: .dependencies/base-bash-libs
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/cli/bash/commands/basectl/subcommands/onboard.sh
+++ b/cli/bash/commands/basectl/subcommands/onboard.sh
@@ -53,42 +53,40 @@ base_onboard_run_command() {
     "$BASE_HOME/bin/basectl" "$@"
 }
 
-base_onboard_read_prompt_answer() {
-    local answer_var="$1"
+base_onboard_prompt() {
+    local prompt="$1"
     local tty_fd="${BASE_ONBOARD_TTY_FD:-}"
     local tty_path="${BASE_ONBOARD_TTY_PATH:-/dev/tty}"
-
-    [[ -n "$answer_var" ]] || return 1
+    local input_fd
+    local status
 
     if [[ -n "$tty_fd" ]]; then
-        [[ "$tty_fd" =~ ^[0-9]+$ ]] || return 1
-        IFS= read -r -u "$tty_fd" "${answer_var:?}"
+        [[ "$tty_fd" =~ ^[0-9]+$ ]] || {
+            printf '%s\n' "No interactive terminal is available; rerun with --yes to accept defaults." >&2
+            return 1
+        }
+        base_std_ask_yes_no "$prompt" no "$tty_fd"
         return $?
     fi
 
-    [[ -r "$tty_path" ]] || return 1
-    IFS= read -r "${answer_var:?}" < "$tty_path"
-}
+    if [[ "$tty_path" == /dev/tty ]]; then
+        if [[ ! -r "$tty_path" ]]; then
+            printf '%s\n' "No interactive terminal is available; rerun with --yes to accept defaults." >&2
+            return 1
+        fi
+        base_std_ask_yes_no "$prompt" no
+        return $?
+    fi
 
-base_onboard_prompt() {
-    local prompt="$1"
-    local answer
-
-    printf '%s [y/N] ' "$prompt"
-    if ! base_onboard_read_prompt_answer answer; then
+    if ! exec {input_fd}< "$tty_path"; then
         printf '\n'
         printf '%s\n' "No interactive terminal is available; rerun with --yes to accept defaults." >&2
         return 1
     fi
-
-    case "$answer" in
-        y|Y|yes|YES|Yes)
-            return 0
-            ;;
-        *)
-            return 1
-            ;;
-    esac
+    base_std_ask_yes_no "$prompt" no "$input_fd"
+    status=$?
+    exec {input_fd}<&-
+    return "$status"
 }
 
 base_onboard_confirm() {

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -116,25 +116,27 @@ setup_interactive_consent_available() {
     base_std_is_interactive
 }
 
-setup_read_confirmation_response() {
-    local response
+setup_ask_confirmation() {
+    local prompt="$1"
+    local response input_fd status
 
     if response="$(setup_test_confirm_response)"; then
-        printf '%s\n' "$response"
-        return 0
+        exec {input_fd}< <(printf '%s' "$response")
+        base_std_ask_yes_no "$prompt" no "$input_fd"
+        status=$?
+        exec {input_fd}<&-
+        return "$status"
     fi
 
     if [[ -r /dev/tty ]]; then
-        IFS= read -r response </dev/tty || return 1
+        base_std_ask_yes_no "$prompt" no
     else
-        IFS= read -r response || return 1
+        base_std_ask_yes_no "$prompt" no 0
     fi
-    printf '%s\n' "$response"
 }
 
 setup_require_linux_debian_system_consent() {
     local reason="$1"
-    local response
 
     setup_yes_enabled && return 0
 
@@ -146,17 +148,9 @@ setup_require_linux_debian_system_consent() {
     if [[ -n "${BASE_SETUP_TEST_STATE_DIR:-}" ]]; then
         setup_allow_test_hooks && touch "$BASE_SETUP_TEST_STATE_DIR/linux-consent-prompted"
     fi
-    printf "Proceed with Ubuntu/Debian setup changes? [y/N] " >&2
-    response="$(setup_read_confirmation_response)" || base_std_fatal_error "Ubuntu/Debian setup was not approved."
-    case "${response,,}" in
-        y|yes)
-            setup_enable_yes
-            return 0
-            ;;
-        *)
-            base_std_fatal_error "Ubuntu/Debian setup was not approved."
-            ;;
-    esac
+    setup_ask_confirmation "Proceed with Ubuntu/Debian setup changes?" || \
+        base_std_fatal_error "Ubuntu/Debian setup was not approved."
+    setup_enable_yes
 }
 
 setup_enable_recreate_venv() {

--- a/cli/bash/commands/basectl/tests/onboard.bats
+++ b/cli/bash/commands/basectl/tests/onboard.bats
@@ -154,7 +154,7 @@ load ./basectl_helpers.bash
 @test "basectl onboard reads prompts from terminal fd when stdin is redirected" {
     local tty_input="$TEST_TMPDIR/onboard-tty"
 
-    printf 'y\nn\n' > "$tty_input"
+    printf 'yn' > "$tty_input"
 
     run env \
         HOME="$TEST_HOME" \
@@ -177,7 +177,7 @@ load ./basectl_helpers.bash
 @test "basectl onboard accepted flow runs setup profile doctor and projects" {
     local tty_input="$TEST_TMPDIR/onboard-tty"
 
-    printf 'y\ny\ny\n' > "$tty_input"
+    printf 'yyy' > "$tty_input"
 
     run env \
         HOME="$TEST_HOME" \

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -21,7 +21,7 @@ ISSUE_BRANCH_POLICY_WORKFLOW = WORKFLOW_DIR / "issue-branch-policy.yml"
 ISSUE_BRANCH_POLICY_TEMPLATE = REPO_ROOT / "templates" / "issue-branch-policy.yml"
 IMPLEMENTATION_ISSUE_TEMPLATE = REPO_ROOT / ".github" / "ISSUE_TEMPLATE" / "implementation.yml"
 FULL_COMMIT_SHA_ACTION_REF = re.compile(r"^[^@]+@[0-9a-f]{40}$")
-BASE_BASH_LIBS_GA_COMMIT = "b4243765726c133499feeabdc50154f99c0fec12"
+BASE_BASH_LIBS_GA_COMMIT = "6792c29e546ed7a6230046e4d54bfa1474cd3b13"
 
 
 def workflow_files() -> list[Path]:
@@ -649,7 +649,7 @@ def test_reusable_base_check_workflow_contract() -> None:
     assert "args=(check --ci \"$BASE_CHECK_PROJECT\" --format \"$BASE_CHECK_OUTPUT_FORMAT\")" in run_commands
     assert "BASE_BASH_LIBS_DIR" in run_commands
     assert "basefoundry/base-bash-libs" in str(steps)
-    assert "b4243765726c133499feeabdc50154f99c0fec12" in str(steps)
+    assert BASE_BASH_LIBS_GA_COMMIT in str(steps)
     assert "${{ inputs.base-ref || github.workflow_sha }}" in str(steps)
     assert "uses: basefoundry/base/.github/workflows/base-check.yml@<base-ref-or-sha>" in ci_docs
     assert "| `setup-mode` | `source-checkout` |" in ci_docs
@@ -682,7 +682,7 @@ def test_base_demo_e2e_workflow_covers_the_external_project_loop() -> None:
         "basefoundry/base-cli",
         "basefoundry/base-bash-libs",
     ]
-    assert "b4243765726c133499feeabdc50154f99c0fec12" in str(steps)
+    assert BASE_BASH_LIBS_GA_COMMIT in str(steps)
     assert "v0.4.3" in str(steps)
 
     for command in (


### PR DESCRIPTION
## Summary

- route `basectl onboard` confirmation prompts through `base_std_ask_yes_no`
- route Linux/Debian setup consent through the same shared helper
- preserve `BASE_ONBOARD_TTY_FD`, `BASE_ONBOARD_TTY_PATH`, and `BASE_SETUP_TEST_CONFIRM_RESPONSE` test seams through caller-owned input descriptors
- keep `--yes` and conservative decline behavior unchanged
- pin Base source-checkout workflows to the immutable `base-bash-libs` API commit used by this migration

## Dependency

Depends on [base-bash-libs#439](https://github.com/basefoundry/base-bash-libs/pull/439), which adds the caller-owned input descriptor accepted by the migrated Base callers. The six Base source-checkout pins in CI now reference that immutable commit.

## Validation

- focused onboarding/setup/setup-common BATS: 106 passed
- complete Base shell/BATS suite: 903 passed
- ShellCheck on changed shell files: passed
- `git diff --check`: passed
- full `base-bash-libs` validation on the dependency branch: passed
- `bin/base-test` was attempted; local Python collection is blocked because `jsonschema` is not installed for two existing schema tests

`.ai-context/` is unchanged because this is an internal prompt implementation refactor with no change to Base command shape or architecture.

Fixes #2122