### PR TITLE
docs(policy): define ecosystem platform, license, and release contracts

### DIFF
--- a/.ai-context/STATUS.md
+++ b/.ai-context/STATUS.md
@@ -83,6 +83,11 @@ The Homebrew bottle and consumer upgrade contract has passed the #526 rehearsal.
 Supported macOS installs should continue to use bottled Homebrew packages, with
 source builds treated as fallback validation rather than the normal user path.
 
+The cross-repository platform, license, provider, and release-artifact policy is
+canonical in `docs/ecosystem-policy.md`. Base's coordinated release matrix is
+Ubuntu 24.04 and macOS 14; standalone component support does not expand the
+Base support claim, and published tags and assets are immutable.
+
 Recent released work includes:
 
 - Ubuntu/Debian runtime support through `BASE_PLATFORM=linux-debian`,
@@ -110,6 +115,7 @@ Recent released work includes:
 - release check, plan, and notes commands
 - local `.ai-context/` export bundles through `basectl export-context`
 - newcomer orientation presentation docs
+- ecosystem platform, license, provider, and release-policy contract
 - optional project Git remote reachability diagnostics
 - explicit `ai` prerequisite profile
 - explicit host-scoped `linux-lab` prerequisite profile for Multipass checks

--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ Key starting points:
 - [IDE Bootstrapping](docs/ide-bootstrapping.md)
 - [Local Config](docs/local-config.md)
 - [Project Demo Workflow](docs/project-demo-workflow.md)
+- [Ecosystem Platform, License, and Release Policy](docs/ecosystem-policy.md)
 
 ## Compatibility
 
@@ -584,7 +585,11 @@ Ubuntu/Debian support currently covers runtime checks, project diagnostics,
 source-checkout validation, and apt-backed setup for the simple prerequisites
 Base owns. Linux setup remains narrower than macOS setup and should stay behind
 the platform-policy boundary described in [docs/linux-support.md](docs/linux-support.md).
-Windows is out of scope.
+Windows is out of scope for Base. Existing Ubuntu/Debian-under-WSL2 guidance is
+read-only/development guidance, not part of the coordinated Base release
+matrix. See the [ecosystem platform, license, and release
+policy](docs/ecosystem-policy.md) for the boundary between Base and the
+standalone component repositories.
 
 The macOS CI floor runs on GitHub's `macos-14` runner. Newer macOS runners may
 be added for coverage, but the floor job should stay until Base intentionally
@@ -666,4 +671,6 @@ tracked in GitHub Issues using the workflow in
 
 ## License
 
-Base is licensed under Apache 2.0. See [LICENSE](LICENSE) for the license terms.
+Base is licensed under Apache-2.0 starting with v1.9.0. Earlier releases retain
+the license stated in their release documentation. See [LICENSE](LICENSE) for
+the current license terms.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,9 @@ worktree-based PR trains, see [GitHub Workflow](github-workflow.md).
 For release preparation, tagging, GitHub Releases, and the Homebrew tap update,
 see [Release Process](release-process.md).
 
+For the canonical cross-repository platform, license, provider, and release
+immutability policy, see [Ecosystem Platform, License, and Release Policy](ecosystem-policy.md).
+
 For self-guided or live walkthrough material, see
 [Presentations](presentations/README.md).
 

