### PR TITLE
refactor(gh): migrate issue readiness parsing to shared helper

### DIFF
--- a/cli/bash/commands/basectl/subcommands/gh_issue_readiness.sh
+++ b/cli/bash/commands/basectl/subcommands/gh_issue_readiness.sh
@@ -4,6 +4,8 @@
 _base_gh_issue_readiness_sourced=1
 readonly _base_gh_issue_readiness_sourced
 
+import_base_lib arg/lib_arg.sh
+
 base_gh_issue_readiness_required_sections() {
     printf '%s\n' \
         "Goal" \
@@ -126,6 +128,15 @@ base_gh_issue_readiness_reset() {
 
 base_gh_issue_readiness_parse_args() {
     local requested_format=""
+    # shellcheck disable=SC2034 # base_arg_parse receives caller-owned arrays by name.
+    local -a option_specs=(
+        "repo|value|--repo"
+        "project_owner|value|--project-owner"
+        "project_number|value|--project-number"
+        "format|value|--format"
+    )
+    local -a parser_args=() positionals=()
+    local -A parsed_options=()
 
     base_inspection_find_output_format _BASE_GH_ISSUE_READINESS_OUTPUT_FORMAT "$@"
 
@@ -143,6 +154,7 @@ base_gh_issue_readiness_parse_args() {
         base_gh_issue_readiness_format_error "$_BASE_GH_ISSUE_READINESS_OUTPUT_FORMAT" "Invalid issue number '$_BASE_GH_ISSUE_READINESS_ISSUE'."
         return $?
     }
+    parser_args+=("$_BASE_GH_ISSUE_READINESS_ISSUE")
     shift
 
     while (($#)); do
@@ -153,6 +165,7 @@ base_gh_issue_readiness_parse_args() {
                     base_gh_issue_readiness_format_error "$_BASE_GH_ISSUE_READINESS_OUTPUT_FORMAT" "Option '--repo' requires an argument."
                     return $?
                 }
+                parser_args+=("--repo=$2")
                 shift
                 ;;
             --project-owner)
@@ -161,6 +174,7 @@ base_gh_issue_readiness_parse_args() {
                     base_gh_issue_readiness_format_error "$_BASE_GH_ISSUE_READINESS_OUTPUT_FORMAT" "Option '--project-owner' requires an argument."
                     return $?
                 }
+                parser_args+=("--project-owner=$2")
                 _BASE_GH_ISSUE_READINESS_PROJECT_VALIDATION_REQUESTED=1
                 shift
                 ;;
@@ -174,6 +188,7 @@ base_gh_issue_readiness_parse_args() {
                     base_gh_issue_readiness_format_error "$_BASE_GH_ISSUE_READINESS_OUTPUT_FORMAT" "Invalid project number '$_BASE_GH_ISSUE_READINESS_PROJECT_NUMBER'."
                     return $?
                 }
+                parser_args+=("--project-number=$2")
                 _BASE_GH_ISSUE_READINESS_PROJECT_VALIDATION_REQUESTED=1
                 shift
                 ;;
@@ -191,6 +206,7 @@ base_gh_issue_readiness_parse_args() {
                         return $?
                         ;;
                 esac
+                parser_args+=("--format=$2")
                 _BASE_GH_ISSUE_READINESS_OUTPUT_FORMAT="$requested_format"
                 shift
                 ;;
@@ -206,6 +222,20 @@ base_gh_issue_readiness_parse_args() {
         esac
         shift
     done
+
+    if ! base_arg_parse parsed_options positionals option_specs -- "${parser_args[@]}"; then
+        base_gh_issue_readiness_format_error "$_BASE_GH_ISSUE_READINESS_OUTPUT_FORMAT" "Could not parse issue readiness arguments."
+        return $?
+    fi
+
+    _BASE_GH_ISSUE_READINESS_ISSUE="${positionals[0]}"
+    _BASE_GH_ISSUE_READINESS_REPOSITORY="${parsed_options[repo]:-}"
+    _BASE_GH_ISSUE_READINESS_PROJECT_OWNER="${parsed_options[project_owner]:-}"
+    _BASE_GH_ISSUE_READINESS_PROJECT_NUMBER="${parsed_options[project_number]:-}"
+    _BASE_GH_ISSUE_READINESS_OUTPUT_FORMAT="${parsed_options[format]:-text}"
+    if [[ -n "${parsed_options[project_owner]+set}" || -n "${parsed_options[project_number]+set}" ]]; then
+        _BASE_GH_ISSUE_READINESS_PROJECT_VALIDATION_REQUESTED=1
+    fi
 
     if ((_BASE_GH_ISSUE_READINESS_PROJECT_VALIDATION_REQUESTED)) &&
         { [[ -z "$_BASE_GH_ISSUE_READINESS_PROJECT_OWNER" ]] || [[ -z "$_BASE_GH_ISSUE_READINESS_PROJECT_NUMBER" ]]; }; then

--- a/cli/bash/commands/basectl/tests/gh.bats
+++ b/cli/bash/commands/basectl/tests/gh.bats
@@ -559,6 +559,18 @@ run_gh_subcommand() {
     [[ "$(cat "$TEST_STATE_DIR/gh-args")" != *"project item-list"* ]]
 }
 
+@test "basectl gh issue readiness parses the selected leaf through the shared helper" {
+    write_issue_readiness_gh_mock
+    write_complete_issue_readiness_body
+
+    run_gh_subcommand issue readiness 123 --repo --format
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Issue #123 readiness: partial"* ]]
+    [[ "$output" == *"Repository: --format"* ]]
+    [[ "$(cat "$TEST_STATE_DIR/gh-args")" == *"issue view 123 --repo --format"* ]]
+}
+
 @test "basectl gh issue readiness reports missing body sections with fix hints" {
     write_issue_readiness_gh_mock
     write_incomplete_issue_readiness_body

--- a/docs/base-bash-libs-migration-matrix.md
+++ b/docs/base-bash-libs-migration-matrix.md
@@ -22,7 +22,7 @@ the Python project layer.
 | `update_profile.sh` | Base owns flags with mutually exclusive combinations and a command-specific usage-error format. | Migrated in #2140 through `base_arg_parse`; retain the preflight validation for left-to-right help and error precedence, then preserve conflict and error output. |
 | `test.sh`, `build.sh`, `demo.sh`, `run.sh` | Base parses project/setup flags, then passes arguments after `--` to a declared project command. | Defer; the `--` boundary and trust/runner behavior need dedicated tests. |
 | `clean.sh`, `logs.sh`, `projects.sh` | Bash recognizes only a subset of options and forwards the remaining grammar to the Python layer. | Defer; a strict shared parser would change pass-through behavior. |
-| `gh*.sh`, `repo*.sh`, `setup_diagnostics_fallback.sh` | Several nested commands have subcommand-specific grammars and forwarded GitHub/tool options. | Defer; migrate one leaf command at a time with runtime help baselines. |
+| `gh*.sh`, `repo*.sh`, `setup_diagnostics_fallback.sh` | Several nested commands have subcommand-specific grammars and forwarded GitHub/tool options. | The `gh issue readiness` leaf is migrated in #2144 through `base_arg_parse` with runtime-help and option-looking-value coverage; keep the remaining leaves on this tracking row for successive migrations. |
 
 Every parser migration must record accepted argv forms, duplicate-option
 behavior, `--` handling, status codes, stdout/stderr ownership, and help


### PR DESCRIPTION
## Summary
- migrate the self-contained `gh issue readiness` leaf parser through `base_arg_parse`
- preserve issue-number validation, option-looking values, duplicate last-value behavior, help precedence, JSON/text errors, and Project option pairing
- add a runtime argv/parser seam regression and update the migration matrix
- leave the remaining nested leaves tracked under #2144 for successive PRs

## Validation
- `cli/bash/commands/basectl/tests/gh.bats`: 62/62
- `bash -n`, ShellCheck, and `git diff --check`

Related to #2144
Related to #2127
Related to #2117