### PR TITLE
refactor(basectl): migrate docs parsing to shared arg helper

### DIFF
--- a/cli/bash/commands/basectl/subcommands/docs.sh
+++ b/cli/bash/commands/basectl/subcommands/docs.sh
@@ -3,6 +3,8 @@
 _base_docs_subcommand_sourced=1
 readonly _base_docs_subcommand_sourced
 
+import_base_lib arg/lib_arg.sh
+
 BASE_DOCS_URL="https://github.com/basefoundry/base#readme"
 readonly BASE_DOCS_URL
 
@@ -50,20 +52,21 @@ base_docs_open_url() {
 }
 
 base_docs_subcommand_main() {
-    local show_url=0
+    local arg
+    # shellcheck disable=SC2034 # base_arg_parse receives caller-owned arrays by name.
+    local -a option_specs=("show_url|flag|--show-url") positionals=()
+    local -A parsed_options=()
 
-    while (($#)); do
-        case "$1" in
+    for arg in "$@"; do
+        case "$arg" in
             -h|--help|help)
                 base_docs_subcommand_usage
                 return 0
                 ;;
             --show-url)
-                show_url=1
-                shift
                 ;;
-            -*)
-                base_docs_usage_error "Unknown docs option '$1'."
+            --|-*)
+                base_docs_usage_error "Unknown docs option '$arg'."
                 return $?
                 ;;
             *)
@@ -73,7 +76,12 @@ base_docs_subcommand_main() {
         esac
     done
 
-    if ((show_url)); then
+    if ! base_arg_parse parsed_options positionals option_specs -- "$@"; then
+        base_docs_usage_error "Could not parse docs arguments."
+        return $?
+    fi
+
+    if [[ "${parsed_options[show_url]:-}" == "1" ]]; then
         printf '%s\n' "$BASE_DOCS_URL"
         return 0
     fi

--- a/cli/bash/commands/basectl/tests/docs.bats
+++ b/cli/bash/commands/basectl/tests/docs.bats
@@ -16,6 +16,28 @@ readonly BASE_DOCS_URL="https://github.com/basefoundry/base#readme"
     [[ "$output" == *"Open the Base documentation home page on GitHub."* ]]
 }
 
+@test "basectl docs parses options through reusable arg helper" {
+    local state_file="$TEST_TMPDIR/docs-arg-parse-state"
+
+    run env \
+        HOME="$TEST_HOME" \
+        BASE_HOME="$BASE_REPO_ROOT" \
+        BASE_BASH_LIBS_DIR="${BASE_BASH_LIBS_DIR:-}" \
+        BASE_TEST_ARG_PARSE_STATE="$state_file" \
+        bash -c '
+            source "$BASE_HOME/base_init.sh"
+            source "$BASE_HOME/cli/bash/commands/basectl/subcommands/docs.sh"
+            base_arg_parse() {
+                printf "%s\n" "$*" > "${BASE_TEST_ARG_PARSE_STATE:?}"
+                return 2
+            }
+            base_docs_subcommand_main --show-url
+        '
+
+    [ "$status" -eq 2 ]
+    [ "$(cat "$state_file")" = "parsed_options positionals option_specs -- --show-url" ]
+}
+
 @test "basectl docs opens the GitHub README in the platform browser" {
     local state_file="$TEST_TMPDIR/docs-open-state"
 
@@ -67,4 +89,16 @@ EOF
     [ "$status" -eq 2 ]
     [[ "$output" == *"basectl docs [options]"* ]]
     [[ "$output" == *"Unknown docs option '--unknown'."* ]]
+}
+
+@test "basectl docs preserves duplicate flags and help precedence" {
+    run_basectl docs --show-url --show-url
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "$BASE_DOCS_URL" ]
+
+    run_basectl docs extra --help
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"The 'docs' command does not accept positional arguments."* ]]
 }

--- a/docs/base-bash-libs-migration-matrix.md
+++ b/docs/base-bash-libs-migration-matrix.md
@@ -18,7 +18,7 @@ the Python project layer.
 | `devenv_report.sh` | Same ownership model as `devcontainer.sh`, without `--write`. | Already migrated; retain focused parser seam tests. |
 | `export_context.sh` | Base owns format, output, print, list, workspace, debug, and one optional project. | Already migrated; retain focused parser seam tests. |
 | `prompt.sh` | Base owns one prompt name plus `--output` and `-v`; help is prompt-name-sensitive. | Candidate for a later parser slice after error/help translation is specified. |
-| `docs.sh` | Base owns one flag and rejects both unknown options and positionals with distinct messages. | Candidate for a later parser slice; preserve the two error messages. |
+| `docs.sh` | Base owns `--show-url`; `-h`, `--help`, and `help` exit immediately, while unknown options and positionals have distinct errors. A standalone `--` is an unknown option. | Migrated in this slice through `base_arg_parse`; retain the preflight validation because the shared parser intentionally normalizes `--` and does not own the command-specific error text. |
 | `update_profile.sh` | Base owns flags with mutually exclusive combinations and a command-specific usage-error format. | Candidate for a later parser slice; preserve conflict and error output. |
 | `test.sh`, `build.sh`, `demo.sh`, `run.sh` | Base parses project/setup flags, then passes arguments after `--` to a declared project command. | Defer; the `--` boundary and trust/runner behavior need dedicated tests. |
 | `clean.sh`, `logs.sh`, `projects.sh` | Bash recognizes only a subset of options and forwards the remaining grammar to the Python layer. | Defer; a strict shared parser would change pass-through behavior. |


### PR DESCRIPTION
## Summary

- migrate the `basectl docs` owned `--show-url` flag to `base_arg_parse`
- preserve left-to-right help precedence, duplicate-flag behavior, the standalone `--` boundary, and distinct unknown-option/positional errors
- add parser-seam and compatibility regression coverage
- record the completed slice in `docs/base-bash-libs-migration-matrix.md`

## Validation

- focused docs BATS: 6/6 passed
- full shell/BATS regression with the #439-compatible base-bash-libs dependency: 905/905 passed
- `bash -n`, ShellCheck, and `git diff --check` passed

This is a narrow, behavior-preserving implementation slice for #2127. The remaining parser-forwarding and nested-command migrations stay split for separate review.

Related: #2127