--- a/docs/ecosystem-policy.md
+++ b/docs/ecosystem-policy.md
@@ -1,0 +1,90 @@
+# Base Ecosystem Platform, License, and Release Policy
+
+This document is the canonical cross-repository policy for the Base ecosystem.
+It keeps the four repositories' public descriptions aligned without making
+their release schedules or support boundaries identical.
+
+## Ownership and dependency direction
+
+| Repository | Owns | Relationship to the ecosystem |
+| --- | --- | --- |
+| `base` | `basectl`, the local operating contract, and coordinated release BOMs | The release coordinator for a tested Base ecosystem combination |
+| `base-cli` | The reusable Python CLI lifecycle framework | An independently released framework consumed by Base and other CLIs |
+| `base-bash-libs` | Reusable Bash libraries and the `base-bash` launcher | An independently released library consumed by Base and other Bash tools |
+| `base-demo` | The public reference project and representative demo | An independently released consumer and cross-repository validation fixture |
+
+`base-cli`, `base-bash-libs`, and `base-demo` remain independently versioned.
+Publishing one of them does not force a Base release. A later Base release may
+adopt a component release only after its exact tag and commit have passed the
+required compatibility checks and have been recorded in the Base-owned BOM.
+
+Base resolves development providers in this order when the command path needs
+them: an explicit `BASE_CLI_SOURCE_DIR` or `BASE_BASH_LIBS_DIR`, the expected
+sibling checkout, and then the installed provider. A sibling or explicit source
+checkout is moving development input, not release evidence. Stable ecosystem
+consumption uses a published release asset or an immutable tag resolved to its
+full commit.
+
+## Platform boundaries
+
+The coordinated Base release matrix is intentionally small and current:
+
+| Repository or combination | Current contract | Not implied by this contract |
+| --- | --- | --- |
+| Base on macOS 14 | Full Base setup, diagnostics, shell integration, and project workflow are release-supported | Older macOS versions are not the tested floor |
+| Base on Ubuntu 24.04 | Runtime checks, diagnostics, apt-backed prerequisites, and source-checkout validation are release-supported | Full macOS-style project setup and interactive demo parity |
+| Base under WSL2 | Future platform expansion; existing Linux guidance is read-only/development guidance only | A supported native-Windows or coordinated WSL2 Base release |
+| Base on native Windows | Out of scope | Git Bash, WSL2, or `base-cli` support does not make `basectl` native Windows support |
+| `base-cli` alone | Its own documented framework matrix, including native Windows core and WSL2 when Python runs inside the Linux distribution | Native Windows support for Base or `basectl` |
+| `base-bash-libs` alone | Bash 4.2+ on supported Unix-like environments; WSL2 follows the Linux-shell boundary | A native Windows Bash runtime contract |
+| `base-demo` | Full interactive demo on macOS; Ubuntu 24.04 read-only CI validation | Full demo setup, activation, or service parity on Ubuntu, WSL2, or native Windows |
+
+The required Base release-stack combinations are `ubuntu-24.04` and
+`macos-14`. Adding WSL2, native Windows, another Linux family, or another
+macOS runner requires an explicit support-matrix update and corresponding
+immutable hosted evidence. Component-level support must not be presented as
+support for the coordinated Base stack.
+
+## License history
+
+License claims are repository- and release-specific:
+
+- Base is Apache-2.0 starting with `v1.9.0`. Earlier Base releases retain the
+  license stated in their release documentation, including the earlier MIT and
+  AGPL release lines.
+- `base-cli` is Apache-2.0 under its current release line. Its release metadata
+  and license file are authoritative for a particular version.
+- `base-bash-libs` is Apache-2.0 under its current release line. Its release
+  documentation is authoritative for historical release boundaries.
+- `base-demo` remains MIT so the small reference project can be copied and
+  adapted as a Base-managed example.
+
+Do not infer one repository's license from another repository's license. New
+generated repository baselines should use the license documented by the
+owning repository and the requested release policy.
+
+## Release and artifact immutability
+
+Every published ecosystem release uses an annotated version tag created from a
+reviewed commit. Published tags, GitHub Release assets, package versions, and
+checksums are immutable. A correction after publication requires a new patch
+version; maintainers do not retag a published version or replace its release
+assets.
+
+Build jobs may retry temporary CI artifacts before publication. That temporary
+retry behavior does not authorize overwriting a published GitHub Release asset.
+If a release already exists, the release job must fail closed and require an
+explicit new version or a documented recovery procedure.
+
+The Base release BOM is the provenance record for a coordinated combination.
+It must contain the exact component versions and full commit identities, and
+every required platform combination must report `passed`. A moving source
+provider may be useful for development but cannot satisfy a release BOM row.
+
+## Maintenance rule
+
+This page is the canonical policy. The four repository READMEs and release
+guides should link here and summarize their repository-specific boundary. Any
+change to the coordinated platform matrix, license history, or immutability
+rule must update this page, the affected repository documentation, and the
+focused documentation checks in the same reviewed change.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -21,6 +21,9 @@ force a Base release. A Base release chooses the exact compatible component
 tags it will support and records those tags, commits, contract versions, and
 Ubuntu 24.04/macOS 14 validation evidence in its BOM. A later component release
 is eligible for a later Base BOM after the required compatibility checks pass.
