### PR TITLE
feat(workspace): report undeclared repositories

### DIFF
--- a/cli/python/base_projects/tests/test_workspace_checks.py
+++ b/cli/python/base_projects/tests/test_workspace_checks.py
@@ -51,6 +51,19 @@ def write_ready_python_bin(python_bin: Path) -> None:
     python_bin.chmod(0o755)
 
 
+def write_git_repository(repository_root: Path) -> None:
+    repository_root.mkdir(parents=True)
+    (repository_root / ".git").mkdir()
+
+
+def write_bare_git_repository(repository_root: Path) -> None:
+    repository_root.mkdir(parents=True)
+    (repository_root / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    (repository_root / "config").write_text("[core]\n\tbare = true\n", encoding="utf-8")
+    (repository_root / "objects").mkdir()
+    (repository_root / "refs").mkdir()
+
+
 def write_workspace_manifest(path: Path, repos: str | None = None) -> None:
     path.write_text(
         "\n".join(
@@ -109,6 +122,114 @@ def invoke_engine(args: list[str], base_home: Path, home: Path) -> tuple[int, st
             status = engine.main(args)
     return status, stdout.getvalue(), stderr.getvalue()
 
+
+class WorkspaceUndeclaredRepositoryTests(unittest.TestCase):
+    def test_workspace_doctor_does_not_report_declared_git_repositories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            write_default_manifest(base_home)
+            write_workspace_manifest(manifest_path, repos="  - name: base\n  - name: bare")
+            write_git_repository(workspace / "base")
+            write_bare_git_repository(workspace / "bare")
+
+            status, stdout, stderr = invoke_engine(
+                ["doctor", "--workspace", str(workspace), "--manifest", str(manifest_path), "--format", "json"],
+                base_home,
+                home,
+            )
+
+        payload = json.loads(stdout)
+        findings = [check for project in payload["projects"] for check in project["checks"]]
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertNotIn("BASE-W013", {check["id"] for check in findings})
+
+    def test_workspace_check_warns_without_failing_for_one_undeclared_git_repository(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            write_default_manifest(base_home)
+            write_workspace_manifest(manifest_path, repos="  - name: base")
+            write_git_repository(workspace / "base")
+            write_git_repository(workspace / "unlisted")
+
+            status, stdout, stderr = invoke_engine(
+                ["check", "--workspace", str(workspace), "--manifest", str(manifest_path), "--format", "json"],
+                base_home,
+                home,
+            )
+
+        payload = json.loads(stdout)
+        undeclared = [
+            check
+            for project in payload["projects"]
+            for check in project["checks"]
+            if check["id"] == "BASE-W013"
+        ]
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(payload["status"], "warn")
+        self.assertEqual(len(undeclared), 1)
+        self.assertEqual(undeclared[0]["status"], "warn")
+        self.assertEqual(undeclared[0]["details"]["path"], str((workspace / "unlisted").resolve()))
+        self.assertIn("mark it as unmanaged", undeclared[0]["fix"])
+
+    def test_workspace_doctor_lists_two_undeclared_repository_paths_in_text_and_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            base_home = root / "base"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            write_default_manifest(base_home)
+            write_workspace_manifest(manifest_path, repos="  - name: base")
+            write_git_repository(workspace / "base")
+            write_git_repository(workspace / "unlisted-one")
+            write_bare_git_repository(workspace / "unlisted-two")
+
+            text_status, text_stdout, text_stderr = invoke_engine(
+                ["doctor", "--workspace", str(workspace), "--manifest", str(manifest_path)],
+                base_home,
+                home,
+            )
+            json_status, json_stdout, json_stderr = invoke_engine(
+                ["doctor", "--workspace", str(workspace), "--manifest", str(manifest_path), "--format", "json"],
+                base_home,
+                home,
+            )
+
+        payload = json.loads(json_stdout)
+        undeclared = [
+            check
+            for project in payload["projects"]
+            for check in project["checks"]
+            if check["id"] == "BASE-W013"
+        ]
+        self.assertEqual(text_status, 0)
+        self.assertIn("Workspace doctor:", text_stdout)
+        self.assertNotIn("BASE-W013", text_stdout)
+        self.assertIn(str((workspace / "unlisted-one").resolve()), text_stderr)
+        self.assertIn(str((workspace / "unlisted-two").resolve()), text_stderr)
+        self.assertEqual(json_status, 0)
+        self.assertEqual(json_stderr, "")
+        self.assertEqual(payload["status"], "warn")
+        self.assertEqual(
+            {check["details"]["path"] for check in undeclared},
+            {str((workspace / "unlisted-one").resolve()), str((workspace / "unlisted-two").resolve())},
+        )
 
 class WorkspaceCheckTests(unittest.TestCase):
     def test_workspace_check_records_ok_and_warning_results_for_status(self) -> None:

--- a/cli/python/base_projects/workspace_checks.py
+++ b/cli/python/base_projects/workspace_checks.py
@@ -18,6 +18,7 @@ from base_projects.workspace_report_common import workspace_repo_check_details
 from base_projects.workspace_repository_url import redact_repository_url
 from base_projects.workspace_scanner import ManifestEntry
 from base_projects.workspace_scanner import workspace_manifest_entries
+from base_projects.workspace_scanner import workspace_repository_paths
 from base_setup.checks import ArtifactCheck
 from base_setup.checks import checks_status
 from base_setup.checks import doctor_status
@@ -111,14 +112,18 @@ def workspace_manifest_project_check_results(
         entry.path.parent.resolve().name: entry
         for entry in workspace_manifest_entries(workspace_root)
     }
+    repository_paths_by_name = {path.name: path for path in workspace_repository_paths(workspace_root)}
     results: list[WorkspaceProjectCheckResult] = []
 
     for repo in workspace_manifest.repos:
         entry = entries_by_repo.pop(repo.name, None)
+        repository_paths_by_name.pop(repo.name, None)
         results.append(workspace_expected_repo_check_result(workspace_root, repo, entry, default_manifest))
 
     for repo_name in sorted(entries_by_repo):
         results.append(workspace_extra_project_check_result(entries_by_repo[repo_name], default_manifest))
+    for repo_name in sorted(repository_paths_by_name):
+        results.append(workspace_undeclared_repo_check_result(repository_paths_by_name[repo_name]))
 
     return tuple(results)
 
@@ -296,6 +301,43 @@ def workspace_extra_project_check(result: WorkspaceProjectCheckResult) -> Artifa
             "expected": False,
             "present": True,
         },
+    )
+
+
+def workspace_undeclared_repo_check(root: Path) -> ArtifactCheck:
+    repository = root.name
+    return ArtifactCheck(
+        name="workspace_manifest_declaration",
+        ok=False,
+        message=f"Git repository '{repository}' is present at '{root}' but is not declared in the workspace manifest.",
+        fix=(
+            f"Add '{repository}' to the workspace manifest if it belongs in this workspace; "
+            "otherwise mark it as unmanaged in the workspace manifest or move it outside the workspace root."
+        ),
+        status="warn",
+        finding_id="BASE-W013",
+        details={
+            "repository": repository,
+            "path": str(root),
+            "expected": False,
+            "present": True,
+        },
+    )
+
+
+def workspace_undeclared_repo_check_result(root: Path) -> WorkspaceProjectCheckResult:
+    check = workspace_undeclared_repo_check(root)
+    return WorkspaceProjectCheckResult(
+        name=root.name,
+        root=root,
+        manifest_path=None,
+        manifest="missing",
+        status=checks_status((check,)),
+        checks=(check,),
+        expected=False,
+        required=False,
+        repo="present",
+        repository=root.name,
     )
 
 

--- a/cli/python/base_projects/workspace_reports.py
+++ b/cli/python/base_projects/workspace_reports.py
@@ -13,6 +13,8 @@ from base_projects.workspace_checks import workspace_non_base_repo_check
 from base_projects.workspace_checks import workspace_project_check_result
 from base_projects.workspace_checks import workspace_project_check_results
 from base_projects.workspace_checks import workspace_repo_presence_check
+from base_projects.workspace_checks import workspace_undeclared_repo_check
+from base_projects.workspace_checks import workspace_undeclared_repo_check_result
 from base_projects.workspace_agent_brief import RepositoryFileSignal
 from base_projects.workspace_agent_brief import RepositoryValidationSignal
 from base_projects.workspace_agent_brief import WorkspaceAgentBrief
@@ -105,5 +107,7 @@ __all__ = (
     "workspace_project_statuses",
     "workspace_repo_check_details",
     "workspace_repo_presence_check",
+    "workspace_undeclared_repo_check",
+    "workspace_undeclared_repo_check_result",
     "workspace_status_to_json",
 )

--- a/cli/python/base_projects/workspace_scanner.py
+++ b/cli/python/base_projects/workspace_scanner.py
@@ -40,3 +40,31 @@ def workspace_manifest_entries(workspace_root: Path) -> tuple[ManifestEntry, ...
         )
 
     return tuple(entries)
+
+
+def workspace_repository_paths(workspace_root: Path) -> tuple[Path, ...]:
+    """Return direct-child directories that look like Git repositories."""
+    if not workspace_root.is_dir():
+        raise ProjectDiscoveryError(f"Workspace '{workspace_root}' is not a directory.")
+
+    repositories: list[Path] = []
+    for candidate in sorted(workspace_root.iterdir(), key=lambda path: path.name):
+        if not candidate.is_dir():
+            continue
+        git_marker = candidate / ".git"
+        if git_marker.is_dir() or git_marker.is_file() or _looks_like_bare_repository(candidate):
+            repositories.append(candidate.resolve())
+
+    return tuple(repositories)
+
+
+def _looks_like_bare_repository(candidate: Path) -> bool:
+    """Recognize the stable on-disk markers created by ``git init --bare``."""
+    return all(
+        (
+            (candidate / "HEAD").is_file(),
+            (candidate / "config").is_file(),
+            (candidate / "objects").is_dir(),
+            (candidate / "refs").is_dir(),
+        )
+    )

--- a/docs/doctor-findings.md
+++ b/docs/doctor-findings.md
@@ -261,6 +261,7 @@ does not print credential-bearing remote URLs.
 | `BASE-W010` | Expected workspace repository presence |
 | `BASE-W011` | Discovered Base-managed project outside the workspace manifest |
 | `BASE-W012` | Present expected repository without a Base project manifest |
+| `BASE-W013` | Git repository present under the workspace root but absent from the workspace manifest |
 
 `BASE-W010` is emitted for every expected repository when workspace check or
 doctor runs with `--manifest <path>`. It is `error` when a required repository
@@ -273,6 +274,12 @@ workspace root but are not listed in the supplied workspace manifest.
 `BASE-W012` reports expected repositories that are present locally but do not
 contain `base_manifest.yaml`. This is an `ok` finding because workspace
 manifests do not require every repository to be Base-managed.
+
+`BASE-W013` reports each direct-child Git repository that is present under the
+workspace root but is not listed in the workspace manifest. It is a `warn`
+finding and does not fail workspace check or doctor. Add the repository to the
+manifest when it belongs in the workspace; otherwise mark it as unmanaged in
+the manifest or move it outside the workspace root.
 
 ## Health Findings
 

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -579,8 +579,12 @@ for present Base-managed projects and renders check-oriented status, names, and
 messages in text output. `basectl workspace doctor --manifest <path>` renders
 the same read-only evidence as actionable findings with stable IDs and fix
 guidance. Both commands emit stable workspace findings for repository
-presence, outside-manifest discovered projects, and present repositories
-without a Base project manifest; their JSON diagnostic items remain compatible.
+presence, outside-manifest discovered projects, present repositories without a
+Base project manifest, and Git repositories present under the workspace root
+but absent from the manifest. The latter is a non-blocking warning for each
+undeclared repository; add it to `repos[]` when it belongs in the workspace, or
+mark it as unmanaged in the manifest or move it outside the workspace root.
+Their JSON diagnostic items remain compatible.
 
 `basectl workspace agent-brief --manifest <path>` reports one item per expected
 repository plus each extra locally discovered Base-managed project. JSON uses


### PR DESCRIPTION
## Summary

- detect direct-child regular and bare Git repositories under the workspace root
- report undeclared repositories as non-blocking BASE-W013 warnings in workspace check and doctor text/JSON output
- add focused coverage for declared, one undeclared, and two undeclared repository layouts
- document the finding and remediation guidance

Related to #2101