### PR TITLE
fix(release): require canonical BOM artifacts

### DIFF
--- a/cli/python/base_release/release_bom_cli.py
+++ b/cli/python/base_release/release_bom_cli.py
@@ -78,8 +78,14 @@ def main() -> int:
             assembled = assemble(args)
             args.output.parent.mkdir(parents=True, exist_ok=True)
             args.output.write_bytes(canonical_bom_bytes(assembled))
+            digest_path = args.output.with_suffix(".sha256")
+            digest_path.write_text(
+                f"{bom_digest(assembled)}  {args.output.name}\n",
+                encoding="utf-8",
+            )
             print(f"release BOM assembled and validated: {args.output}")
             print(f"sha256: {bom_digest(assembled)}")
+            print(f"digest sidecar: {digest_path}")
     except ReleaseBomError as exc:
         print(f"release BOM check: {exc}", file=sys.stderr)
         return EXIT_FAILURE

--- a/cli/python/base_release/release_readiness.py
+++ b/cli/python/base_release/release_readiness.py
@@ -9,7 +9,7 @@ from typing import Callable
 
 from base_setup.git_remote_parse import parse_origin_remote
 
-from .release_bom import ReleaseBomError, validate_bom_file
+from .release_bom import ReleaseBomError, canonical_bom_bytes, load_bom, validate_bom
 from .release_model import ReleaseContext, ReleaseError, ReleaseFinding
 
 CHANGELOG_HEADER_RE = re.compile(r"^##\s+(?:\[(?P<bracket>[^\]]+)\]|(?P<plain>\S+))(?:\s+-.*)?$")
@@ -50,8 +50,13 @@ def bom_finding(ctx: ReleaseContext, reviewed_commit: str | None) -> ReleaseFind
     if not ctx.bom_path.is_file():
         return ReleaseFinding("error", "bom", f"Release BOM is missing: {ctx.bom_path}")
     try:
