### PR TITLE
refactor(release): remove dead BOM branches

### DIFF
--- a/cli/python/base_release/release_bom.py
+++ b/cli/python/base_release/release_bom.py
@@ -41,7 +41,7 @@ def validate_bom(
         raise ReleaseBomError("schema_version must be 1")
 
     release = _mapping(document, "release")
-    _repository(release, "repository", "release")
+    release_repository = _repository(release, "repository", "release")
     release_version = _string(release, "version", "release.version")
     release_tag = _string(release, "tag", "release.tag")
     release_commit = _commit(release, "commit", "release.commit")
@@ -100,11 +100,14 @@ def validate_bom(
                 raise ReleaseBomError(f"{path}.tag must be an immutable vX.Y.Z tag")
         if commit != commit.lower():
             raise ReleaseBomError(f"{path}.commit must use lowercase hexadecimal")
+    if release_repository not in component_repositories:
+        raise ReleaseBomError("release.repository must be declared in components")
 
     combinations = document.get("combinations")
     if not isinstance(combinations, list) or not combinations:
         raise ReleaseBomError("combinations must be a non-empty array")
     required_combination = False
+    required_release_combination = False
     for index, combination in enumerate(combinations):
         path = f"combinations[{index}]"
         row = _mapping_value(combination, path)
@@ -114,6 +117,8 @@ def validate_bom(
             raise ReleaseBomError(f"{path}.participants must be a non-empty array")
         if not all(isinstance(participant, str) for participant in participants):
             raise ReleaseBomError(f"{path}.participants must contain repository strings")
+        if len(set(participants)) < 2:
+            raise ReleaseBomError(f"{path}.participants must contain at least two repositories")
         unknown = sorted(set(participants) - component_repositories)
         if unknown:
             raise ReleaseBomError(f"{path}.participants references unknown components: {unknown}")
@@ -125,12 +130,16 @@ def validate_bom(
         evidence = _string(row, "evidence", f"{path}.evidence")
         if required:
             required_combination = True
+            if release_repository in participants:
+                required_release_combination = True
             if result != "passed":
                 raise ReleaseBomError(f"{path} is required but result is {result!r}")
             if not evidence:
                 raise ReleaseBomError(f"{path}.evidence is required")
     if not required_combination:
         raise ReleaseBomError("at least one required combination must be declared")
+    if not required_release_combination:
+        raise ReleaseBomError("at least one required combination must include release.repository")
 
 
 def validate_bom_file(

--- a/cli/python/base_release/release_bom.py
+++ b/cli/python/base_release/release_bom.py
@@ -86,14 +86,12 @@ def validate_bom(
         result = _string(row, "result", f"{path}.result")
         if result not in RESULTS:
             raise ReleaseBomError(f"{path}.result must be one of: {', '.join(sorted(RESULTS))}")
-        evidence = _string(row, "evidence", f"{path}.evidence")
+        _string(row, "evidence", f"{path}.evidence")
         if required:
             if source_mode == "moving":
                 raise ReleaseBomError(f"{path} cannot require a moving source")
             if result != "passed":
                 raise ReleaseBomError(f"{path} is required but result is {result!r}")
-            if not evidence:
-                raise ReleaseBomError(f"{path}.evidence is required")
         if source_mode == "moving" and row.get("tag") is not None:
             raise ReleaseBomError(f"{path}.tag must be omitted for moving sources")
         if source_mode != "moving":
@@ -128,15 +126,13 @@ def validate_bom(
         result = _string(row, "result", f"{path}.result")
         if result not in RESULTS:
             raise ReleaseBomError(f"{path}.result must be one of: {', '.join(sorted(RESULTS))}")
-        evidence = _string(row, "evidence", f"{path}.evidence")
+        _string(row, "evidence", f"{path}.evidence")
         if required:
             required_combination = True
             if release_repository.casefold() in participant_keys:
                 required_release_combination = True
             if result != "passed":
                 raise ReleaseBomError(f"{path} is required but result is {result!r}")
-            if not evidence:
-                raise ReleaseBomError(f"{path}.evidence is required")
     if not required_combination:
         raise ReleaseBomError("at least one required combination must be declared")
     if not required_release_combination:

--- a/cli/python/base_release/release_bom.py
+++ b/cli/python/base_release/release_bom.py
@@ -8,6 +8,7 @@ from typing import Any
 
 
 FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+REPOSITORY_RE = re.compile(r"^[^/\s]+/[^/\s]+$")
 TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+$")
 RESULTS = {"passed", "failed", "not_tested"}
 SOURCE_MODES = {"release", "tag", "moving"}
@@ -47,7 +48,7 @@ def validate_bom(
     release_commit = _commit(release, "commit", "release.commit")
     if not TAG_RE.fullmatch(release_tag) or release_tag != f"v{release_version}":
         raise ReleaseBomError("release.tag must be v<release.version>")
-    if expected_repository is not None and release["repository"] != expected_repository:
+    if expected_repository is not None and release_repository.casefold() != expected_repository.casefold():
         raise ReleaseBomError(
             f"release.repository {release['repository']!r} does not match {expected_repository!r}"
         )
@@ -66,14 +67,15 @@ def validate_bom(
         path = f"components[{index}]"
         row = _mapping_value(component, path)
         repository = _repository(row, "repository", path)
-        if repository in component_repositories:
+        repository_key = repository.casefold()
+        if repository_key in component_repositories:
             raise ReleaseBomError(f"{path}.repository is duplicated: {repository}")
-        component_repositories.add(repository)
+        component_repositories.add(repository_key)
         _string(row, "version", f"{path}.version")
         source_mode = _string(row, "source_mode", f"{path}.source_mode")
         if source_mode not in SOURCE_MODES:
             raise ReleaseBomError(f"{path}.source_mode must be one of: {', '.join(sorted(SOURCE_MODES))}")
-        commit = _commit(row, "commit", path)
+        _commit(row, "commit", path)
         required = _boolean(row, "required", path)
         _string(row, "api_schema_version", f"{path}.api_schema_version")
         platforms = row.get("platforms")
@@ -98,9 +100,7 @@ def validate_bom(
             tag = _string(row, "tag", f"{path}.tag")
             if not TAG_RE.fullmatch(tag):
                 raise ReleaseBomError(f"{path}.tag must be an immutable vX.Y.Z tag")
-        if commit != commit.lower():
-            raise ReleaseBomError(f"{path}.commit must use lowercase hexadecimal")
-    if release_repository not in component_repositories:
+    if release_repository.casefold() not in component_repositories:
         raise ReleaseBomError("release.repository must be declared in components")
 
     combinations = document.get("combinations")
@@ -117,9 +117,10 @@ def validate_bom(
             raise ReleaseBomError(f"{path}.participants must be a non-empty array")
         if not all(isinstance(participant, str) for participant in participants):
             raise ReleaseBomError(f"{path}.participants must contain repository strings")
-        if len(set(participants)) < 2:
+        if len(set(participant.casefold() for participant in participants)) < 2:
             raise ReleaseBomError(f"{path}.participants must contain at least two repositories")
-        unknown = sorted(set(participants) - component_repositories)
+        participant_keys = {participant.casefold() for participant in participants}
+        unknown = sorted(participant_keys - component_repositories)
         if unknown:
             raise ReleaseBomError(f"{path}.participants references unknown components: {unknown}")
         _string(row, "platform", f"{path}.platform")
@@ -130,7 +131,7 @@ def validate_bom(
         evidence = _string(row, "evidence", f"{path}.evidence")
         if required:
             required_combination = True
-            if release_repository in participants:
+            if release_repository.casefold() in participant_keys:
                 required_release_combination = True
             if result != "passed":
                 raise ReleaseBomError(f"{path} is required but result is {result!r}")
@@ -186,15 +187,15 @@ def _string(row: dict[str, Any], key: str, path: str) -> str:
 
 def _repository(row: dict[str, Any], key: str = "repository", path: str = "") -> str:
     value = _string(row, key, f"{path + '.' if path else ''}{key}")
-    if "/" not in value or value.startswith("/") or value.endswith("/"):
+    if not REPOSITORY_RE.fullmatch(value):
         raise ReleaseBomError(f"{path + '.' if path else ''}{key} must use owner/name format")
     return value
 
 
 def _commit(row: dict[str, Any], key: str, path: str) -> str:
     value = _string(row, key, f"{path}.{key}")
-    if not FULL_SHA_RE.fullmatch(value.lower()):
-        raise ReleaseBomError(f"{path}.{key} must be a full 40-character SHA")
+    if not FULL_SHA_RE.fullmatch(value):
+        raise ReleaseBomError(f"{path}.{key} must be a lowercase full 40-character SHA")
     return value
 
 

--- a/cli/python/base_release/release_bom_cli.py
+++ b/cli/python/base_release/release_bom_cli.py
@@ -5,7 +5,7 @@ import json
 import sys
 from pathlib import Path
 
-from .release_bom import ReleaseBomError, bom_digest, load_bom, validate_bom
+from .release_bom import ReleaseBomError, bom_digest, canonical_bom_bytes, load_bom, validate_bom
 
 EXIT_SUCCESS = 0
 EXIT_FAILURE = 1
@@ -77,7 +77,7 @@ def main() -> int:
         else:
             assembled = assemble(args)
             args.output.parent.mkdir(parents=True, exist_ok=True)
-            args.output.write_text(json.dumps(assembled, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            args.output.write_bytes(canonical_bom_bytes(assembled))
             print(f"release BOM assembled and validated: {args.output}")
             print(f"sha256: {bom_digest(assembled)}")
     except ReleaseBomError as exc:

--- a/cli/python/base_release/tests/test_release_bom.py
+++ b/cli/python/base_release/tests/test_release_bom.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
+import sys
 from pathlib import Path
 
 import pytest
 
 from base_release.release_bom import ReleaseBomError, bom_digest, validate_bom
 from base_release.release_bom import load_bom, validate_bom_file
+from base_release.release_bom_cli import main
 
 
 SHA = "a" * 40
@@ -169,6 +172,39 @@ def test_digest_is_stable_for_mapping_order() -> None:
     reordered = json.loads(json.dumps(document))
     reordered["release"] = {key: document["release"][key] for key in reversed(document["release"])}
     assert bom_digest(document) == bom_digest(reordered)
+
+
+def test_assemble_writes_bytes_matching_reported_digest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    document = valid_bom()
+    component_paths = []
+    for index, component in enumerate(document["components"][:2]):
+        component_path = tmp_path / f"component-{index}.json"
+        component_path.write_text(json.dumps(component), encoding="utf-8")
+        component_paths.append(component_path)
+    output_path = tmp_path / "release-bom.json"
+    arguments = [
+        "base-release-bom",
+        "assemble",
+        "--repository",
+        document["release"]["repository"],
+        "--version",
+        document["release"]["version"],
+        "--commit",
+        document["release"]["commit"],
+    ]
+    for component_path in component_paths:
+        arguments.extend(("--component", str(component_path)))
+    arguments.extend(
+        (
+            "--combination",
+            json.dumps(document["combinations"][0]),
+            "--output",
+            str(output_path),
+        )
+    )
+    monkeypatch.setattr(sys, "argv", arguments)
+    assert main() == 0
+    assert hashlib.sha256(output_path.read_bytes()).hexdigest() == bom_digest(load_bom(output_path))
 
 
 def test_duplicate_component_and_unknown_participant_are_rejected() -> None:

--- a/cli/python/base_release/tests/test_release_bom.py
+++ b/cli/python/base_release/tests/test_release_bom.py
@@ -127,6 +127,43 @@ def test_commit_and_version_mismatch_are_rejected() -> None:
         validate_bom(document, expected_commit="d" * 40)
 
 
+def test_release_and_component_commits_must_be_lowercase() -> None:
+    document = valid_bom()
+    document["release"]["commit"] = SHA.upper()
+    with pytest.raises(ReleaseBomError, match="lowercase full 40-character SHA"):
+        validate_bom(document)
+
+    document = valid_bom()
+    document["components"][0]["commit"] = SHA.upper()
+    with pytest.raises(ReleaseBomError, match="lowercase full 40-character SHA"):
+        validate_bom(document)
+
+
+def test_repository_identity_matching_is_case_insensitive() -> None:
+    document = valid_bom()
+    document["release"]["repository"] = "BaseFoundry/Base-Bash-Libs"
+    document["components"][0]["repository"] = "BASEFOUNDRY/BASE-BASH-LIBS"
+    document["combinations"][0]["participants"][0] = "basefoundry/BASE-BASH-LIBS"
+    validate_bom(document, expected_repository="basefoundry/base-bash-libs")
+
+
+def test_repository_identity_rejects_malformed_owner_name_values() -> None:
+    for value in ("basefoundry/base/extra", "basefoundry/base libs", "/basefoundry/base"):
+        document = valid_bom()
+        document["components"][0]["repository"] = value
+        with pytest.raises(ReleaseBomError, match="must use owner/name format"):
+            validate_bom(document)
+
+
+def test_repository_duplicates_are_case_insensitive() -> None:
+    document = valid_bom()
+    duplicate = copy.deepcopy(document["components"][0])
+    duplicate["repository"] = duplicate["repository"].upper()
+    document["components"].append(duplicate)
+    with pytest.raises(ReleaseBomError, match="duplicated"):
+        validate_bom(document)
+
+
 def test_digest_is_stable_for_mapping_order() -> None:
     document = valid_bom()
     reordered = json.loads(json.dumps(document))

--- a/cli/python/base_release/tests/test_release_bom.py
+++ b/cli/python/base_release/tests/test_release_bom.py
@@ -91,6 +91,34 @@ def test_required_failed_combination_is_rejected() -> None:
         validate_bom(document)
 
 
+def test_release_repository_must_be_a_declared_component() -> None:
+    document = valid_bom()
+    document["components"] = document["components"][1:]
+    with pytest.raises(ReleaseBomError, match="release.repository must be declared"):
+        validate_bom(document)
+
+
+def test_required_combination_must_include_release_repository() -> None:
+    document = valid_bom()
+    document["combinations"][0]["participants"] = ["basefoundry/base"]
+    with pytest.raises(ReleaseBomError, match="at least two repositories"):
+        validate_bom(document)
+
+    document["combinations"][0]["participants"] = ["basefoundry/base", "basefoundry/base-cli"]
+    with pytest.raises(ReleaseBomError, match="must include release.repository"):
+        validate_bom(document)
+
+
+def test_combinations_require_two_distinct_participants() -> None:
+    document = valid_bom()
+    document["combinations"][0]["participants"] = [
+        "basefoundry/base-bash-libs",
+        "basefoundry/base-bash-libs",
+    ]
+    with pytest.raises(ReleaseBomError, match="at least two repositories"):
+        validate_bom(document)
+
+
 def test_commit_and_version_mismatch_are_rejected() -> None:
     document = valid_bom()
     with pytest.raises(ReleaseBomError, match="does not match '2.2.0'"):

--- a/docs/release-bom.md
+++ b/docs/release-bom.md
@@ -19,7 +19,12 @@ include evidence. Moving-source rows are allowed only as advisory rows and do
 not block a release. The validator also rejects duplicate repositories, missing
 participants, a release repository absent from the component list or required
 combinations, single-repository combinations, mutable release identities, and
-version or commit mismatches.
+version or commit mismatches. Repository identity comparisons are
+case-insensitive, while repository values must still use the schema's owner/name
+form and commit values must be lowercase full SHAs.
+Repository identity comparisons are case-insensitive, while repository values
+must still use the schema's owner/name form and commit values must be lowercase
+full SHAs.
 
 Validate and fingerprint a BOM locally:
 

--- a/docs/release-bom.md
+++ b/docs/release-bom.md
@@ -17,7 +17,9 @@ release BOM contains:
 Required rows must use an immutable release or tag source, report `passed`, and
 include evidence. Moving-source rows are allowed only as advisory rows and do
 not block a release. The validator also rejects duplicate repositories, missing
-participants, mutable release identities, and version or commit mismatches.
+participants, a release repository absent from the component list or required
+combinations, single-repository combinations, mutable release identities, and
+version or commit mismatches.
 
 Validate and fingerprint a BOM locally:
 

--- a/docs/release-bom.md
+++ b/docs/release-bom.md
@@ -38,7 +38,9 @@ bin/base-release-bom digest path/to/release-bom.json
 
 The release coordinator can assemble the complete record from repository-owned
 component rows and explicit combination results. Each combination is a JSON
-object; required combinations must already report `passed`:
+object; required combinations must already report `passed`. Assembly writes
+canonical deterministic bytes, so the printed digest matches `sha256sum` of the
+attached BOM artifact:
 
 ```bash
 bin/base-release-bom assemble \

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -773,9 +773,6 @@ _base_basectl_completion() {
                 _base_basectl_completion_compgen "--version --manifest --bom --format -h --help" "$cur"
             else
                 case "${COMP_WORDS[2]:-}" in
-                    check)
-                        _base_basectl_completion_compgen "--version --manifest --bom -h --help" "$cur"
-                        ;;
                     plan|notes)
                         _base_basectl_completion_compgen "--version --manifest -h --help" "$cur"
                         ;;


### PR DESCRIPTION
## Summary

- Remove redundant evidence checks after common non-empty-string validation.
- Remove the unreachable Bash completion branch shadowed by the release-check arm.
- Preserve focused release and completion coverage.

## Issue

Fixes #2134
Parent: #2133

## Validation

- `PYTHONPATH=cli/python python -m pytest -q cli/python/base_release/tests/test_release_bom.py` (15 passed)
- `BASE_BASH_LIBS_DIR=... bats cli/bash/commands/basectl/tests/release.bats lib/shell/completions/tests/completions.bats` (34 passed)
- `git diff --check`

`.ai-context/` was left unchanged because this is internal cleanup with no public contract change.