### PR TITLE
ci(release): harden BOM workflow row generation

### DIFF
--- a/.github/workflows/ecosystem-release-bom.yml
+++ b/.github/workflows/ecosystem-release-bom.yml
@@ -47,7 +47,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.base_version }}-${{ inputs.base_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.base_version }}-${{ inputs.base_ref }}
   cancel-in-progress: false
 
 jobs:
@@ -110,22 +110,19 @@ jobs:
           fetch-depth: 1
 
       - name: Check out base-demo
-        env:
-          BASE_DEMO_REF: ${{ inputs.base_demo_ref }}
-        run: |
-          set -euo pipefail
-          git init "$GITHUB_WORKSPACE/../base-demo"
-          git -C "$GITHUB_WORKSPACE/../base-demo" remote add origin \
-            https://github.com/basefoundry/base-demo.git
-          git -C "$GITHUB_WORKSPACE/../base-demo" fetch --depth 1 origin "$BASE_DEMO_REF"
-          git -C "$GITHUB_WORKSPACE/../base-demo" checkout --detach FETCH_HEAD
-          git -C "$GITHUB_WORKSPACE/../base-demo" log -1 --oneline
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          repository: basefoundry/base-demo
+          ref: ${{ inputs.base_demo_ref }}
+          path: .dependencies/base-demo
+          fetch-depth: 1
 
       - name: Expose peer checkouts for workspace validation
         run: |
           set -euo pipefail
           ln -s "$GITHUB_WORKSPACE/.dependencies/base-cli" "$GITHUB_WORKSPACE/../base-cli"
           ln -s "$GITHUB_WORKSPACE/.dependencies/base-bash-libs" "$GITHUB_WORKSPACE/../base-bash-libs"
+          ln -s "$GITHUB_WORKSPACE/.dependencies/base-demo" "$GITHUB_WORKSPACE/../base-demo"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
@@ -304,6 +301,9 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Install BOM YAML parser
+        run: python -m pip install --disable-pip-version-check PyYAML==6.0.3
+
       - name: Download compatibility evidence
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
@@ -333,27 +333,35 @@ jobs:
             --platform macos-14 \
             --output "$RUNNER_TEMP/base-bom/base-row.json"
 
-          jq -n \
-            --arg version "$BASE_CLI_VERSION" \
-            --arg commit "$base_cli_commit" \
-            --arg evidence "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-            '{repository:"basefoundry/base-cli",version:$version,tag:("v" + $version),commit:$commit,source_mode:"release",api_schema_version:("base-cli-api@" + $version),platforms:["macos-14","ubuntu-24.04"],required:true,result:"passed",evidence:$evidence}' \
-            > "$RUNNER_TEMP/base-bom/base-cli-row.json"
-          bash_api_version="$(awk -F': ' '$1 == "manifest_version" {print $2; exit}' .dependencies/base-bash-libs/base_api_manifest.yaml)"
+          ./bin/base-release-bom-row \
+            --repository basefoundry/base-cli \
+            --version "$BASE_CLI_VERSION" \
+            --commit "$base_cli_commit" \
+            --evidence "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --api-schema-version "base-cli-api@$BASE_CLI_VERSION" \
+            --platform ubuntu-24.04 \
+            --platform macos-14 \
+            --output "$RUNNER_TEMP/base-bom/base-cli-row.json"
+          bash_api_version="$(python -c 'import sys, yaml; print(yaml.safe_load(open(sys.argv[1], encoding="utf-8"))["manifest_version"])' .dependencies/base-bash-libs/base_api_manifest.yaml)"
           test -n "$bash_api_version"
-          jq -n \
-            --arg version "$BASE_BASH_LIBS_VERSION" \
-            --arg api_schema_version "base-bash-libs-api@$bash_api_version" \
-            --arg commit "$base_bash_libs_commit" \
-            --arg evidence "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-            '{repository:"basefoundry/base-bash-libs",version:$version,tag:("v" + $version),commit:$commit,source_mode:"release",api_schema_version:$api_schema_version,platforms:["macos-14","ubuntu-24.04"],required:true,result:"passed",evidence:$evidence}' \
-            > "$RUNNER_TEMP/base-bom/base-bash-libs-row.json"
-          jq -n \
-            --arg version "$BASE_DEMO_VERSION" \
-            --arg commit "$base_demo_commit" \
-            --arg evidence "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-            '{repository:"basefoundry/base-demo",version:$version,tag:("v" + $version),commit:$commit,source_mode:"release",api_schema_version:("base-demo-release@" + $version),platforms:["macos-14","ubuntu-24.04"],required:true,result:"passed",evidence:$evidence}' \
-            > "$RUNNER_TEMP/base-bom/base-demo-row.json"
+          ./bin/base-release-bom-row \
+            --repository basefoundry/base-bash-libs \
+            --version "$BASE_BASH_LIBS_VERSION" \
+            --commit "$base_bash_libs_commit" \
+            --evidence "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --api-schema-version "base-bash-libs-api@$bash_api_version" \
+            --platform ubuntu-24.04 \
+            --platform macos-14 \
+            --output "$RUNNER_TEMP/base-bom/base-bash-libs-row.json"
+          ./bin/base-release-bom-row \
+            --repository basefoundry/base-demo \
+            --version "$BASE_DEMO_VERSION" \
+            --commit "$base_demo_commit" \
+            --evidence "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --api-schema-version "base-demo-release@$BASE_DEMO_VERSION" \
+            --platform ubuntu-24.04 \
+            --platform macos-14 \
+            --output "$RUNNER_TEMP/base-bom/base-demo-row.json"
 
           bom="$RUNNER_TEMP/base-bom/release-bom.json"
           ubuntu_evidence="$(jq -r '.evidence' evidence/release-stack-ubuntu-24.04.json)"