-        validate_bom_file(
-            ctx.bom_path,
+        document = load_bom(ctx.bom_path)
+        if canonical_bom_bytes(document) != ctx.bom_path.read_bytes():
+            raise ReleaseBomError(
+                "Release BOM is not in canonical form; regenerate it with bin/base-release-bom assemble."
+            )
+        validate_bom(
+            document,
             expected_repository=ctx.release.github.repository,
             expected_version=ctx.version,
             expected_commit=reviewed_commit,

--- a/cli/python/base_release/tests/test_release_bom.py
+++ b/cli/python/base_release/tests/test_release_bom.py
@@ -205,6 +205,9 @@ def test_assemble_writes_bytes_matching_reported_digest(tmp_path: Path, monkeypa
     monkeypatch.setattr(sys, "argv", arguments)
     assert main() == 0
     assert hashlib.sha256(output_path.read_bytes()).hexdigest() == bom_digest(load_bom(output_path))
+    assert (tmp_path / "release-bom.sha256").read_text(encoding="utf-8") == (
+        f"{bom_digest(load_bom(output_path))}  release-bom.json\n"
+    )
 
 
 def test_duplicate_component_and_unknown_participant_are_rejected() -> None:

--- a/cli/python/base_release/tests/test_release_readiness.py
+++ b/cli/python/base_release/tests/test_release_readiness.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from base_release.release_bom import canonical_bom_bytes
+from base_release.release_readiness import bom_finding
+
+
+COMMIT = "a" * 40
+
+
+def valid_bom() -> dict:
+    return {
+        "schema_version": 1,
+        "release": {
+            "repository": "basefoundry/base",
+            "version": "1.9.0",
+            "tag": "v1.9.0",
+            "commit": COMMIT,
+        },
+        "components": [
+            {
+                "repository": "basefoundry/base",
+                "version": "1.9.0",
+                "tag": "v1.9.0",
+                "commit": COMMIT,
+                "source_mode": "release",
+                "api_schema_version": "manifest-1",
+                "platforms": ["ubuntu-24.04"],
+                "required": True,
+                "result": "passed",
+                "evidence": "run://base/123",
+            },
+            {
+                "repository": "basefoundry/base-cli",
+                "version": "0.4.3",
+                "tag": "v0.4.3",
+                "commit": "b" * 40,
+                "source_mode": "release",
+                "api_schema_version": "base-cli-api@0.4.3",
+                "platforms": ["ubuntu-24.04"],
+                "required": True,
+                "result": "passed",
+                "evidence": "run://base-cli/123",
+            },
+        ],
+        "combinations": [
+            {
+                "name": "base-release-stack-ubuntu-24.04",
+                "participants": ["basefoundry/base", "basefoundry/base-cli"],
+                "platform": "ubuntu-24.04",
+                "required": True,
+                "result": "passed",
+                "evidence": "run://base/123",
+            }
+        ],
+    }
+
+
+def context(path: Path):
+    return SimpleNamespace(
+        bom_path=path,
+        release=SimpleNamespace(github=SimpleNamespace(repository="basefoundry/base")),
+        version="1.9.0",
+    )
+
+
+def test_bom_finding_accepts_canonical_bom_bytes(tmp_path: Path) -> None:
+    path = tmp_path / "release-bom.json"
+    path.write_bytes(canonical_bom_bytes(valid_bom()))
+
+    finding = bom_finding(context(path), COMMIT)
+
+    assert finding.status == "ok"
+
+
+def test_bom_finding_rejects_valid_but_noncanonical_bom_bytes(tmp_path: Path) -> None:
+    path = tmp_path / "release-bom.json"
+    path.write_text(json.dumps(valid_bom(), indent=2) + "\n", encoding="utf-8")
+
+    finding = bom_finding(context(path), COMMIT)
+
+    assert finding.status == "error"
+    assert finding.name == "bom"
+    assert "canonical form" in finding.message
+    assert "base-release-bom assemble" in finding.message

--- a/docs/release-bom.md
+++ b/docs/release-bom.md
@@ -78,8 +78,12 @@ basectl release check --version 1.9.0 \
 
 `release publish` accepts the same `--bom` option and refuses to publish when
 the BOM is missing, invalid, or does not match the reviewed release identity.
-When supplied, it uploads `release-bom.json` and `release-bom.sha256` to the
-GitHub Release and verifies both assets after publication. A BOM is
+The supplied BOM must be the exact canonical artifact produced by `assemble`;
+pretty-printed or hand-edited JSON is rejected so its byte digest remains bound
+to the reviewed artifact. `assemble` writes a matching `*.sha256` sidecar next
+to its output. When supplied, `release publish` uploads `release-bom.json` and
+`release-bom.sha256` to the GitHub Release and verifies both assets after
+publication. A BOM is
 intentionally opt-in for existing manifests so historical releases remain
 inspectable; Base 1.9.0 is the first Base release that requires this governed
 release path.


### PR DESCRIPTION
## Summary

- Reject non-canonical BOM bytes during release readiness checks so published digests stay tied to the reviewed artifact.
- Make `base-release-bom assemble` write a matching `*.sha256` sidecar.
- Document the canonical-artifact requirement and add regression coverage.

## Issue

Fixes #2172

The optional `--bom-sha256` interface is intentionally deferred because the issue marks that flag as optional and it needs a maintainer contract decision.

## Validation

- `python -m pytest cli/python/base_release/tests/test_release_bom.py cli/python/base_release/tests/test_release_readiness.py cli/python/base_release/tests/test_engine.py -q` — 63 passed, 8 subtests passed.
- Full Python source gate — 1,229 passed.
- `git diff --check` and Pylint passed.
- Aggregate BATS was not usable from the nested issue worktree because Base sibling-library discovery and HOME-relative check-record assertions resolve differently there; unchanged `main` passes the focused record test.

## Docs Impact

Updated `docs/release-bom.md` with the canonical-artifact and digest-sidecar requirement.