### PR TITLE
Declare and preflight project test requirements

### DIFF
--- a/.ai-context/ARCHITECTURE.md
+++ b/.ai-context/ARCHITECTURE.md
@@ -74,6 +74,14 @@ work, do not inherit Base bootstrap packages into a project venv, and report
 workspace venv state as `not_applicable`. `project.languages` remains taxonomy.
 The broader runtime separation remains tracked in #1611.
 
+Manifest-declared test requirements are an explicit project-runtime contract.
+`test.requirements` is repository-relative and currently supports direct
+package names with optional exact `==` versions. Setup installs the file into
+the routed project environment; check, doctor, and test preflight fail closed
+for missing files, invalid declarations, or missing/mismatched packages.
+uv-managed projects keep dependency ownership in `pyproject.toml` and their
+lockfile instead of using this requirements-file path.
+
 When Bash needs metadata from `base_projects` or the `base_setup` route action,
 it requests the internal versioned `command-protocol` format. Records have
 explicit schemas, field names, string/boolean/null types, and hex-framed UTF-8

--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -37,7 +37,10 @@ the v1.x compatibility window; new automation should use `--debug-wrapper`.
   `--format json` provides stable finding IDs for automation.
 - `basectl doctor [project]` - diagnose Base or project readiness and explain
   fixes.
-- `basectl test [project]` - run a project's declared test command.
+- `basectl test [project]` - run a project's declared test command. A
+  manifest may declare `test.requirements` as a repository-relative direct
+  requirements file; setup installs it, check/doctor report missing or
+  mismatched packages, and test preflights it before execution.
 - `basectl build [project] [target...]` - run declared build targets for the positional, explicit, or nearest project.
 - `basectl demo [project]` - run a declared interactive demo script.
 - `basectl run [project] <command>` - run a declared command for the positional, explicit, or nearest project.

--- a/.ai-context/WORKFLOWS.md
+++ b/.ai-context/WORKFLOWS.md
@@ -156,10 +156,12 @@ considering mutating installers.
 Project-originated IDE app, extension, and global user-setting mutations are a
 separate setup consent boundary. `basectl setup --dry-run` must be reviewed,
 and applying the plan requires `--allow-project-ide-mutations`; `--yes` alone
-does not authorize it. Manifest command trust remains bound to the
-`base_manifest.yaml` SHA-256 only, so status and execution guidance warns that
-referenced scripts, direct executable files, Git HEAD, and uncommitted working
-tree changes are not independently verified or invalidating inputs.
+does not authorize it. Manifest command trust is bound to the
+`base_manifest.yaml` SHA-256 and the declared local `test.requirements`
+SHA-256. Changes to either require re-approval; status and execution guidance
+still warns that referenced scripts, direct executable files, Git HEAD, and
+uncommitted working-tree changes are not independently verified or invalidating
+inputs.
 
 ## AI Context Maintenance
 

--- a/base_manifest.yaml
+++ b/base_manifest.yaml
@@ -7,6 +7,7 @@ project:
 
 test:
   command: ./bin/base-test
+  requirements: requirements-dev.txt
 
 demo:
   script: ./demo/demo.sh

--- a/cli/bash/commands/basectl/README.md
+++ b/cli/bash/commands/basectl/README.md
@@ -192,8 +192,11 @@ such command directories exist. Optional utility CLIs such as `caff` and
   `--category <name>` to offline `--pr --dry-run` previews.
 - `basectl test [project]` runs the project's manifest `test.command` or
   `test.mise` from the project root with Base project environment variables
-  exported. Use `basectl test <project> -- <args...>` to pass extra arguments
-  to the delegated test command.
+  exported. A project may declare a repository-local Python requirements file
+  as `test.requirements`; Base setup installs it, check/doctor verify it, and
+  test refuses to run until the project environment satisfies it. Use
+  `basectl test <project> -- <args...>` to pass extra arguments to the
+  delegated test command.
 - `basectl build [project] [target...]` runs manifest `build.targets` from
   each target's `working_dir`. With no targets, it runs `build.default`
   sequentially. Use `basectl build [project] --list` to inspect targets and

--- a/cli/bash/commands/basectl/subcommands/test.sh
+++ b/cli/bash/commands/basectl/subcommands/test.sh
@@ -169,6 +169,15 @@ base_test_subcommand_main() {
         return 0
     fi
 
+    resolve_output="$($wrapper --project base base_projects "${command_args[@]}" "${args[@]}" --format command-protocol --test-preflight)" || return $?
+    base_command_protocol_decode_one project-command "$resolve_output" || {
+        base_std_fatal_error "Unable to resolve test command for project '$project'."
+    }
+    test_command="${BASE_COMMAND_PROTOCOL_FIELDS[command]}"
+    command_runner="${BASE_COMMAND_PROTOCOL_FIELDS[runner]}"
+    command_runner="${command_runner:-}"
+    command_to_run="$(base_command_with_runner "$command_runner" "$test_command" "${extra_args[@]}")" || return $?
+
     base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "$trust_required" || return $?
     base_project_activate_environment \
         "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "$route_venv_dir" "$uses_uv_manager" >/dev/null

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -72,6 +72,7 @@ from base_setup.demo import resolve_demo_script_path
 from base_setup.errors import ArtifactError
 from base_setup.manifest import read_manifest
 from base_setup.manifest_loader import ManifestError
+from base_setup.test_requirements import check_test_requirements
 
 
 app = base_cli_app(name="base_projects")
@@ -121,6 +122,11 @@ def main(argv: list[str] | None = None) -> int:
 )
 @base_cli.option("--apply", is_flag=True, help="Apply workspace configure changes after the plan is shown.")
 @base_cli.option("--yes", is_flag=True, help="Approve workspace setup or configure changes that require confirmation.")