--- a/cli/python/base_release/release_bom_row.py
+++ b/cli/python/base_release/release_bom_row.py
@@ -7,29 +7,36 @@ from pathlib import Path
 
 
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+REPOSITORY_RE = re.compile(r"^[^/\s]+/[^/\s]+$")
 VERSION_RE = re.compile(r"^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$")
 EXIT_SUCCESS = 0
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(prog="bin/base-release-bom-row")
+    parser.add_argument("--repository", default="basefoundry/base")
     parser.add_argument("--version", required=True)
     parser.add_argument("--commit", required=True)
     parser.add_argument("--evidence", required=True)
+    parser.add_argument("--api-schema-version", default="manifest-1")
     parser.add_argument("--platform", action="append", dest="platforms", required=True)
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
+    if not REPOSITORY_RE.fullmatch(args.repository):
+        parser.error("--repository must use owner/name format")
     if not VERSION_RE.fullmatch(args.version):
         parser.error("--version must be a stable SemVer value")
     if not SHA_RE.fullmatch(args.commit):
         parser.error("--commit must be a lowercase full 40-character SHA")
+    if not args.api_schema_version.strip():
+        parser.error("--api-schema-version must be a non-empty value")
     document = {
-        "repository": "basefoundry/base",
+        "repository": args.repository,
         "version": args.version,
         "tag": f"v{args.version}",
         "commit": args.commit,
         "source_mode": "release",
-        "api_schema_version": "manifest-1",
+        "api_schema_version": args.api_schema_version,
         "platforms": sorted(set(args.platforms)),
         "required": True,
         "result": "passed",

--- a/cli/python/base_release/tests/test_release_bom_row.py
+++ b/cli/python/base_release/tests/test_release_bom_row.py
@@ -42,3 +42,32 @@ def test_base_release_bom_row_emits_the_base_release_contract(tmp_path: Path) ->
         "tag": "v1.9.0",
         "version": "1.9.0",
     }
+
+
+def test_base_release_bom_row_accepts_component_identity_overrides(tmp_path: Path) -> None:
+    output = tmp_path / "component-row.json"
+    subprocess.run(
+        [
+            str(ROOT / "bin" / "base-release-bom-row"),
+            "--repository",
+            "basefoundry/base-cli",
+            "--version",
+            "0.4.3",
+            "--commit",
+            "b" * 40,
+            "--evidence",
+            "run://base-cli/123",
+            "--api-schema-version",
+            "base-cli-api@0.4.3",
+            "--platform",
+            "ubuntu-24.04",
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+
+    row = json.loads(output.read_text(encoding="utf-8"))
+    assert row["repository"] == "basefoundry/base-cli"
+    assert row["api_schema_version"] == "base-cli-api@0.4.3"
+    assert row["tag"] == "v0.4.3"

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -129,16 +129,6 @@ def test_ecosystem_release_bom_workflow_owns_base_and_required_platform_matrix()
         for step in job.get("steps", [])
         if isinstance(step, dict)
     )
-    compatibility_checkouts = [
-        step
-        for step in compatibility.get("steps", [])
-        if isinstance(step, dict) and step.get("uses", "").startswith("actions/checkout@")
-    ]
-    assemble_checkouts = [
-        step
-        for step in assemble.get("steps", [])
-        if isinstance(step, dict) and step.get("uses", "").startswith("actions/checkout@")
-    ]
 
     assert workflow["name"] == "Ecosystem Release BOM"
     assert workflow["permissions"] == {"contents": "read"}
@@ -154,7 +144,9 @@ def test_ecosystem_release_bom_workflow_owns_base_and_required_platform_matrix()
         "base_demo_ref",
     }
     assert assemble["needs"] == "compatibility"
