### PR TITLE
fix(release): bind BOM combinations to the release repository

### DIFF
--- a/cli/python/base_release/release_bom.py
+++ b/cli/python/base_release/release_bom.py
@@ -41,7 +41,7 @@ def validate_bom(
         raise ReleaseBomError("schema_version must be 1")
 
     release = _mapping(document, "release")
-    _repository(release, "repository", "release")
+    release_repository = _repository(release, "repository", "release")
     release_version = _string(release, "version", "release.version")
     release_tag = _string(release, "tag", "release.tag")
     release_commit = _commit(release, "commit", "release.commit")
@@ -100,11 +100,14 @@ def validate_bom(
                 raise ReleaseBomError(f"{path}.tag must be an immutable vX.Y.Z tag")
         if commit != commit.lower():
             raise ReleaseBomError(f"{path}.commit must use lowercase hexadecimal")
+    if release_repository not in component_repositories:
+        raise ReleaseBomError("release.repository must be declared in components")
 
     combinations = document.get("combinations")
     if not isinstance(combinations, list) or not combinations:
         raise ReleaseBomError("combinations must be a non-empty array")
     required_combination = False
+    required_release_combination = False
     for index, combination in enumerate(combinations):
         path = f"combinations[{index}]"
         row = _mapping_value(combination, path)
@@ -114,6 +117,8 @@ def validate_bom(
             raise ReleaseBomError(f"{path}.participants must be a non-empty array")
         if not all(isinstance(participant, str) for participant in participants):
             raise ReleaseBomError(f"{path}.participants must contain repository strings")
+        if len(set(participants)) < 2:
+            raise ReleaseBomError(f"{path}.participants must contain at least two repositories")
         unknown = sorted(set(participants) - component_repositories)
         if unknown:
             raise ReleaseBomError(f"{path}.participants references unknown components: {unknown}")
@@ -125,12 +130,16 @@ def validate_bom(
         evidence = _string(row, "evidence", f"{path}.evidence")
         if required:
             required_combination = True
+            if release_repository in participants:
+                required_release_combination = True
             if result != "passed":
                 raise ReleaseBomError(f"{path} is required but result is {result!r}")
             if not evidence:
                 raise ReleaseBomError(f"{path}.evidence is required")
     if not required_combination:
         raise ReleaseBomError("at least one required combination must be declared")
+    if not required_release_combination:
+        raise ReleaseBomError("at least one required combination must include release.repository")
 
 
 def validate_bom_file(

--- a/cli/python/base_release/tests/test_release_bom.py
+++ b/cli/python/base_release/tests/test_release_bom.py
@@ -91,6 +91,34 @@ def test_required_failed_combination_is_rejected() -> None:
         validate_bom(document)
 
 
+def test_release_repository_must_be_a_declared_component() -> None:
+    document = valid_bom()
+    document["components"] = document["components"][1:]
+    with pytest.raises(ReleaseBomError, match="release.repository must be declared"):
+        validate_bom(document)
+
+
+def test_required_combination_must_include_release_repository() -> None:
+    document = valid_bom()
+    document["combinations"][0]["participants"] = ["basefoundry/base"]
+    with pytest.raises(ReleaseBomError, match="at least two repositories"):
+        validate_bom(document)
+
+    document["combinations"][0]["participants"] = ["basefoundry/base", "basefoundry/base-cli"]
+    with pytest.raises(ReleaseBomError, match="must include release.repository"):
+        validate_bom(document)
+
+
+def test_combinations_require_two_distinct_participants() -> None:
+    document = valid_bom()
+    document["combinations"][0]["participants"] = [
+        "basefoundry/base-bash-libs",
+        "basefoundry/base-bash-libs",
+    ]
+    with pytest.raises(ReleaseBomError, match="at least two repositories"):
+        validate_bom(document)
+
+
 def test_commit_and_version_mismatch_are_rejected() -> None:
     document = valid_bom()
     with pytest.raises(ReleaseBomError, match="does not match '2.2.0'"):

--- a/docs/release-bom.md
+++ b/docs/release-bom.md
@@ -17,7 +17,9 @@ release BOM contains:
 Required rows must use an immutable release or tag source, report `passed`, and
 include evidence. Moving-source rows are allowed only as advisory rows and do
 not block a release. The validator also rejects duplicate repositories, missing
-participants, mutable release identities, and version or commit mismatches.
+participants, a release repository absent from the component list or required
+combinations, single-repository combinations, mutable release identities, and
+version or commit mismatches.
 
 Validate and fingerprint a BOM locally:
 


### PR DESCRIPTION
## Summary

- Require the releasing repository to be declared in the BOM component rows.
- Require at least one required passing combination to include the releasing repository.
- Reject single-repository combinations.
- Add focused validator tests and document the relational gate.

## Issue

Fixes #2131
Parent: #2115

## Validation

- `PYTHONPATH=cli/python python -m pytest -q cli/python/base_release/tests/test_release_bom.py` (10 passed)
- `git diff --check`

`.ai-context/` was left unchanged because this is an internal release-validator hardening change.