### PR TITLE
fix(release): enforce canonical BOM identities

### DIFF
--- a/cli/python/base_release/release_bom.py
+++ b/cli/python/base_release/release_bom.py
@@ -8,6 +8,7 @@ from typing import Any
 
 
 FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+REPOSITORY_RE = re.compile(r"^[^/\s]+/[^/\s]+$")
 TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+$")
 RESULTS = {"passed", "failed", "not_tested"}
 SOURCE_MODES = {"release", "tag", "moving"}
@@ -47,7 +48,7 @@ def validate_bom(
     release_commit = _commit(release, "commit", "release.commit")
     if not TAG_RE.fullmatch(release_tag) or release_tag != f"v{release_version}":
         raise ReleaseBomError("release.tag must be v<release.version>")
-    if expected_repository is not None and release["repository"] != expected_repository:
+    if expected_repository is not None and release_repository.casefold() != expected_repository.casefold():
         raise ReleaseBomError(
             f"release.repository {release['repository']!r} does not match {expected_repository!r}"
         )
@@ -66,14 +67,15 @@ def validate_bom(
         path = f"components[{index}]"
         row = _mapping_value(component, path)
         repository = _repository(row, "repository", path)
-        if repository in component_repositories:
+        repository_key = repository.casefold()
+        if repository_key in component_repositories:
             raise ReleaseBomError(f"{path}.repository is duplicated: {repository}")
-        component_repositories.add(repository)
+        component_repositories.add(repository_key)
         _string(row, "version", f"{path}.version")
         source_mode = _string(row, "source_mode", f"{path}.source_mode")
         if source_mode not in SOURCE_MODES:
             raise ReleaseBomError(f"{path}.source_mode must be one of: {', '.join(sorted(SOURCE_MODES))}")
-        commit = _commit(row, "commit", path)
+        _commit(row, "commit", path)
         required = _boolean(row, "required", path)
         _string(row, "api_schema_version", f"{path}.api_schema_version")
         platforms = row.get("platforms")
@@ -98,9 +100,7 @@ def validate_bom(
             tag = _string(row, "tag", f"{path}.tag")
             if not TAG_RE.fullmatch(tag):
                 raise ReleaseBomError(f"{path}.tag must be an immutable vX.Y.Z tag")
-        if commit != commit.lower():
-            raise ReleaseBomError(f"{path}.commit must use lowercase hexadecimal")
-    if release_repository not in component_repositories:
+    if release_repository.casefold() not in component_repositories:
         raise ReleaseBomError("release.repository must be declared in components")
 
     combinations = document.get("combinations")
@@ -117,9 +117,10 @@ def validate_bom(
             raise ReleaseBomError(f"{path}.participants must be a non-empty array")
         if not all(isinstance(participant, str) for participant in participants):
             raise ReleaseBomError(f"{path}.participants must contain repository strings")
-        if len(set(participants)) < 2:
+        if len(set(participant.casefold() for participant in participants)) < 2:
             raise ReleaseBomError(f"{path}.participants must contain at least two repositories")
-        unknown = sorted(set(participants) - component_repositories)
+        participant_keys = {participant.casefold() for participant in participants}
+        unknown = sorted(participant_keys - component_repositories)
         if unknown:
             raise ReleaseBomError(f"{path}.participants references unknown components: {unknown}")
         _string(row, "platform", f"{path}.platform")
@@ -130,7 +131,7 @@ def validate_bom(
         evidence = _string(row, "evidence", f"{path}.evidence")
         if required:
             required_combination = True
-            if release_repository in participants:
+            if release_repository.casefold() in participant_keys:
                 required_release_combination = True
             if result != "passed":
                 raise ReleaseBomError(f"{path} is required but result is {result!r}")
@@ -186,15 +187,15 @@ def _string(row: dict[str, Any], key: str, path: str) -> str:
 
 def _repository(row: dict[str, Any], key: str = "repository", path: str = "") -> str:
     value = _string(row, key, f"{path + '.' if path else ''}{key}")
-    if "/" not in value or value.startswith("/") or value.endswith("/"):
+    if not REPOSITORY_RE.fullmatch(value):
         raise ReleaseBomError(f"{path + '.' if path else ''}{key} must use owner/name format")
     return value
 
 
 def _commit(row: dict[str, Any], key: str, path: str) -> str:
     value = _string(row, key, f"{path}.{key}")
-    if not FULL_SHA_RE.fullmatch(value.lower()):
-        raise ReleaseBomError(f"{path}.{key} must be a full 40-character SHA")
+    if not FULL_SHA_RE.fullmatch(value):
+        raise ReleaseBomError(f"{path}.{key} must be a lowercase full 40-character SHA")
     return value
 
 

--- a/cli/python/base_release/tests/test_release_bom.py
+++ b/cli/python/base_release/tests/test_release_bom.py
@@ -127,6 +127,43 @@ def test_commit_and_version_mismatch_are_rejected() -> None:
         validate_bom(document, expected_commit="d" * 40)
 
 
+def test_release_and_component_commits_must_be_lowercase() -> None:
+    document = valid_bom()
+    document["release"]["commit"] = SHA.upper()
+    with pytest.raises(ReleaseBomError, match="lowercase full 40-character SHA"):
+        validate_bom(document)
+
+    document = valid_bom()
+    document["components"][0]["commit"] = SHA.upper()
+    with pytest.raises(ReleaseBomError, match="lowercase full 40-character SHA"):
+        validate_bom(document)
+
+
+def test_repository_identity_matching_is_case_insensitive() -> None:
+    document = valid_bom()
+    document["release"]["repository"] = "BaseFoundry/Base-Bash-Libs"
+    document["components"][0]["repository"] = "BASEFOUNDRY/BASE-BASH-LIBS"
+    document["combinations"][0]["participants"][0] = "basefoundry/BASE-BASH-LIBS"
+    validate_bom(document, expected_repository="basefoundry/base-bash-libs")
+
+
+def test_repository_identity_rejects_malformed_owner_name_values() -> None:
+    for value in ("basefoundry/base/extra", "basefoundry/base libs", "/basefoundry/base"):
+        document = valid_bom()
+        document["components"][0]["repository"] = value
+        with pytest.raises(ReleaseBomError, match="must use owner/name format"):
+            validate_bom(document)
+
+
+def test_repository_duplicates_are_case_insensitive() -> None:
+    document = valid_bom()
+    duplicate = copy.deepcopy(document["components"][0])
+    duplicate["repository"] = duplicate["repository"].upper()
+    document["components"].append(duplicate)
+    with pytest.raises(ReleaseBomError, match="duplicated"):
+        validate_bom(document)
+
+
 def test_digest_is_stable_for_mapping_order() -> None:
     document = valid_bom()
     reordered = json.loads(json.dumps(document))

--- a/docs/release-bom.md
+++ b/docs/release-bom.md
@@ -19,7 +19,12 @@ include evidence. Moving-source rows are allowed only as advisory rows and do
 not block a release. The validator also rejects duplicate repositories, missing
 participants, a release repository absent from the component list or required
 combinations, single-repository combinations, mutable release identities, and
-version or commit mismatches.
+version or commit mismatches. Repository identity comparisons are
+case-insensitive, while repository values must still use the schema's owner/name
+form and commit values must be lowercase full SHAs.
+Repository identity comparisons are case-insensitive, while repository values
+must still use the schema's owner/name form and commit values must be lowercase
+full SHAs.
 
 Validate and fingerprint a BOM locally:
 


### PR DESCRIPTION
## Summary

- Enforce lowercase full SHA values for release and component identities.
- Make repository comparisons and duplicate detection case-insensitive.
- Enforce the schema owner/name repository shape at runtime.
- Add focused fixtures and tests for mixed-case identities and malformed repository values.

## Issue

Fixes #2132
Parent: #2131

## Validation

- `PYTHONPATH=cli/python python -m pytest -q cli/python/base_release/tests/test_release_bom.py` (14 passed, including the preceding #2131 train commit)
- `git diff --check`

`.ai-context/` was left unchanged because this is internal BOM contract hardening.