-    assert workflow["concurrency"]["group"] == "${{ github.workflow }}-${{ inputs.base_version }}-${{ inputs.base_ref }}"
+    assert workflow["concurrency"]["group"] == (
+        "${{ github.workflow }}-${{ inputs.base_version }}-${{ inputs.base_ref }}"
+    )
     assert "base-release-bom assemble" in run_commands
     assert run_commands.count("base-release-bom-row") == 4
     assert "--repository basefoundry/base-cli" in run_commands
@@ -163,10 +155,11 @@ def test_ecosystem_release_bom_workflow_owns_base_and_required_platform_matrix()
     assert "release-bom.sha256" in run_commands
     assert "^\u005b0-9a-f\u005d{40}$" in run_commands
     assert "awk -F': '" not in run_commands
-    assert any(step.get("with", {}).get("path") == ".dependencies/base-demo" for step in compatibility_checkouts)
-    assert any(step.get("with", {}).get("path") == ".dependencies/base-demo" for step in assemble_checkouts)
-    assert "yaml.safe_load" in run_commands
-    assert "Install BOM YAML parser" in str(assemble["steps"])
+    assert all(
+        any(step.get("with", {}).get("path") == ".dependencies/base-demo" for step in job["steps"])
+        for job in (compatibility, assemble)
+    )
+    assert "yaml.safe_load" in run_commands and "Install BOM YAML parser" in str(assemble["steps"])
     assert "--format json --no-notify --yes" in compatibility_commands
     assert 'base_demo_commit="$(git -C "$GITHUB_WORKSPACE/../base-demo" rev-parse HEAD)"' in compatibility_commands
     assert 'printf \'  root: %s\\n\' "$GITHUB_WORKSPACE/.."' in compatibility_commands

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -129,6 +129,16 @@ def test_ecosystem_release_bom_workflow_owns_base_and_required_platform_matrix()
         for step in job.get("steps", [])
         if isinstance(step, dict)
     )
+    compatibility_checkouts = [
+        step
+        for step in compatibility.get("steps", [])
+        if isinstance(step, dict) and step.get("uses", "").startswith("actions/checkout@")
+    ]
+    assemble_checkouts = [
+        step
+        for step in assemble.get("steps", [])
+        if isinstance(step, dict) and step.get("uses", "").startswith("actions/checkout@")
+    ]
 
     assert workflow["name"] == "Ecosystem Release BOM"
     assert workflow["permissions"] == {"contents": "read"}
@@ -144,12 +154,19 @@ def test_ecosystem_release_bom_workflow_owns_base_and_required_platform_matrix()
         "base_demo_ref",
     }
     assert assemble["needs"] == "compatibility"
+    assert workflow["concurrency"]["group"] == "${{ github.workflow }}-${{ inputs.base_version }}-${{ inputs.base_ref }}"
     assert "base-release-bom assemble" in run_commands
-    assert "base-release-bom-row" in run_commands
+    assert run_commands.count("base-release-bom-row") == 4
+    assert "--repository basefoundry/base-cli" in run_commands
+    assert "--repository basefoundry/base-bash-libs" in run_commands
+    assert "--repository basefoundry/base-demo" in run_commands
     assert "release-bom.sha256" in run_commands
     assert "^\u005b0-9a-f\u005d{40}$" in run_commands
-    assert 'git init "$GITHUB_WORKSPACE/../base-demo"' in compatibility_commands
-    assert 'git -C "$GITHUB_WORKSPACE/../base-demo" fetch --depth 1 origin "$BASE_DEMO_REF"' in compatibility_commands
+    assert "awk -F': '" not in run_commands
+    assert any(step.get("with", {}).get("path") == ".dependencies/base-demo" for step in compatibility_checkouts)
+    assert any(step.get("with", {}).get("path") == ".dependencies/base-demo" for step in assemble_checkouts)
+    assert "yaml.safe_load" in run_commands
+    assert "Install BOM YAML parser" in str(assemble["steps"])
     assert "--format json --no-notify --yes" in compatibility_commands
     assert 'base_demo_commit="$(git -C "$GITHUB_WORKSPACE/../base-demo" rev-parse HEAD)"' in compatibility_commands
     assert 'printf \'  root: %s\\n\' "$GITHUB_WORKSPACE/.."' in compatibility_commands


### PR DESCRIPTION
## Summary

- Use the validated BOM row tool for all four component rows.
- Replace fragile `awk` YAML parsing with `yaml.safe_load`.
- Use the same `actions/checkout` mechanism for `base-demo` in both workflow jobs.
- Remove the dead `github.ref` concurrency fallback.

## Issue

Fixes #2174

## Validation

- `python -m pytest cli/python/base_release/tests/test_release_bom_row.py tests/test_github_workflows.py -q` — 44 passed.
- Full Python source gate — 1,228 passed.
- `git diff --check` and Pylint passed.
- Aggregate BATS was not usable from the nested issue worktree because Base sibling-library discovery and HOME-relative check-record assertions resolve differently there; unchanged `main` passes the focused record test.