+@base_cli.option(
+    "--test-preflight",
+    is_flag=True,
+    help="Check a project test requirements file before resolving its test command.",
+)
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 def run(
     ctx: base_cli.Context,
@@ -137,6 +143,7 @@ def run(
     dry_run: bool,
     apply: bool,
     yes: bool,
+    test_preflight: bool,
 ) -> int:
     try:
         return dispatch_projects_command(
@@ -155,6 +162,7 @@ def run(
                 dry_run=dry_run,
                 apply=apply,
                 yes=yes,
+                test_preflight=test_preflight,
             ),
             project_command_actions(),
         )
@@ -585,6 +593,7 @@ def test_command_project_command(
     project_name: str | None,
     workspace: str | None,
     output_format: str = "text",
+    test_preflight: bool = False,
 ) -> int:
     try:
         if project_name:
@@ -606,6 +615,14 @@ def test_command_project_command(
             project.manifest_path,
         )
         return base_cli.ExitCode.FAILURE
+
+    if test_preflight:
+        check = check_test_requirements(manifest)
+        if check is not None and not check.ok:
+            ctx.log.error(check.message)
+            if check.fix:
+                ctx.log.error("Fix: %s", check.fix)
+            return base_cli.ExitCode.FAILURE
 
     command_config = test_command(manifest.test)
     if output_format == "command-protocol":

--- a/cli/python/base_projects/project_dispatch.py
+++ b/cli/python/base_projects/project_dispatch.py
@@ -21,6 +21,7 @@ class WorkspaceCommandOptions:
     dry_run: bool = False
     apply: bool = False
     yes: bool = False
+    test_preflight: bool = False
 
 
 @dataclass(frozen=True)
@@ -40,7 +41,7 @@ class ProjectCommandActions:
     current_project: Callable[[base_cli.Context, str], int]
     manifest_project: Callable[[base_cli.Context, str | None, str], int]
     resolve_project: Callable[[base_cli.Context, str | None, str | None, str], int]
-    test_command_project: Callable[[base_cli.Context, str | None, str | None, str], int]
+    test_command_project: Callable[[base_cli.Context, str | None, str | None, str, bool], int]
     demo_script_project: Callable[[base_cli.Context, str | None, str | None, str], int]
     activation_sources_project: Callable[[base_cli.Context, str | None, str | None, str], int]
     run_command_project: Callable[
@@ -255,7 +256,7 @@ def _handle_test_command(
     if options.project_name is not None and arguments:
         raise ProjectUsageError("Project command 'test-command' does not accept a positional project with --project.")
     project = options.project_name or optional_project_argument("test-command", arguments)
-    return actions.test_command_project(ctx, project, options.workspace, options.output_format)
+    return actions.test_command_project(ctx, project, options.workspace, options.output_format, options.test_preflight)
 
 
 def _handle_demo_script(

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -1062,6 +1062,34 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertIn("__base_manifest_command_trust_required=true", stdout)
 
+    def test_projects_test_command_preflight_refuses_missing_test_requirements(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            base_home = workspace / "base"
+            base_home.mkdir()
+            project_root = workspace / "demo"
+            project_root.mkdir()
+            (project_root / "base_manifest.yaml").write_text(
+                "project:\n"
+                "  name: demo\n"
+                "test:\n"
+                "  command: pytest tests/\n"
+                "  requirements: requirements-dev.txt\n"
+                "artifacts: []\n",
+                encoding="utf-8",
+            )
+            (project_root / "requirements-dev.txt").write_text("jsonschema==4.25.1\n", encoding="utf-8")
+            (project_root / ".venv" / "bin").mkdir(parents=True)
+            (project_root / ".venv" / "bin" / "python").touch()
+
+            with mock.patch("base_setup.test_requirements.python_artifact_installed", return_value=False):
+                status, stdout, stderr = run_engine(["test-command", "demo", "--test-preflight"], base_home)
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stdout, "")
+        self.assertIn("has missing or mismatched packages: jsonschema==4.25.1", stderr)
+        self.assertIn("Run 'basectl setup demo'", stderr)
+
     def test_projects_test_command_prints_python_route_metadata_for_inline_uv_manager(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             workspace = Path(tmpdir)

--- a/cli/python/base_setup/finding_explanations.py
+++ b/cli/python/base_setup/finding_explanations.py
@@ -270,6 +270,54 @@ CATALOG = catalog_by_id(
             related_commands=("basectl check <project>", "basectl run <project> <command> --dry-run"),
             docs=(RelatedDoc("Python Manifest - Command Runners", "docs/python-manifest.md#command-runners"),),
         ),
+        FindingExplanation(
+            finding_id="BASE-P180",
+            title="Declared project test requirements file",
+            summary=(
+                "Base could not validate the repository-local requirements file declared for the project test command."
+            ),
+            why_it_matters=(
+                "A test requirements file is an explicit part of the project test contract. Missing, external, "
+                "or unsupported inputs would make setup and test behavior differ across machines."
+            ),
+            likely_causes=(
+                "The path in `test.requirements` does not exist.",
+                "The path resolves outside the project root or uses unsupported pip requirement syntax.",
+                "A uv-managed project declared a requirements file instead of using its pyproject and lockfile."
+            ),
+            fix_steps=(
+                "Review `test.requirements` in `base_manifest.yaml`.",
+                "Keep the file inside the repository and use direct package names with optional `==` versions.",
+                "Run `basectl setup <project>` after correcting the declaration."
+            ),
+            related_commands=(
+                "basectl setup <project> --dry-run",
+                "basectl check <project>",
+                "basectl doctor <project>",
+            ),
+            docs=(RelatedDoc("Testing", "docs/testing.md"),),
+        ),
+        FindingExplanation(
+            finding_id="BASE-P181",
+            title="Project test requirements environment",
+            summary="The project virtual environment does not satisfy the requirements declared for its test command.",
+            why_it_matters=(
+                "Running a test command before its declared environment is ready produces late import or tool "
+                "errors. Base reports the missing packages before executing the command."
+            ),
+            likely_causes=(
+                "The project has not been set up after adding or changing `test.requirements`.",
+                "A package was removed or changed directly inside the project virtual environment.",
+                "The project virtual environment is missing or uses a different setup path."
+            ),
+            fix_steps=(
+                "Run `basectl setup <project>` to install the declared test requirements.",
+                "Run `basectl check <project>` and confirm `BASE-P181` reports `ok`.",
+                "Rerun the test command only after the environment check passes."
+            ),
+            related_commands=("basectl setup <project>", "basectl check <project>", "basectl test <project>"),
+            docs=(RelatedDoc("Testing", "docs/testing.md"),),
+        ),
     )
 )
 

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -180,21 +180,26 @@ def _read_test(path: Path, test_data: Any) -> TestConfig | None:
     if not isinstance(test_data, dict):
         raise ManifestError(f"{path}: test must be a mapping when provided.")
 
-    allowed_keys = {"command", "mise", "runner"}
+    allowed_keys = {"command", "mise", "runner", "requirements"}
     unknown_keys = sorted(set(test_data) - allowed_keys)
     if unknown_keys:
         raise ManifestError(f"{path}: test has unsupported keys: {', '.join(unknown_keys)}.")
 
     command = test_data.get("command")
     mise = test_data.get("mise")
+    requirements = test_data.get("requirements")
     if command is not None and (not isinstance(command, str) or not command.strip()):
         raise ManifestError(f"{path}: test.command must be a non-empty string when provided.")
     if mise is not None and (not isinstance(mise, str) or not mise.strip()):
         raise ManifestError(f"{path}: test.mise must be a non-empty string when provided.")
+    if requirements is not None and (not isinstance(requirements, str) or not requirements.strip()):
+        raise ManifestError(f"{path}: test.requirements must be a non-empty string when provided.")
     if command is not None and has_control_line_break(command):
         raise ManifestError(f"{path}: test.command must not contain control line breaks.")
     if mise is not None and has_control_line_break(mise):
         raise ManifestError(f"{path}: test.mise must not contain control line breaks.")
+    if requirements is not None and has_control_line_break(requirements):
+        raise ManifestError(f"{path}: test.requirements must not contain control line breaks.")
     if command is not None and mise is not None:
         raise ManifestError(f"{path}: test must declare only one of command or mise.")
     if command is None and mise is None:
@@ -204,6 +209,7 @@ def _read_test(path: Path, test_data: Any) -> TestConfig | None:
         command=command.strip() if command is not None else None,
         mise=mise.strip() if mise is not None else None,
         runner=_read_optional_runner(path, "test.runner", test_data.get("runner")),
+        requirements=requirements.strip() if requirements is not None else None,
     )
 
 

--- a/cli/python/base_setup/manifest_checks.py
+++ b/cli/python/base_setup/manifest_checks.py
@@ -26,6 +26,7 @@ from .python_runtime import project_python_runtime_check
 from .setup_reconcile import effective_manifest_with_user_config
 from .setup_reconcile import project_runtime_argument
 from .setup_reconcile import setup_artifacts
+from .test_requirements import check_test_requirements
 from .uv import check_uv
 
 IDE_EXTENSION_PROFILE = "dev"
@@ -72,6 +73,9 @@ def manifest_checks(
     checks.extend(check_uv(effective_manifest))
     checks.extend(check_pyproject(effective_manifest))
     checks.extend(project_python_runtime_check(effective_manifest))
+    test_requirements_check = check_test_requirements(effective_manifest)
+    if test_requirements_check is not None:
+        checks.append(test_requirements_check)
 
     runtime_config = project_runtime_argument(effective_manifest)
     for artifact, definition in zip(artifacts, definitions, strict=True):

--- a/cli/python/base_setup/manifest_model.py
+++ b/cli/python/base_setup/manifest_model.py
@@ -29,6 +29,7 @@ class TestConfig:
     command: str | None = None
     mise: str | None = None
     runner: str | None = None
+    requirements: str | None = None
 
 
 @dataclass(frozen=True)

--- a/cli/python/base_setup/project_routing.py
+++ b/cli/python/base_setup/project_routing.py
@@ -84,6 +84,8 @@ def manifest_requires_project_python(manifest: BaseManifest) -> bool:
 
     if manifest.python_declared:
         return True
+    if manifest.test is not None and manifest.test.requirements is not None:
+        return True
     return any(artifact.artifact_type == "python-package" for artifact in manifest.artifacts)
 
 

--- a/cli/python/base_setup/setup_reconcile.py
+++ b/cli/python/base_setup/setup_reconcile.py
@@ -22,6 +22,7 @@ from .ide_settings import reconcile_ide_settings
 from .manifest import BaseManifest
 from .project_routing import manifest_requires_project_python
 from .project_routing import route_for_manifest
+from .test_requirements import reconcile_test_requirements
 from .uv import manifest_uses_uv_project_manager
 from .uv import reconcile_uv_project
 
@@ -73,6 +74,8 @@ def reconcile_manifest(
             project_runtime_argument(effective_manifest),
             dry_run=dry_run,
         )
+
+    reconcile_test_requirements(ctx, effective_manifest, dry_run=dry_run)
 
     ctx.log.info("Project '%s' setup is complete.", effective_manifest.project_name)
 

--- a/cli/python/base_setup/test_requirements.py
+++ b/cli/python/base_setup/test_requirements.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import base_cli
+
+from . import process
+from .checks import ArtifactCheck
+from .errors import ArtifactError
+from .manifest import BaseManifest
+from .python_artifacts import create_project_virtualenv
+from .python_artifacts import project_venv_recreate_enabled
+from .python_artifacts import python_artifact_installed
+from .project_routing import route_for_manifest
+from .uv import manifest_uses_uv_project_manager
+
+
+TEST_REQUIREMENTS_FILE_FINDING_ID = "BASE-P180"
+TEST_REQUIREMENTS_ENVIRONMENT_FINDING_ID = "BASE-P181"
+_DIRECT_REQUIREMENT_RE = re.compile(
+    r"^(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[A-Za-z0-9_,.-]+\])?"
+    r"(?:(?P<operator>===|==)\s*(?P<version>[A-Za-z0-9][A-Za-z0-9.!+_-]*))?$"
+)
+
+
+@dataclass(frozen=True)
+class RequirementSpec:
+    name: str
+    version: str
+    raw: str
+
+
+def resolve_test_requirements_path(manifest: BaseManifest) -> Path | None:
+    if manifest.test is None or manifest.test.requirements is None:
+        return None
+
+    raw_path = Path(manifest.test.requirements)
+    if raw_path.is_absolute():
+        raise ArtifactError("test.requirements must be a repository-relative path.")
+
+    project_root = manifest.path.parent.resolve()
+    candidate = (project_root / raw_path).resolve()
+    try:
+        candidate.relative_to(project_root)
+    except ValueError as exc:
+        raise ArtifactError("test.requirements must resolve inside the project root.") from exc
+    return candidate
+
+
+def requirements_file_digest(manifest: BaseManifest) -> str | None:
+    try:
+        path = resolve_test_requirements_path(manifest)
+    except ArtifactError:
+        return None
+    if path is None or not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_test_requirements(manifest: BaseManifest) -> tuple[Path, tuple[RequirementSpec, ...]] | None:
+    path = resolve_test_requirements_path(manifest)
+    if path is None:
+        return None
+    if manifest_uses_uv_project_manager(manifest):
+        raise ArtifactError(
+            "test.requirements is not supported for uv-managed projects. "
+            "Declare test dependencies in pyproject.toml and synchronize with uv."
+        )
+    if not path.is_file():
+        raise ArtifactError(
+            f"Declared test requirements file '{path}' does not exist. "
+            f"Run 'basectl setup {manifest.project_name}' after adding it or update test.requirements."
+        )
+
+    requirements: list[RequirementSpec] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise ArtifactError(f"Unable to read declared test requirements file '{path}': {exc}") from exc
+
+    for line_number, line in enumerate(lines, start=1):
+        candidate = line.split(" #", 1)[0].strip()
+        if not candidate or candidate.startswith("#"):
+            continue
+        if candidate.startswith(("-", "http://", "https://")):
+            raise ArtifactError(
+                f"{path}:{line_number} uses unsupported requirement syntax '{candidate}'. "
+                "Base currently supports direct package names with optional == versions only."
+            )
+        match = _DIRECT_REQUIREMENT_RE.fullmatch(candidate)
+        if match is None:
+            raise ArtifactError(
+                f"{path}:{line_number} uses unsupported requirement syntax '{candidate}'. "
+                "Base currently supports direct package names with optional == versions only."
+            )
+        requirements.append(
+            RequirementSpec(
+                name=match.group("name"),
+                version=match.group("version") or "latest",
+                raw=candidate,
+            )
+        )
+    return path, tuple(requirements)
+
+
+def check_test_requirements(manifest: BaseManifest) -> ArtifactCheck | None:
+    if manifest.test is None or manifest.test.requirements is None:
+        return None
+
+    try:
+        parsed = read_test_requirements(manifest)
+    except ArtifactError as exc:
+        return ArtifactCheck(
+            name="test requirements file",
+            ok=False,
+            message=str(exc),
+            fix=f"Review test.requirements in '{manifest.path}' and rerun 'basectl setup {manifest.project_name}'.",
+            finding_id=TEST_REQUIREMENTS_FILE_FINDING_ID,
+        )
+    if parsed is None:
+        return None
+    path, requirements = parsed
+    route = route_for_manifest(manifest)
+    python_bin = route.project_venv_dir / "bin" / "python"
+    if not python_bin.is_file():
+        return ArtifactCheck(
+            name="test requirements environment",
+            ok=False,
+            message=(
+                f"Test requirements file '{path.relative_to(route.project_root)}' is declared, but the project "
+                f"Python environment is missing at '{route.project_venv_dir}'."
+            ),
+            fix=f"Run 'basectl setup {manifest.project_name}' before running its tests.",
+            finding_id=TEST_REQUIREMENTS_ENVIRONMENT_FINDING_ID,
+        )
+
+    missing = [
+        requirement.raw
+        for requirement in requirements
+        if not python_requirement_installed(python_bin, requirement)
+    ]
+    if missing:
+        return ArtifactCheck(
+            name="test requirements environment",
+            ok=False,
+            message=(
+                f"Test requirements file '{path.relative_to(route.project_root)}' has missing or mismatched "
+                f"packages: {', '.join(missing)}."
+            ),
+            fix=f"Run 'basectl setup {manifest.project_name}' to install the declared test requirements.",
+            finding_id=TEST_REQUIREMENTS_ENVIRONMENT_FINDING_ID,
+            details={"requirements": str(path), "missing": missing},
+        )
+    return ArtifactCheck(
+        name="test requirements environment",
+        ok=True,
+        message=(
+            f"Test requirements file '{path.relative_to(route.project_root)}' is satisfied in "
+            f"'{route.project_venv_dir}'."
+        ),
+        fix="",
+        finding_id=TEST_REQUIREMENTS_ENVIRONMENT_FINDING_ID,
+        details={"requirements": str(path), "sha256": requirements_file_digest(manifest) or ""},
+    )
+
+
+def python_requirement_installed(python_bin: Path, requirement: RequirementSpec) -> bool:
+    if requirement.version == "latest":
+        return python_artifact_installed(python_bin, requirement.name, "latest")
+    return python_artifact_installed(python_bin, requirement.name, requirement.version)
+
+
+def reconcile_test_requirements(ctx: base_cli.Context, manifest: BaseManifest, dry_run: bool) -> None:
+    parsed = read_test_requirements(manifest)
+    if parsed is None:
+        return
+    path, _requirements = parsed
+    route = route_for_manifest(manifest)
+    python_bin = route.project_venv_dir / "bin" / "python"
+    if project_venv_recreate_enabled() or not python_bin.exists():
+        create_project_virtualenv(ctx, route.project_venv_dir, manifest.python.requires_python)
+    command = [str(python_bin), "-m", "pip", "install", "--disable-pip-version-check", "-r", str(path)]
+    if dry_run:
+        process.dry_run_command(ctx, command, cwd=route.project_root)
+        return
+    ctx.log.info(
+        "Installing project test requirements from '%s' into '%s'.",
+        path.relative_to(route.project_root),
+        route.project_venv_dir,
+    )
+    process.run_command(ctx, command, cwd=route.project_root)
+
+
+__all__ = [
+    "TEST_REQUIREMENTS_ENVIRONMENT_FINDING_ID",
+    "TEST_REQUIREMENTS_FILE_FINDING_ID",
+    "RequirementSpec",
+    "check_test_requirements",
+    "read_test_requirements",
+    "reconcile_test_requirements",
+    "resolve_test_requirements_path",
+    "requirements_file_digest",
+]

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -987,6 +987,21 @@ class ManifestParsingTests(unittest.TestCase):
         self.assertEqual(manifest.test.command, "pytest tests/")
         self.assertIsNone(manifest.test.mise)
         self.assertIsNone(manifest.test.runner)
+        self.assertIsNone(manifest.test.requirements)
+
+
+    def test_reads_manifest_test_requirements_file(self) -> None:
+        manifest = self.read_manifest_lines(
+            "project:",
+            "  name: demo",
+            "test:",
+            "  command: pytest tests/",
+            "  requirements: requirements-dev.txt",
+            "artifacts: []",
+        )
+
+        assert manifest.test is not None
+        self.assertEqual(manifest.test.requirements, "requirements-dev.txt")
 
 
     def test_reads_manifest_test_command_runner(self) -> None:
@@ -1059,8 +1074,8 @@ class ManifestParsingTests(unittest.TestCase):
                 read_manifest(manifest_path)
 
 
-    def test_rejects_control_line_breaks_in_manifest_test_command_or_mise(self) -> None:
-        for field_name in ("command", "mise"):
+    def test_rejects_control_line_breaks_in_manifest_test_fields(self) -> None:
+        for field_name in ("command", "mise", "requirements"):
             for escaped_control_break in (r"\0", r"\n", r"\r"):
                 with self.subTest(field_name=field_name, escaped_control_break=escaped_control_break):
                     with tempfile.TemporaryDirectory() as tmpdir:

--- a/cli/python/base_setup/tests/test_test_requirements.py
+++ b/cli/python/base_setup/tests/test_test_requirements.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from base_setup.manifest import read_manifest
+from base_setup.manifest_model import BaseManifest
+from base_setup.manifest_model import TestConfig as ManifestTestConfig
+from base_setup.test_requirements import check_test_requirements
+from base_setup.test_requirements import read_test_requirements
+from base_setup.test_requirements import reconcile_test_requirements
+from base_setup.test_requirements import resolve_test_requirements_path
+from base_setup.test_requirements import requirements_file_digest
+from base_setup.tests.helpers import fake_context
+
+
+class TestRequirementsTests(unittest.TestCase):
+    @staticmethod
+    def write_manifest(root: Path, requirements: str = "requirements-dev.txt"):
+        manifest_path = root / "base_manifest.yaml"
+        manifest_path.write_text(
+            "project:\n"
+            "  name: demo\n"
+            "test:\n"
+            "  command: pytest tests/\n"
+            f"  requirements: {requirements}\n"
+            "artifacts: []\n",
+            encoding="utf-8",
+        )
+        return read_manifest(manifest_path)
+
+    def test_reads_direct_exact_and_unpinned_requirements(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest = self.write_manifest(root)
+            (root / "requirements-dev.txt").write_text(
+                "pytest==9.0.3\njsonschema\n# comment\n",
+                encoding="utf-8",
+            )
+
+            path, requirements = read_test_requirements(manifest) or (None, ())
+
+        self.assertEqual(path, (root / "requirements-dev.txt").resolve())
+        self.assertEqual(
+            [(item.name, item.version) for item in requirements],
+            [("pytest", "9.0.3"), ("jsonschema", "latest")],
+        )
+
+    def test_rejects_requirements_outside_project_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir) / "project"
+            root.mkdir()
+            manifest = self.write_manifest(root, "../requirements.txt")
+
+            with self.assertRaisesRegex(RuntimeError, "inside the project root"):
+                resolve_test_requirements_path(manifest)
+
+    def test_rejects_unsupported_requirements_syntax(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest = self.write_manifest(root)
+            (root / "requirements-dev.txt").write_text("-r other.txt\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, "unsupported requirement syntax"):
+                read_test_requirements(manifest)
+
+    def test_check_reports_missing_test_requirement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest = self.write_manifest(root)
+            (root / "requirements-dev.txt").write_text("jsonschema==4.25.1\n", encoding="utf-8")
+            (root / ".venv" / "bin").mkdir(parents=True)
+            (root / ".venv" / "bin" / "python").touch()
+
+            with mock.patch("base_setup.test_requirements.python_artifact_installed", return_value=False):
+                check = check_test_requirements(manifest)
+
+        assert check is not None
+        self.assertFalse(check.ok)
+        self.assertEqual(check.finding_id, "BASE-P181")
+        self.assertIn("jsonschema==4.25.1", check.message)
+        self.assertIn("basectl setup demo", check.fix)
+
+    def test_check_passes_and_reports_requirements_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest = self.write_manifest(root)
+            requirements_path = root / "requirements-dev.txt"
+            requirements_path.write_text("jsonschema==4.25.1\n", encoding="utf-8")
+            (root / ".venv" / "bin").mkdir(parents=True)
+            (root / ".venv" / "bin" / "python").touch()
+
+            with mock.patch("base_setup.test_requirements.python_artifact_installed", return_value=True):
+                check = check_test_requirements(manifest)
+
+            digest = requirements_file_digest(manifest)
+
+        assert check is not None
+        self.assertTrue(check.ok)
+        self.assertEqual(check.finding_id, "BASE-P181")
+        self.assertEqual(check.details["sha256"], digest)
+        self.assertIsInstance(digest, str)
+
+    def test_reconcile_dry_run_plans_install_from_declared_requirements(self) -> None:
+        ctx = fake_context()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            requirements_path = root / "requirements-dev.txt"
+            requirements_path.write_text("jsonschema==4.25.1\n", encoding="utf-8")
+            manifest = BaseManifest(
+                path=root / "base_manifest.yaml",
+                project_name="demo",
+                brewfile=None,
+                artifacts=(),
+                test=ManifestTestConfig(command="pytest", requirements="requirements-dev.txt"),
+            )
+
+            with (
+                mock.patch("base_setup.test_requirements.create_project_virtualenv") as create_virtualenv,
+                mock.patch("base_setup.test_requirements.process.dry_run_command") as dry_run_command,
+            ):
+                reconcile_test_requirements(ctx, manifest, dry_run=True)
+
+        expected_root = root.resolve()
+        expected_venv = expected_root / ".venv"
+        create_virtualenv.assert_called_once_with(ctx, expected_venv, None)
+        dry_run_command.assert_called_once_with(
+            ctx,
+            [
+                str(expected_venv / "bin" / "python"),
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "-r",
+                str(requirements_path.resolve()),
+            ],
+            cwd=expected_root,
+        )

--- a/cli/python/base_trust/engine.py
+++ b/cli/python/base_trust/engine.py
@@ -298,8 +298,11 @@ def status_payload(trust_status: TrustStatus) -> dict[str, Any]:
         payload["allow_command"] = allow_command_text(trust_status.identity)
     if trust_status.changed_record is not None:
         changed_project = trust_status.changed_record.get("project", {})
-        if isinstance(changed_project, dict) and isinstance(changed_project.get("manifest_sha256"), str):
-            payload["recorded_manifest_sha256"] = changed_project["manifest_sha256"]
+        if isinstance(changed_project, dict):
+            if isinstance(changed_project.get("manifest_sha256"), str):
+                payload["recorded_manifest_sha256"] = changed_project["manifest_sha256"]
+            if isinstance(changed_project.get("test_requirements_sha256"), str):
+                payload["recorded_test_requirements_sha256"] = changed_project["test_requirements_sha256"]
     return payload
 
 
@@ -333,8 +336,13 @@ def print_status_text(trust_status: TrustStatus, surfaces: tuple[str, ...]) -> N
         print_trust_scope_warning()
         return
 
-    if trust_status.reason == "manifest_changed":
-        print(f"Manifest command trust is blocked for project '{identity.project_name}': manifest changed.")
+    if trust_status.reason in {"manifest_changed", "test_requirements_changed"}:
+        print(
+            f"Manifest command trust is blocked for project '{identity.project_name}': "
+            "manifest or declared test requirements changed."
+        )
+        if trust_status.reason == "test_requirements_changed":
+            print("Declared test requirements changed; review the requirements file before allowing commands.")
         changed_project = (trust_status.changed_record or {}).get("project", {})
         if isinstance(changed_project, dict) and changed_project.get("manifest_sha256"):
             print(f"Recorded Manifest SHA-256: {changed_project['manifest_sha256']}")
@@ -357,10 +365,10 @@ def print_blocked_command_text(
     stream: Any,
 ) -> None:
     identity = trust_status.identity
-    if trust_status.reason == "manifest_changed":
+    if trust_status.reason in {"manifest_changed", "test_requirements_changed"}:
         print(
             f"ERROR: Manifest command trust is blocked for project '{identity.project_name}': "
-            "manifest command contract changed.",
+            "manifest command or declared test requirements contract changed.",
             file=stream,
         )
     else:
@@ -371,11 +379,13 @@ def print_blocked_command_text(
         )
     print(f"Project root: {identity.project_root}", file=stream)
     print(f"Manifest: {identity.manifest_path}", file=stream)
-    if trust_status.reason == "manifest_changed":
+    if trust_status.reason in {"manifest_changed", "test_requirements_changed"}:
         changed_project = (trust_status.changed_record or {}).get("project", {})
         if isinstance(changed_project, dict) and changed_project.get("manifest_sha256"):
             print(f"Recorded Manifest SHA-256: {changed_project['manifest_sha256']}", file=stream)
     print(f"Manifest SHA-256: {identity.manifest_sha256}", file=stream)
+    if identity.test_requirements_sha256 is not None:
+        print(f"Test requirements SHA-256: {identity.test_requirements_sha256}", file=stream)
     if identity.origin is not None:
         print(f"Origin: {identity.origin}", file=stream)
     print(file=stream)
@@ -416,6 +426,8 @@ def print_identity(title: str, identity: ManifestCommandTrustIdentity) -> None:
     print(f"  Project root: {identity.project_root}")
     print(f"  Manifest: {identity.manifest_path}")
     print(f"  Manifest SHA-256: {identity.manifest_sha256}")
+    if identity.test_requirements_sha256 is not None:
+        print(f"  Test requirements SHA-256: {identity.test_requirements_sha256}")
     if identity.origin is not None:
         print(f"  Origin: {identity.origin}")
     if identity.head is not None:

--- a/cli/python/base_trust/tests/test_engine.py
+++ b/cli/python/base_trust/tests/test_engine.py
@@ -200,7 +200,10 @@ class ManifestCommandTrustTests(unittest.TestCase):
         self.assertEqual(payload["schema_version"], 1)
         self.assertEqual(payload["status"], "blocked")
         self.assertEqual(payload["reason"], "not_allowed")
-        self.assertEqual(payload["trust_scope"]["approval_basis"], "base_manifest.yaml_sha256")
+        self.assertEqual(
+            payload["trust_scope"]["approval_basis"],
+            "base_manifest.yaml_sha256+declared_test_requirements_sha256",
+        )
         self.assertTrue(payload["trust_scope"]["manifest_changes_invalidate"])
         self.assertFalse(payload["trust_scope"]["referenced_script_changes_invalidate"])
         self.assertFalse(payload["trust_scope"]["git_head_changes_invalidate"])
@@ -443,13 +446,52 @@ class ManifestCommandTrustTests(unittest.TestCase):
                 )
 
         self.assertEqual(result.exit_code, 0, result.output)
-        self.assertIn("Manifest command trust is blocked for project 'demo': manifest changed.", result.stdout)
+        self.assertIn(
+            "Manifest command trust is blocked for project 'demo': manifest or declared test requirements changed.",
+            result.stdout,
+        )
         self.assertIn(f"Recorded Manifest SHA-256: {identity.manifest_sha256}", result.stdout)
         self.assertIn(f"Manifest SHA-256: {current_digest}", result.stdout)
         self.assertIn("basectl test demo --dry-run", result.stdout)
         self.assertIn(
             f"basectl trust allow demo --manifest-sha256 {current_digest}",
             result.stdout,
+        )
+
+    def test_declared_test_requirements_changes_invalidate_manifest_trust(self) -> None:
+        from base_trust import engine
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            project_root = root / "work" / "demo"
+            manifest_path = self.manifest_factory.write(project_root)
+            manifest_path.write_text(
+                manifest_path.read_text(encoding="utf-8").replace(
+                    "  command: pytest tests/\n",
+                    "  command: pytest tests/\n  requirements: requirements-dev.txt\n",
+                ),
+                encoding="utf-8",
+            )
+            requirements_path = project_root / "requirements-dev.txt"
+            requirements_path.write_text("jsonschema==4.25.1\n", encoding="utf-8")
+            initial_identity = engine.compute_trust_identity_for_manifest(manifest_path)
+            store = engine.ManifestCommandTrustStore(home=home)
+            store.allow(initial_identity, base_version="9.9.9")
+
+            requirements_path.write_text("jsonschema==4.25.2\n", encoding="utf-8")
+            current_identity = engine.compute_trust_identity_for_manifest(manifest_path)
+            status = store.status(current_identity)
+            payload = engine.status_payload(status)
+
+        self.assertNotEqual(
+            current_identity.test_requirements_sha256,
+            initial_identity.test_requirements_sha256,
+        )
+        self.assertEqual(status.reason, "test_requirements_changed")
+        self.assertEqual(
+            payload["recorded_test_requirements_sha256"],
+            initial_identity.test_requirements_sha256,
         )
 
     def test_referenced_script_and_git_head_changes_do_not_invalidate_manifest_trust(self) -> None:

--- a/cli/python/base_trust/trust_store.py
+++ b/cli/python/base_trust/trust_store.py
@@ -13,19 +13,22 @@ from base_setup.git_commands import run_git
 from base_setup.git_remote_parse import parse_origin_remote
 from base_setup.manifest import BaseManifest
 from base_setup.manifest import read_manifest
+from base_setup.test_requirements import requirements_file_digest
 
 SCHEMA_VERSION = 1
 ALLOWED_COMMANDS = ["test", "run", "build", "demo", "activate"]
 TRUST_RELATIVE_ROOT = Path("trust") / "manifest-commands"
 TRUST_SCOPE_WARNING = (
-    "Approval is bound to the base_manifest.yaml SHA-256 only. Manifest changes "
-    "invalidate approval; referenced scripts, direct executable files, Git HEAD, "
-    "and uncommitted working-tree changes are not independently verified or bound "
-    "to approval. Re-review those inputs before execution after repository changes."
+    "Approval is bound to the base_manifest.yaml SHA-256 and declared local test "
+    "requirements SHA-256. Manifest or declared test requirements changes invalidate "
+    "approval; referenced scripts, direct executable files, Git HEAD, and uncommitted "
+    "working-tree changes are not independently verified or bound to approval. Re-review "
+    "those inputs before execution after repository changes."
 )
 TRUST_SCOPE = {
-    "approval_basis": "base_manifest.yaml_sha256",
+    "approval_basis": "base_manifest.yaml_sha256+declared_test_requirements_sha256",
     "manifest_changes_invalidate": True,
+    "declared_test_requirements_changes_invalidate": True,
     "referenced_script_changes_invalidate": False,
     "direct_executable_file_changes_invalidate": False,
     "git_head_changes_invalidate": False,
@@ -45,6 +48,7 @@ class ManifestCommandTrustIdentity:
     manifest_path: Path
     manifest_sha256: str
     identity_key: str
+    test_requirements_sha256: str | None = None
     git_root: Path | None = None
     origin: str | None = None
     head: str | None = None
@@ -56,6 +60,8 @@ class ManifestCommandTrustIdentity:
             "manifest": str(self.manifest_path),
             "manifest_sha256": self.manifest_sha256,
         }
+        if self.test_requirements_sha256 is not None:
+            payload["test_requirements_sha256"] = self.test_requirements_sha256
         if self.git_root is not None:
             payload["git_root"] = str(self.git_root)
         if self.origin is not None:
@@ -104,7 +110,7 @@ class ManifestCommandTrustStore:
         if changed_record is not None:
             return TrustStatus(
                 status="blocked",
-                reason="manifest_changed",
+                reason=trust_change_reason(identity, changed_record),
                 identity=identity,
                 changed_record=changed_record,
             )
@@ -196,15 +202,17 @@ def compute_trust_identity(manifest: BaseManifest) -> ManifestCommandTrustIdenti
     canonical_manifest = manifest.path.resolve()
     project_root = canonical_manifest.parent.resolve()
     manifest_sha256 = sha256_file(canonical_manifest)
+    requirements_sha256 = requirements_file_digest(manifest)
     git_root = git_repository_root(project_root)
     origin = git_origin(project_root)
     head = git_head(project_root)
-    identity_key = compute_identity_key(project_root, canonical_manifest, manifest_sha256)
+    identity_key = compute_identity_key(project_root, canonical_manifest, manifest_sha256, requirements_sha256)
     return ManifestCommandTrustIdentity(
         project_name=manifest.project_name,
         project_root=project_root,
         manifest_path=canonical_manifest,
         manifest_sha256=manifest_sha256,
+        test_requirements_sha256=requirements_sha256,
         identity_key=identity_key,
         git_root=git_root,
         origin=origin,
@@ -220,8 +228,13 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def compute_identity_key(project_root: Path, manifest_path: Path, manifest_sha256: str) -> str:
-    payload = "\0".join([str(project_root), str(manifest_path), manifest_sha256])
+def compute_identity_key(
+    project_root: Path,
+    manifest_path: Path,
+    manifest_sha256: str,
+    test_requirements_sha256: str | None = None,
+) -> str:
+    payload = "\0".join([str(project_root), str(manifest_path), manifest_sha256, test_requirements_sha256 or ""])
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
@@ -234,7 +247,21 @@ def identity_key_from_record(record: dict[str, Any]) -> str | None:
     digest = project.get("manifest_sha256")
     if not all(isinstance(value, str) and value for value in (root, manifest, digest)):
         return None
-    return compute_identity_key(Path(root), Path(manifest), digest)
+    requirements_digest = project.get("test_requirements_sha256")
+    if requirements_digest is not None and not isinstance(requirements_digest, str):
+        return None
+    return compute_identity_key(Path(root), Path(manifest), digest, requirements_digest)
+
+
+def trust_change_reason(identity: ManifestCommandTrustIdentity, record: dict[str, Any]) -> str:
+    project = record.get("project")
+    if not isinstance(project, dict):
+        return "manifest_changed"
+    if project.get("manifest_sha256") != identity.manifest_sha256:
+        return "manifest_changed"
+    if project.get("test_requirements_sha256") != identity.test_requirements_sha256:
+        return "test_requirements_changed"
+    return "manifest_changed"
 
 
 def git_repository_root(project_root: Path) -> Path | None:

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -185,6 +185,8 @@ Doctor commands use the same diagnostic item fields. The top-level
 | `BASE-P170` | Project Python version requirement support window |
 | `BASE-P171` | Selected project Python interpreter availability |
 | `BASE-P172` | Actual inspectable project Python runtime: environment manager, virtualenv path, interpreter path, and Python minor version |
+| `BASE-P180` | Declared project test requirements file |
+| `BASE-P181` | Project test requirements environment |
 
 `BASE-P050` is the stable project virtual-environment readiness finding. The
 Bash setup/check path reports detailed venv health messages when a project venv

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -158,6 +158,26 @@ resolves to a source checkout. In a packaged install such as Homebrew,
 skips source-checkout-only BATS and integration tests with a message pointing
 back to the source checkout command above.
 
+### Declared test requirements
+
+A project can declare a repository-local Python requirements file alongside its
+test command:
+
+```yaml
+test:
+  command: pytest tests/
+  requirements: requirements-dev.txt
+```
+
+Base supports direct package names with optional exact `==` versions in this
+file. `basectl setup <project>` installs the file into the routed project
+virtual environment. `basectl check <project>` and `basectl doctor <project>`
+report missing packages as `BASE-P181`, while `basectl test <project>` performs
+the same read-only preflight and does not execute the test command until the
+environment is ready. Paths outside the project root, unsupported requirement
+syntax, and uv-managed projects using this field fail closed; uv projects
+should declare test dependencies in `pyproject.toml` and use `uv sync`.
+
 Base deliberately uses command-focused BATS regression coverage plus ShellCheck
 as the Bash equivalent instead of a line percentage. Contributors changing a
 public command or runtime branch must add or update a focused BATS assertion,


### PR DESCRIPTION
## Summary
- Add `test.requirements` to the Base manifest contract and declare Base's `requirements-dev.txt`.
- Make `basectl setup` install the declared file, while check/doctor and test preflight report actionable missing or mismatched packages before test execution.
- Bind manifest-command trust to the declared requirements digest and document the behavior.

## Issue
- Fixes #2150

## Validation
- Focused pytest: 166 passed, 138 subtests passed.
- Trust/setup pytest: 23 passed, 18 subtests passed.
- Full `bin/base-test`: 1189 passed, 138 subtests passed; 3 unrelated baseline failures remain in run-index schema, Base CLI context documentation, and an existing base-bash-libs workflow pin.
- BATS `cli/bash/commands/basectl/tests/test.bats`: 15 passed.
- Pylint, Bash syntax, ShellCheck, and `git diff --check` passed.

## Docs Impact
- Updated `docs/testing.md`, `docs/doctor-findings.md`, and the basectl command README.

## AI Context Impact
- Updated `.ai-context/COMMANDS.md`, `.ai-context/ARCHITECTURE.md`, and `.ai-context/WORKFLOWS.md` with the manifest, setup, preflight, and trust contract.

## Notes
- uv-managed projects continue to declare dependencies in `pyproject.toml` and their lockfile; the requirements-file contract is for direct Base-routed environments.