+See the [Ecosystem Platform, License, and Release Policy](ecosystem-policy.md)
+for the shared platform boundaries, license history, provider precedence, and
+published-artifact immutability rule.
 
 The Homebrew tap update happens after the Base tag and GitHub Release exist.
 The formula points at a versioned tag archive and records that archive's

--- a/tests/test_ecosystem_policy_docs.py
+++ b/tests/test_ecosystem_policy_docs.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POLICY = REPO_ROOT / "docs" / "ecosystem-policy.md"
+README = REPO_ROOT / "README.md"
+DOCS_README = REPO_ROOT / "docs" / "README.md"
+RELEASE_PROCESS = REPO_ROOT / "docs" / "release-process.md"
+
+
+def test_ecosystem_policy_is_canonical_and_covers_required_boundaries() -> None:
+    text = POLICY.read_text(encoding="utf-8")
+
+    for required in (
+        "Ownership and dependency direction",
+        "Platform boundaries",
+        "License history",
+        "Release and artifact immutability",
+        "`ubuntu-24.04`",
+        "`macos-14`",
+        "Base is Apache-2.0 starting with `v1.9.0`",
+        "base-demo` remains MIT",
+        "must fail closed",
+        "moving source",
+    ):
+        assert required in text
+
+
+def test_public_base_docs_link_to_the_canonical_ecosystem_policy() -> None:
+    assert "docs/ecosystem-policy.md" in README.read_text(encoding="utf-8")
+    assert "ecosystem-policy.md" in DOCS_README.read_text(encoding="utf-8")
+    assert "ecosystem-policy.md" in RELEASE_PROCESS.read_text(encoding="utf-8")
+
+
+def test_base_license_and_platform_summary_are_version_qualified() -> None:
+    readme = README.read_text(encoding="utf-8")
+
+    assert "Windows is out of scope for Base." in readme
+    assert "read-only/development guidance" in readme
+    assert "Apache-2.0 starting with v1.9.0" in readme
+    assert "Earlier releases retain" in readme


### PR DESCRIPTION
## Summary

Define Base's canonical cross-repository platform, license, provider, and release-artifact policy. Align Base's public compatibility and license wording, document that Ubuntu 24.04 and macOS 14 are the current coordinated release matrix, and add a focused documentation contract test.

## Issue

Related to #2116. This is the Base parent PR for the coordinated documentation train; the parent issue will close after the companion PRs land.

## Validation

- env -u BASE_HOME BASE_BASH_LIBS_DIR=/Users/rameshhp/work/base-bash-libs/lib/bash BASE_CLI_SOURCE_DIR=/Users/rameshhp/work/base-cli/lib/python BASE_CACHE_DIR=/private/tmp/base-2116-docs PYTHONPATH=cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q tests/test_ecosystem_policy_docs.py tests/test_contract_hardening.py tests/test_github_workflows.py (58 passed)
- git diff --check

## Demo Impact

None. Companion base-demo documentation is updated in its coordinated PR.

## Docs Impact

Adds the canonical ecosystem policy and aligns Base README, documentation map, release process, and AI context.

## CI Impact

Adds focused assertions for the policy document; no release workflow behavior changes in Base.

## Notes

The standalone repositories have companion PRs linked to this parent issue: base-cli, base-bash-libs, and base-demo. Published tags and release assets are documented as immutable; corrections require a new version.

AI context updated: .ai-context/STATUS.md.