### PR TITLE
refactor(basectl): use shared command path resolver

### DIFF
--- a/cli/bash/commands/basectl/subcommands/docs.sh
+++ b/cli/bash/commands/basectl/subcommands/docs.sh
@@ -26,10 +26,10 @@ base_docs_usage_error() {
 }
 
 base_docs_platform_opener() {
-    local opener
+    local opener opener_path
 
     for opener in open xdg-open wslview; do
-        if command -v "$opener" >/dev/null 2>&1; then
+        if base_std_command_path opener_path "$opener" && [[ -n "$opener_path" ]]; then
             printf '%s\n' "$opener"
             return 0
         fi

--- a/cli/bash/commands/basectl/subcommands/gh.sh
+++ b/cli/bash/commands/basectl/subcommands/gh.sh
@@ -647,13 +647,14 @@ base_gh_usage_error() {
 
 base_gh_require_command() {
     local command="$1"
+    local command_path
 
     if [[ "$command" == "gh" ]]; then
         base_gh_require_cli
         return $?
     fi
 
-    command -v "$command" >/dev/null 2>&1 || {
+    base_std_command_path command_path "$command" && [[ -n "$command_path" ]] || {
         base_gh_error "Required command '$command' was not found on PATH."
         return 1
     }

--- a/cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh
+++ b/cli/bash/commands/basectl/subcommands/gh_branch_worktree.sh
@@ -219,8 +219,10 @@ base_gh_branch_merged_to_ref() {
 }
 
 base_gh_prune_github_ready() {
+    local gh_path
+
     if [[ -z "${_base_gh_prune_github_ready+x}" ]]; then
-        if command -v gh >/dev/null 2>&1; then
+        if base_std_command_path gh_path gh && [[ -n "$gh_path" ]]; then
             _base_gh_prune_github_ready=1
         else
             _base_gh_prune_github_ready=0

--- a/cli/bash/commands/basectl/subcommands/project_command_helpers.sh
+++ b/cli/bash/commands/basectl/subcommands/project_command_helpers.sh
@@ -180,13 +180,17 @@ base_project_run_shell_command() {
 
 base_validate_command_runner() {
     local runner="$1"
+    local uv_path
 
     case "$runner" in
         "")
             return 0
             ;;
         uv)
-            if command -v uv >/dev/null 2>&1 || [[ -n "${HOME:-}" && -x "$HOME/.local/bin/uv" ]]; then
+            if base_std_command_path uv_path uv && [[ -n "$uv_path" ]]; then
+                return 0
+            fi
+            if [[ -n "${HOME:-}" && -x "$HOME/.local/bin/uv" ]]; then
                 return 0
             fi
             base_std_fatal_error "Command runner 'uv' is not available. Install uv or remove runner: uv from the project manifest."

--- a/cli/bash/commands/basectl/subcommands/projects.sh
+++ b/cli/bash/commands/basectl/subcommands/projects.sh
@@ -57,8 +57,7 @@ base_projects_source_python() {
     local python_bin
     local base_pythonpath
 
-    python_bin="$(command -v python3 2>/dev/null || true)"
-    [[ -n "$python_bin" ]] || return 1
+    base_std_command_path python_bin python3 || return 1
 
     base_pythonpath="$(base_projects_source_pythonpath)"
     env BASE_HOME="$BASE_HOME" BASE_PROJECT=base PYTHONPATH="$base_pythonpath" \

--- a/cli/bash/commands/basectl/subcommands/repo.sh
+++ b/cli/bash/commands/basectl/subcommands/repo.sh
@@ -2138,6 +2138,7 @@ base_repo_clone_check_destination() {
 base_repo_clone_with_gh() {
     local clone_url="$4"
     local dry_run="$1"
+    local gh_path
     local parent
     local repo="$2"
     local status
@@ -2167,7 +2168,7 @@ base_repo_clone_with_gh() {
         return 0
     fi
 
-    command -v gh >/dev/null 2>&1 || {
+    base_std_command_path gh_path gh && [[ -n "$gh_path" ]] || {
         base_std_log_error "GitHub CLI 'gh' is required for repository clone."
         return 1
     }

--- a/cli/bash/commands/basectl/subcommands/repo_github_settings.sh
+++ b/cli/bash/commands/basectl/subcommands/repo_github_settings.sh
@@ -15,9 +15,10 @@ readonly BASE_GITHUB_ACTIONS_INTEGRATION_ID
 BASE_REPO_GITHUB_REPO_CREATED=0
 
 base_repo_homebrew_gh_outdated() {
+    local brew_path
     local output=""
 
-    command -v brew >/dev/null 2>&1 || return 1
+    base_std_command_path brew_path brew && [[ -n "$brew_path" ]] || return 1
     HOMEBREW_NO_AUTO_UPDATE=1 brew list gh >/dev/null 2>&1 || return 1
     output="$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated gh 2>/dev/null || true)"
     printf '%s\n' "$output" | awk '$1 == "gh" { found = 1 } END { exit found ? 0 : 1 }'

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -288,6 +288,7 @@ setup_recovery_project_layer() {
 }
 
 setup_notify_completion() {
+    local command_path
     local exit_code="$1"
     local current_seconds
     local elapsed_seconds=0
@@ -297,7 +298,7 @@ setup_notify_completion() {
     setup_notifications_enabled || return 0
     setup_is_dry_run && return 0
     [[ "$OSTYPE" == darwin* ]] || return 0
-    if ! command -v osascript >/dev/null 2>&1; then
+    if ! base_std_command_path command_path osascript; then
         if setup_notifications_forced; then
             base_std_log_warn "Setup notification was requested, but 'osascript' is not available on this Mac."
         fi
@@ -330,7 +331,10 @@ end run' "$title" "$message" >/dev/null 2>&1 || true
 }
 
 setup_command_path() {
-    command -v "$1" 2>/dev/null || return 1
+    local command_path
+
+    base_std_command_path command_path "${1-}" || return 1
+    printf '%s\n' "$command_path"
 }
 
 setup_current_machine() {
@@ -338,11 +342,11 @@ setup_current_machine() {
 }
 
 setup_executable_architecture() {
-    local output path="$1"
+    local command_path output path="$1"
 
     [[ -n "$path" ]] || return 1
-    command -v file >/dev/null 2>&1 || return 1
-    output="$(file -L "$path" 2>/dev/null || true)"
+    base_std_command_path command_path file || return 1
+    output="$("$command_path" -L "$path" 2>/dev/null || true)"
     case "$output" in
         *x86_64*arm64*|*arm64*x86_64*)
             printf '%s\n' "universal"
@@ -479,12 +483,12 @@ setup_pythonpath() {
 }
 
 setup_diagnostics_python_bin() {
-    local candidate python_bin venv_dir
+    local candidate python_bin python_path venv_dir
     local candidates=()
 
     setup_ensure_cached_paths
-    if command -v python3 >/dev/null 2>&1; then
-        candidates+=("$(command -v python3)")
+    if base_std_command_path python_path python3; then
+        candidates+=("$python_path")
     fi
     if python_bin="$(setup_find_python_bin)"; then
         candidates+=("$python_bin")

--- a/cli/bash/commands/basectl/subcommands/setup_linux_debian.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_linux_debian.sh
@@ -57,6 +57,8 @@ setup_recovery_linux_github_cli() {
 }
 
 setup_find_linux_python_bin() {
+    local python_path
+
     if [[ -n "${BASE_SETUP_PYTHON_BIN:-}" ]]; then
         setup_reject_test_hook_if_disallowed BASE_SETUP_PYTHON_BIN
         [[ -x "${BASE_SETUP_PYTHON_BIN}" ]] || return 1
@@ -64,8 +66,8 @@ setup_find_linux_python_bin() {
         return 0
     fi
 
-    if command -v python3 >/dev/null 2>&1; then
-        command -v python3
+    if base_std_command_path python_path python3; then
+        printf '%s\n' "$python_path"
         return 0
     fi
 
@@ -90,9 +92,11 @@ setup_test_linux_tool_forced_missing() {
 
 setup_linux_command_path() {
     local command_name="$1"
+    local command_path
 
     setup_test_linux_tool_forced_missing "$command_name" && return 1
-    command -v "$command_name" 2>/dev/null
+    base_std_command_path command_path "$command_name" || return 1
+    printf '%s\n' "$command_path"
 }
 
 setup_linux_python_venv_available() {
@@ -300,10 +304,11 @@ setup_linux_debian_apt_prerequisite_command() {
 }
 
 setup_linux_debian_apt_prerequisites_installed() {
+    local command_path
     local package
     local status
 
-    command -v dpkg-query >/dev/null 2>&1 || return 1
+    base_std_command_path command_path dpkg-query || return 1
 
     for package in "$@"; do
         status="$(dpkg-query -W -f='${Status}' "$package" 2>/dev/null)" || return 1
@@ -339,6 +344,7 @@ setup_run_linux_debian_apt_prerequisites() {
 
 setup_run_linux_debian_github_cli_prerequisite() {
     local arch
+    local command_path
     local keyring_tmp
     local source_tmp
 
@@ -362,8 +368,8 @@ setup_run_linux_debian_github_cli_prerequisite() {
     setup_require_linux_debian_system_consent \
         "Ubuntu/Debian setup can install apt packages, configure package repositories, and run platform bootstraps." || return $?
 
-    command -v curl >/dev/null 2>&1 || base_std_fatal_error "curl is required to install GitHub CLI 'gh' from its official Debian/Ubuntu apt repository."
-    command -v dpkg >/dev/null 2>&1 || base_std_fatal_error "dpkg is required to configure GitHub CLI's official Debian/Ubuntu apt repository."
+    base_std_command_path command_path curl || base_std_fatal_error "curl is required to install GitHub CLI 'gh' from its official Debian/Ubuntu apt repository."
+    base_std_command_path command_path dpkg || base_std_fatal_error "dpkg is required to configure GitHub CLI's official Debian/Ubuntu apt repository."
     arch="$(dpkg --print-architecture)" || base_std_fatal_error "Unable to read Debian architecture for GitHub CLI apt repository setup."
     [[ -n "$arch" ]] || base_std_fatal_error "Unable to read Debian architecture for GitHub CLI apt repository setup."
 

--- a/cli/bash/commands/basectl/subcommands/setup_macos_homebrew.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_macos_homebrew.sh
@@ -62,7 +62,7 @@ setup_recovery_python() {
 }
 
 setup_find_brew_bin() {
-    local candidate
+    local candidate brew_path
 
     if [[ -n "${BASE_SETUP_BREW_BIN+x}" ]]; then
         if [[ -x "${BASE_SETUP_BREW_BIN}" ]]; then
@@ -72,8 +72,8 @@ setup_find_brew_bin() {
         return 1
     fi
 
-    if command -v brew >/dev/null 2>&1; then
-        command -v brew
+    if base_std_command_path brew_path brew; then
+        printf '%s\n' "$brew_path"
         return 0
     fi
 
@@ -197,6 +197,7 @@ setup_log_homebrew_mutable_policy() {
 setup_fetch_homebrew_installer() {
     local installer_url="$1"
     local target="$2"
+    local curl_path
     local installer_path
 
     case "$installer_url" in
@@ -208,8 +209,8 @@ setup_fetch_homebrew_installer() {
             cp "$installer_url" "$target"
             ;;
         *)
-            command -v curl >/dev/null 2>&1 || return 127
-            curl -fsSL "$installer_url" -o "$target"
+            base_std_command_path curl_path curl || return 127
+            "$curl_path" -fsSL "$installer_url" -o "$target"
             ;;
     esac
 }
@@ -356,7 +357,7 @@ setup_install_python() {
 }
 
 setup_find_python_bin() {
-    local brew_bin formula prefix candidate
+    local brew_bin formula prefix candidate python_path
     local candidates=()
 
     if [[ -n "${BASE_SETUP_PYTHON_BIN:-}" ]]; then
@@ -396,8 +397,8 @@ setup_find_python_bin() {
         fi
     fi
 
-    if setup_allow_system_python && command -v python3 >/dev/null 2>&1; then
-        command -v python3
+    if setup_allow_system_python && base_std_command_path python_path python3; then
+        printf '%s\n' "$python_path"
         return 0
     fi
 

--- a/cli/bash/commands/basectl/subcommands/update.sh
+++ b/cli/bash/commands/basectl/subcommands/update.sh
@@ -217,15 +217,15 @@ base_update_homebrew_requires_tap_trust() {
 }
 
 base_update_json_python_bin() {
-    local candidate
+    local candidate python_path
 
     if [[ -n "${BASE_UPDATE_JSON_PYTHON:-}" && -x "${BASE_UPDATE_JSON_PYTHON:-}" ]]; then
         printf '%s\n' "$BASE_UPDATE_JSON_PYTHON"
         return 0
     fi
 
-    if command -v python3 >/dev/null 2>&1; then
-        command -v python3
+    if base_std_command_path python_path python3; then
+        printf '%s\n' "$python_path"
         return 0
     fi
 
@@ -343,6 +343,7 @@ base_update_homebrew_install() {
     local dry_run="$2"
     local after_version
     local before_version
+    local brew_path
     local exit_code
     local package
 
@@ -355,7 +356,7 @@ base_update_homebrew_install() {
         return 0
     fi
 
-    if ! command -v brew >/dev/null 2>&1; then
+    if ! base_std_command_path brew_path brew || [[ -z "$brew_path" ]]; then
         base_std_log_error "Homebrew-managed Base install detected, but 'brew' is not available in PATH."
         return 1
     fi

--- a/cli/bash/commands/basectl/tests/update.bats
+++ b/cli/bash/commands/basectl/tests/update.bats
@@ -184,6 +184,14 @@ EOF
         PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
         bash -c '
             base_std_log_debug() { :; }
+            base_std_command_path() {
+                local result_name="$1"
+                local command_name="$2"
+                local command_path
+                command_path="$(type -P "$command_name" 2>/dev/null || true)"
+                printf -v "$result_name" '%s' "$command_path"
+                [[ -n "$command_path" ]]
+            }
             base_std_log_error() { printf "ERROR: %s\n" "$*"; }
             base_std_log_info() { printf "INFO: %s\n" "$*"; }
             base_std_log_warn() { printf "WARN: %s\n" "$*"; }

--- a/cli/bash/commands/basectl/tests/update.bats
+++ b/cli/bash/commands/basectl/tests/update.bats
@@ -259,6 +259,14 @@ EOF
         PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
         bash -c '
             base_std_log_debug() { :; }
+            base_std_command_path() {
+                local result_name="$1"
+                local command_name="$2"
+                local command_path
+                command_path="$(type -P "$command_name" 2>/dev/null || true)"
+                printf -v "$result_name" '%s' "$command_path"
+                [[ -n "$command_path" ]]
+            }
             base_std_log_error() { printf "ERROR: %s\n" "$*"; }
             base_std_log_info() { printf "INFO: %s\n" "$*"; }
             base_std_log_warn() { printf "WARN: %s\n" "$*"; }
@@ -317,6 +325,14 @@ EOF
         PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
         bash -c '
             base_std_log_debug() { :; }
+            base_std_command_path() {
+                local result_name="$1"
+                local command_name="$2"
+                local command_path
+                command_path="$(type -P "$command_name" 2>/dev/null || true)"
+                printf -v "$result_name" '%s' "$command_path"
+                [[ -n "$command_path" ]]
+            }
             base_std_log_error() { printf "ERROR: %s\n" "$*"; }
             base_std_log_info() { printf "INFO: %s\n" "$*"; }
             base_std_log_warn() { printf "WARN: %s\n" "$*"; }
@@ -367,6 +383,14 @@ EOF
         PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
         bash -c '
             base_std_log_debug() { :; }
+            base_std_command_path() {
+                local result_name="$1"
+                local command_name="$2"
+                local command_path
+                command_path="$(type -P "$command_name" 2>/dev/null || true)"
+                printf -v "$result_name" '%s' "$command_path"
+                [[ -n "$command_path" ]]
+            }
             base_std_log_error() { printf "ERROR: %s\n" "$*"; }
             base_std_log_info() { printf "INFO: %s\n" "$*"; }
             base_std_log_warn() { printf "WARN: %s\n" "$*"; }
@@ -434,6 +458,14 @@ EOF
         PATH="$fake_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
         bash -c '
             base_std_log_debug() { :; }
+            base_std_command_path() {
+                local result_name="$1"
+                local command_name="$2"
+                local command_path
+                command_path="$(type -P "$command_name" 2>/dev/null || true)"
+                printf -v "$result_name" '%s' "$command_path"
+                [[ -n "$command_path" ]]
+            }
             base_std_log_error() { printf "ERROR: %s\n" "$*"; }
             base_std_log_info() { printf "INFO: %s\n" "$*"; }
             base_std_log_warn() { printf "WARN: %s\n" "$*"; }

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,9 @@ see [Release Process](release-process.md).
 For self-guided or live walkthrough material, see
 [Presentations](presentations/README.md).
 
+For the behavior boundaries of the Base Bash-libs dogfooding work, see the
+[Base Bash-libs Migration Matrix](base-bash-libs-migration-matrix.md).
+
 Base's product outcome is a local operating contract for deterministic readiness
 and handoff across independent Git repositories. The durable loop is
 inventory -> prepare -> verify -> trust -> onboard -> hand off. See [Why Base](why-base.md)

--- a/docs/base-bash-libs-migration-matrix.md
+++ b/docs/base-bash-libs-migration-matrix.md
@@ -1,0 +1,48 @@
+# Base Bash-Libs Migration Matrix
+
+This matrix records the behavior boundaries for the remaining Base shell
+dogfooding work tracked by [#2122](https://github.com/basefoundry/base/issues/2122)
+and [#2127](https://github.com/basefoundry/base/issues/2127). It is an
+implementation guide, not a change to the public `basectl` contract.
+
+## Argument parsing
+
+`base_arg_parse` is appropriate when Base owns the complete option grammar and
+can preserve the command's help, error, and positional semantics. It is not a
+drop-in replacement for commands that forward unknown options or arguments to
+the Python project layer.
+
+| Caller | Current contract | Migration decision |
+| --- | --- | --- |
+| `devcontainer.sh` | Base owns `--workspace`, `--format`, `--write`, `-v`, and one optional project; parser failures return usage status 2. | Already migrated; retain focused parser seam tests. |
+| `devenv_report.sh` | Same ownership model as `devcontainer.sh`, without `--write`. | Already migrated; retain focused parser seam tests. |
+| `export_context.sh` | Base owns format, output, print, list, workspace, debug, and one optional project. | Already migrated; retain focused parser seam tests. |
+| `prompt.sh` | Base owns one prompt name plus `--output` and `-v`; help is prompt-name-sensitive. | Candidate for a later parser slice after error/help translation is specified. |
+| `docs.sh` | Base owns one flag and rejects both unknown options and positionals with distinct messages. | Candidate for a later parser slice; preserve the two error messages. |
+| `update_profile.sh` | Base owns flags with mutually exclusive combinations and a command-specific usage-error format. | Candidate for a later parser slice; preserve conflict and error output. |
+| `test.sh`, `build.sh`, `demo.sh`, `run.sh` | Base parses project/setup flags, then passes arguments after `--` to a declared project command. | Defer; the `--` boundary and trust/runner behavior need dedicated tests. |
+| `clean.sh`, `logs.sh`, `projects.sh` | Bash recognizes only a subset of options and forwards the remaining grammar to the Python layer. | Defer; a strict shared parser would change pass-through behavior. |
+| `gh*.sh`, `repo*.sh`, `setup_diagnostics_fallback.sh` | Several nested commands have subcommand-specific grammars and forwarded GitHub/tool options. | Defer; migrate one leaf command at a time with runtime help baselines. |
+
+Every parser migration must record accepted argv forms, duplicate-option
+behavior, `--` handling, status codes, stdout/stderr ownership, and help
+precedence before changing code.
+
+## Command discovery
+
+The shared `base_std_command_path` helper resolves external commands through
+`PATH` without logging or exiting. It is the correct replacement when the
+caller needs a path or a quiet predicate. `base_std_assert_command_exists`
+remains appropriate only where its aggregate fatal message is acceptable.
+
+| Area | Callers | Required semantics | Decision |
+| --- | --- | --- | --- |
+| Setup and update path resolution | `setup_common.sh`, `setup_linux_debian.sh`, `setup_macos_homebrew.sh`, `update.sh`, `projects.sh` | Resolve an external executable, preserve explicit test hooks and platform fallback paths, and return failure quietly. | Migrate to `base_std_command_path`. |
+| Custom prerequisite errors | Linux `curl`/`dpkg`, repository `gh`, GitHub helper commands | Keep the existing command-specific error text and status. | Use `base_std_command_path` as the predicate, then retain the local error. |
+| Browser and GitHub readiness predicates | `docs.sh`, `gh_branch_worktree.sh`, `repo_github_settings.sh` | Preserve ordered fallback selection and cached readiness state. | Use `base_std_command_path`; keep the local selection/cache behavior. |
+| Explicit non-PATH fallbacks | Homebrew absolute candidates and project-local `~/.local/bin/uv` | Preserve absolute-path fallback and project-local runner semantics. | Keep the fallback after the shared PATH lookup. |
+| Tests and fixtures | BATS helpers, runtime probes, secret scanners | Test infrastructure may intentionally use `command -v` to locate a real tool or skip a test. | Out of production migration scope. |
+
+The command-discovery slice in the implementation PR covers all production
+`command -v` sites in `cli/bash/commands/basectl/subcommands`. It does not
+change installer first-mile fallbacks or test fixture discovery.


### PR DESCRIPTION
Summary: replace production command discovery in basectl subcommands with base_std_command_path; preserve custom errors, ordered fallbacks, explicit test hooks, and project-local uv behavior; add the #2127 argument/command migration matrix and update direct-source update test seams. Validation: affected BATS 410/410, update BATS 21/21, ShellCheck warnings clean except one pre-existing warning in repo_github_settings.sh, bash -n, and git diff --check. Related: basefoundry/base#2122 and basefoundry/base#2127.