### PR TITLE
ci: align base-bash-libs matrix pins

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: b4243765726c133499feeabdc50154f99c0fec12
+          ref: 6792c29e546ed7a6230046e4d54bfa1474cd3b13
           path: .dependencies/base-bash-libs
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: basefoundry/base-bash-libs
-          ref: b4243765726c133499feeabdc50154f99c0fec12
+          ref: 6792c29e546ed7a6230046e4d54bfa1474cd3b13
           path: .dependencies/base-bash-libs
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5


### PR DESCRIPTION
## Summary
- Align the stability-compatibility and Python-matrix `base-bash-libs` checkouts with the current immutable compatibility revision.
- Restore the workflow invariant that every active checkout uses `6792c29e546ed7a6230046e4d54bfa1474cd3b13`.

## Issue
- Fixes #1992

## Validation
- `PYTHONPATH=cli/python python -m pytest tests/test_github_workflows.py -q`: 40 passed.
- `git diff --check`: passed.
- Hosted matrix is running, including Python 3.10-3.13 and Ubuntu source-checkout coverage.

## Notes
- This is a two-line CI pin repair only; no product or test-contract behavior is changed.