### PR TITLE
docs: map Base ecosystem and workspace manifest ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,21 @@ work/                          ← shared workspace root (`workspace.root`)
   infra/                       ← another peer repo that can opt into Base
 ```
 
+This directory shape does not prescribe one universal repository set. Each
+project owns its own `base_manifest.yaml`; a team that wants a shared
+repository inventory supplies a separate `workspace.yaml`, either as a local
+file or through a dedicated workspace-config repository. Base Foundry's
+maintainer inventory is kept in `base-workspace`, but normal Base installations
+do not need that private workspace configuration.
+
 Projects opt into Base with minimal coupling:
 
 - Base discovers projects in the shared workspace
 - projects expose a small contract through `base_manifest.yaml`
 - Base provides common orchestration on top
+
+See [Workspace Manifest](docs/workspace-manifest.md) for the ownership split,
+manifest sources, and workspace command behavior.
 
 ## Design Principles
 

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -17,6 +17,42 @@ manifest explicitly with `basectl workspace pull`. Pull supports local paths,
 sources by default, validates fetched content before writing, and does not
 mutate project repositories.
 
+## Project And Workspace Manifest Ownership
+
+Base uses two related but distinct manifest layers:
+
+| File | Owner | Answers | Normal location |
+| --- | --- | --- | --- |
+| `base_manifest.yaml` | Each participating project | How does this repository prepare, run, test, and report its local contract? | Inside that project repository |
+| `workspace.yaml` | A team or workspace owner | Which repositories belong together in this local workspace? | A local file or dedicated workspace-config repository |
+
+The `base` repository owns its own `base_manifest.yaml`, just like every other
+Base-managed project. A workspace manifest does not replace or extend that
+project manifest; it names the repository set around it.
+
+The Base Foundry maintainer workspace keeps its canonical `workspace.yaml` in
+the dedicated `base-workspace` configuration repository. That manifest is a
+maintainer workspace example, not a Base runtime dependency or a universal
+default for every Base installation. Other teams should use a local or
+team-owned workspace manifest that matches their own repository set.
+
+### Base ecosystem map
+
+The four primary Base repositories have different roles and dependency
+directions:
+
+| Repository | Role | Relationship |
+| --- | --- | --- |
+| `base` | Local operating contract for repository readiness, setup, trust, onboarding, and handoff | Consumes `base-cli` and externally resolved `base-bash-libs` during source/runtime operation |
+| `base-cli` | Standalone Python lifecycle framework for Click and Typer applications | Base is one consumer; other CLIs can consume it independently |
+| `base-bash-libs` | Standalone reusable Bash library package | Base resolves it from a sibling checkout, explicit source, or supported package |
+| `base-demo` | First-party downstream consumer and integration fixture | Exercises the Base ecosystem; it is not a runtime dependency of `base` |
+
+The dependency direction is therefore `base-cli` and `base-bash-libs` into
+`base`, with `base-demo` downstream of the stack. A workspace manifest may list
+all four for maintainer validation, but listing a repository does not make it a
+runtime dependency.
+
 ## Vocabulary
 
 `workspace.root` is a machine-local setting in `~/.base.d/config.yaml`. It tells


### PR DESCRIPTION
## Summary

Closes #2118. Documents the four-repository Base ecosystem map and clarifies the ownership boundary between per-project `base_manifest.yaml` files and cross-repository `workspace.yaml` files.

The docs identify `base-workspace` as the Base Foundry maintainer workspace configuration example while making clear that it is not a universal Base runtime dependency or required for normal installations.

## Issue

Closes #2118

## Validation

- `git diff --check`
- `env -u BASE_HOME BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python BASE_CACHE_DIR=/private/tmp/base-docs-2118 /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest tests/test_contract_hardening.py -q`
- Result: `14 passed`

## Notes

This is documentation-only. It does not add a live workspace manifest to `base`, change workspace runtime behavior, or make the private `base-workspace` configuration part of the public installation path.