### PR TITLE
test(release): cover invalid BOM blocking paths

### DIFF
--- a/cli/python/base_release/tests/test_engine.py
+++ b/cli/python/base_release/tests/test_engine.py
@@ -23,6 +23,7 @@ from base_release import release_readiness
 from base_release.engine import ReleaseError
 from base_release.engine import ReleaseFinding
 from base_release.engine import main
+from base_release.release_bom import canonical_bom_bytes
 
 
 READY_FINDINGS = (
@@ -74,6 +75,55 @@ def run_engine(args: list[str], cwd: Path, extra_env: dict[str, str] | None = No
 class TerminalStringIO(io.StringIO):
     def isatty(self) -> bool:
         return True
+
+
+def valid_release_bom_bytes(repository: str, version: str, commit: str) -> bytes:
+    document = {
+        "schema_version": 1,
+        "release": {
+            "repository": repository,
+            "version": version,
+            "tag": f"v{version}",
+            "commit": commit,
+        },
+        "components": [
+            {
+                "repository": repository,
+                "version": version,
+                "tag": f"v{version}",
+                "commit": commit,
+                "source_mode": "release",
+                "api_schema_version": "manifest-1",
+                "platforms": ["macos-14", "ubuntu-24.04"],
+                "required": True,
+                "result": "passed",
+                "evidence": "run://release/123",
+            },
+            {
+                "repository": "basefoundry/base-cli",
+                "version": "0.4.3",
+                "tag": "v0.4.3",
+                "commit": "b" * 40,
+                "source_mode": "release",
+                "api_schema_version": "base-cli-api@0.4.3",
+                "platforms": ["macos-14", "ubuntu-24.04"],
+                "required": True,
+                "result": "passed",
+                "evidence": "run://base-cli/123",
+            },
+        ],
+        "combinations": [
+            {
+                "name": "release-stack-ubuntu-24.04",
+                "participants": [repository, "basefoundry/base-cli"],
+                "platform": "ubuntu-24.04",
+                "required": True,
+                "result": "passed",
+                "evidence": "run://release/123",
+            }
+        ],
+    }
+    return canonical_bom_bytes(document)
 
 
 def add_origin(root: Path) -> None:
@@ -241,6 +291,49 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertIsNone(payload["error"])
         self.assertEqual(payload["data"]["findings"][1]["status"], "error")
 
+    def test_check_with_invalid_bom_reports_a_blocking_bom_finding(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = self.manifest_factory.write_release(root)
+            bom_path = root / "invalid-bom.json"
+            bom_path.write_text("{}\n", encoding="utf-8")
+
+            with (
+                mock.patch(
+                    "base_release.engine.gh_cli_finding",
+                    return_value=ReleaseFinding("ok", "gh", "GitHub CLI is authenticated."),
+                ),
+                mock.patch(
+                    "base_release.release_readiness.inspect_release_provenance",
+                    return_value=release_readiness.ReleaseProvenanceInspection(
+                        findings=READY_PROVENANCE_FINDINGS,
+                        commit_sha=READY_SHA,
+                    ),
+                ),
+            ):
+                status, stdout, stderr = run_engine(
+                    [
+                        "check",
+                        "--format",
+                        "json",
+                        "--version",
+                        "1.2.3",
+                        "--manifest",
+                        str(manifest_path),
+                        "--bom",
+                        str(bom_path),
+                    ],
+                    root,
+                )
+
+        self.assertEqual(status, 1, stderr)
+        self.assertEqual(stderr, "")
+        payload = json.loads(stdout)
+        bom_findings = [finding for finding in payload["data"]["findings"] if finding["name"] == "bom"]
+        self.assertEqual(len(bom_findings), 1)
+        self.assertEqual(bom_findings[0]["status"], "error")
+        self.assertIn("schema_version", bom_findings[0]["message"])
+
     def test_check_json_warning_and_empty_findings_preserve_success_exit(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -402,6 +495,47 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertIn("Homebrew handoff required after GitHub release", stdout)
         run_step.assert_not_called()
 
+    def test_publish_with_invalid_bom_is_blocked_before_git_or_github_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = self.manifest_factory.write_release(root)
+            bom_path = root / "invalid-bom.json"
+            bom_path.write_text("{}\n", encoding="utf-8")
+
+            with (
+                mock.patch(
+                    "base_release.engine.gh_cli_finding",
+                    return_value=ReleaseFinding("ok", "gh", "GitHub CLI is authenticated."),
+                ),
+                mock.patch(
+                    "base_release.release_readiness.inspect_release_provenance",
+                    return_value=release_readiness.ReleaseProvenanceInspection(
+                        findings=READY_PROVENANCE_FINDINGS,
+                        commit_sha=READY_SHA,
+                    ),
+                ),
+                mock.patch("base_release.engine.run_release_step") as run_step,
+            ):
+                status, stdout, stderr = run_engine(
+                    [
+                        "publish",
+                        "--yes",
+                        "--version",
+                        "1.2.3",
+                        "--manifest",
+                        str(manifest_path),
+                        "--bom",
+                        str(bom_path),
+                    ],
+                    root,
+                )
+
+        self.assertEqual(status, 1, stderr)
+        self.assertEqual(stderr, "")
+        self.assertIn("Release publish blocked by readiness findings", stdout)
+        self.assertIn("error  bom", stdout)
+        run_step.assert_not_called()
+
     def test_publish_requires_yes_when_stdin_is_not_interactive(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -485,7 +619,7 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
             root = Path(tmpdir)
             manifest_path = self.manifest_factory.write_release(root)
             bom_path = root / "candidate-bom.json"
-            bom_bytes = b'{"release":"base-1.9.0"}\n'
+            bom_bytes = valid_release_bom_bytes("codeforester/demo", "1.2.3", READY_SHA)
             bom_path.write_bytes(bom_bytes)
             commands: list[tuple[list[str], Path | None]] = []
             uploaded_contents: dict[str, bytes] = {}

--- a/cli/python/base_release/tests/test_release_readiness.py
+++ b/cli/python/base_release/tests/test_release_readiness.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from base_release.release_readiness import bom_finding
+
+
+BASE_COMMIT = "a" * 40
+
+
+def valid_bom(*, repository: str = "basefoundry/base", version: str = "1.9.0", commit: str = BASE_COMMIT) -> dict:
+    return {
+        "schema_version": 1,
+        "release": {
+            "repository": repository,
+            "version": version,
+            "tag": f"v{version}",
+            "commit": commit,
+        },
+        "components": [
+            {
+                "repository": repository,
+                "version": version,
+                "tag": f"v{version}",
+                "commit": commit,
+                "source_mode": "release",
+                "api_schema_version": "manifest-1",
+                "platforms": ["macos-14", "ubuntu-24.04"],
+                "required": True,
+                "result": "passed",
+                "evidence": "run://base/123",
+            },
+            {
+                "repository": "basefoundry/base-cli",
+                "version": "0.4.3",
+                "tag": "v0.4.3",
+                "commit": "b" * 40,
+                "source_mode": "release",
+                "api_schema_version": "base-cli-api@0.4.3",
+                "platforms": ["macos-14", "ubuntu-24.04"],
+                "required": True,
+                "result": "passed",
+                "evidence": "run://base-cli/123",
+            },
+        ],
+        "combinations": [
+            {
+                "name": "base-release-stack-ubuntu-24.04",
+                "participants": [repository, "basefoundry/base-cli"],
+                "platform": "ubuntu-24.04",
+                "required": True,
+                "result": "passed",
+                "evidence": "run://base/123",
+            }
+        ],
+    }
+
+
+def release_context(bom_path: Path | None):
+    return SimpleNamespace(
+        bom_path=bom_path,
+        release=SimpleNamespace(github=SimpleNamespace(repository="basefoundry/base")),
+        version="1.9.0",
+    )
+
+
+def write_bom(path: Path, document: object) -> Path:
+    path.write_text(json.dumps(document), encoding="utf-8")
+    return path
+
+
+def test_bom_finding_accepts_a_valid_reviewed_bom(tmp_path: Path) -> None:
+    path = write_bom(tmp_path / "release-bom.json", valid_bom())
+
+    finding = bom_finding(release_context(path), BASE_COMMIT)
+
+    assert finding.status == "ok"
+    assert finding.name == "bom"
+
+
+def test_bom_finding_accepts_an_unrequested_bom() -> None:
+    finding = bom_finding(release_context(None), None)
+
+    assert finding.status == "ok"
+    assert "No release BOM was requested" in finding.message
+
+
+@pytest.mark.parametrize(
+    ("document", "expected"),
+    [
+        (None, "missing"),
+        ({}, "schema_version"),
+        (valid_bom(repository="basefoundry/other"), "release.repository"),
+        (valid_bom(version="1.8.0"), "release.version"),
+        (valid_bom(commit="c" * 40), "release.commit"),
+    ],
+)
+def test_bom_finding_reports_blocking_validation_errors(
+    tmp_path: Path, document: object, expected: str
+) -> None:
+    path = tmp_path / "release-bom.json"
+    if document is not None:
+        write_bom(path, document)
+
+    finding = bom_finding(release_context(path), BASE_COMMIT)
+
+    assert finding.status == "error"
+    assert finding.name == "bom"
+    assert expected in finding.message
+
+
+def test_bom_finding_reports_malformed_json(tmp_path: Path) -> None:
+    path = tmp_path / "release-bom.json"
+    path.write_text("{not-json}\n", encoding="utf-8")
+
+    finding = bom_finding(release_context(path), BASE_COMMIT)
+
+    assert finding.status == "error"
+    assert "not valid JSON" in finding.message


### PR DESCRIPTION
## Summary

- Add direct coverage for every `bom_finding` readiness branch.
- Exercise invalid BOM behavior through `release check --format json` and `release publish`.
- Replace the publish test stub with a canonical schema-valid BOM fixture builder.

## Issue

Fixes #2169

## Validation

- `python -m pytest cli/python/base_release/tests/test_release_readiness.py cli/python/base_release/tests/test_engine.py -q` — 56 passed, 8 subtests passed.
- Full Python source gate — 1,237 passed.
- `git diff --check` and Pylint passed.
- Aggregate BATS was not usable from the nested issue worktree because Base sibling-library discovery and HOME-relative check-record assertions resolve differently there; unchanged `main` passes the focused record test.