### PR TITLE
fix(workspace): preserve logical names and containment in reports

### DIFF
--- a/cli/python/base_projects/project_discovery.py
+++ b/cli/python/base_projects/project_discovery.py
@@ -35,7 +35,7 @@ def current_project() -> Project:
 
 def discover_projects_cached(ctx: base_cli.Context, workspace_root: Path) -> tuple[Project, ...]:
     start = time.perf_counter()
-    entries = workspace_manifest_entries(workspace_root)
+    entries = workspace_manifest_entries(workspace_root, include_outside=False)
     cached_projects = read_project_cache(workspace_root, entries)
     elapsed_ms = (time.perf_counter() - start) * 1000
     if cached_projects is not None:

--- a/cli/python/base_projects/tests/test_workspace_checks.py
+++ b/cli/python/base_projects/tests/test_workspace_checks.py
@@ -232,6 +232,54 @@ class WorkspaceUndeclaredRepositoryTests(unittest.TestCase):
         )
 
 class WorkspaceCheckTests(unittest.TestCase):
+    def test_workspace_check_matches_logical_symlink_names_and_skips_outside_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            outside = root / "outside"
+            base_home = root / "base"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            workspace.mkdir()
+            outside.mkdir()
+            write_default_manifest(base_home)
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "schema_version: 1",
+                        "workspace:",
+                        "  name: symlink-suite",
+                        "repos:",
+                        "  - name: api",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            physical = root / "physical-api"
+            write_shell_manifest(physical, "api")
+            (physical / ".git").mkdir()
+            (workspace / "api").symlink_to(physical, target_is_directory=True)
+            outside_project = outside / "physical-outside"
+            write_shell_manifest(outside_project, "outside")
+            (outside_project / ".git").mkdir()
+            (workspace / "outside").symlink_to(outside_project, target_is_directory=True)
+
+            status, stdout, stderr = invoke_engine(
+                ["check", "--workspace", str(workspace), "--manifest", str(manifest_path), "--format", "json"],
+                base_home,
+                home,
+            )
+
+        payload = json.loads(stdout)
+        projects_by_repo = {project["repository"]: project for project in payload["projects"]}
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(set(projects_by_repo), {"api"})
+        self.assertTrue(projects_by_repo["api"]["expected"])
+
     def test_workspace_check_records_ok_and_warning_results_for_status(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/cli/python/base_projects/tests/test_workspace_checks.py
+++ b/cli/python/base_projects/tests/test_workspace_checks.py
@@ -231,7 +231,7 @@ class WorkspaceUndeclaredRepositoryTests(unittest.TestCase):
             {str((workspace / "unlisted-one").resolve()), str((workspace / "unlisted-two").resolve())},
         )
 
-class WorkspaceCheckTests(unittest.TestCase):
+class WorkspaceSymlinkTests(unittest.TestCase):
     def test_workspace_check_matches_logical_symlink_names_and_skips_outside_targets(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -280,6 +280,8 @@ class WorkspaceCheckTests(unittest.TestCase):
         self.assertEqual(set(projects_by_repo), {"api"})
         self.assertTrue(projects_by_repo["api"]["expected"])
 
+
+class WorkspaceCheckTests(unittest.TestCase):
     def test_workspace_check_records_ok_and_warning_results_for_status(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/cli/python/base_projects/tests/test_workspace_status_manifest.py
+++ b/cli/python/base_projects/tests/test_workspace_status_manifest.py
@@ -96,6 +96,53 @@ def invoke_engine(
 
 
 class WorkspaceStatusManifestTests(unittest.TestCase):
+    def test_workspace_status_matches_logical_symlink_names_and_skips_outside_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            home = root / "home"
+            workspace = root / "workspace"
+            outside = root / "outside"
+            base_home = root / "base"
+            manifest_path = root / "workspace.yaml"
+            home.mkdir()
+            base_home.mkdir()
+            workspace.mkdir()
+            outside.mkdir()
+            manifest_path.write_text(
+                "\n".join(
+                    [
+                        "schema_version: 1",
+                        "workspace:",
+                        "  name: symlink-suite",
+                        "repos:",
+                        "  - name: api",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            physical = root / "physical-api"
+            write_manifest(physical, "api")
+            (physical / ".git").mkdir()
+            (workspace / "api").symlink_to(physical, target_is_directory=True)
+            outside_project = outside / "physical-outside"
+            write_manifest(outside_project, "outside")
+            (workspace / "outside").symlink_to(outside_project, target_is_directory=True)
+
+            status, stdout, stderr = invoke_engine(
+                ["status", "--workspace", str(workspace), "--manifest", str(manifest_path), "--format", "json"],
+                base_home,
+                home,
+            )
+
+        payload = json.loads(stdout)
+        projects_by_repo = {project["repository"]: project for project in payload["projects"]}
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(set(projects_by_repo), {"api"})
+        self.assertEqual(projects_by_repo["api"]["expected"], True)
+        self.assertEqual(projects_by_repo["api"]["repo"], "present")
+
     def test_workspace_status_manifest_reports_expected_missing_and_extra_repositories(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/cli/python/base_projects/workspace_checks.py
+++ b/cli/python/base_projects/workspace_checks.py
@@ -109,7 +109,7 @@ def workspace_manifest_project_check_results(
     default_manifest: BaseManifest,
 ) -> tuple[WorkspaceProjectCheckResult, ...]:
     entries_by_repo = {
-        entry.path.parent.resolve().name: entry
+        entry.path.parent.name: entry
         for entry in workspace_manifest_entries(workspace_root)
     }
     repository_paths_by_name = {path.name: path for path in workspace_repository_paths(workspace_root)}
@@ -210,7 +210,7 @@ def workspace_extra_project_check_result(
         expected=False,
         required=False,
         repo="present",
-        repository=entry.path.parent.resolve().name,
+        repository=entry.path.parent.name,
     )
 
 

--- a/cli/python/base_projects/workspace_checks.py
+++ b/cli/python/base_projects/workspace_checks.py
@@ -98,7 +98,7 @@ def workspace_project_check_results(
     if workspace_manifest is None:
         return tuple(
             workspace_project_check_result(entry, default_manifest)
-            for entry in workspace_manifest_entries(workspace_root)
+            for entry in workspace_manifest_entries(workspace_root, include_outside=False)
         )
     return workspace_manifest_project_check_results(workspace_root, workspace_manifest, default_manifest)
 
@@ -110,7 +110,7 @@ def workspace_manifest_project_check_results(
 ) -> tuple[WorkspaceProjectCheckResult, ...]:
     entries_by_repo = {
         entry.path.parent.name: entry
-        for entry in workspace_manifest_entries(workspace_root)
+        for entry in workspace_manifest_entries(workspace_root, include_outside=False)
     }
     repository_paths_by_name = {path.name: path for path in workspace_repository_paths(workspace_root)}
     results: list[WorkspaceProjectCheckResult] = []

--- a/cli/python/base_projects/workspace_context.py
+++ b/cli/python/base_projects/workspace_context.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import base_cli
 from base_projects.workspace_manifest import WorkspaceManifest
 from base_projects.workspace_manifest import read_workspace_manifest
-from base_projects.workspace_scanner import ProjectDiscoveryError
+from base_projects.workspace_errors import ProjectDiscoveryError
 
 
 class WorkspacePathOutsideRootError(ValueError):

--- a/cli/python/base_projects/workspace_errors.py
+++ b/cli/python/base_projects/workspace_errors.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+class ProjectDiscoveryError(RuntimeError):
+    pass
+
+
+class ProjectNotFoundError(ProjectDiscoveryError):
+    pass

--- a/cli/python/base_projects/workspace_scanner.py
+++ b/cli/python/base_projects/workspace_scanner.py
@@ -3,13 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-
-class ProjectDiscoveryError(RuntimeError):
-    pass
-
-
-class ProjectNotFoundError(ProjectDiscoveryError):
-    pass
+from base_projects.workspace_context import resolve_workspace_repo_root
+from base_projects.workspace_errors import ProjectDiscoveryError
+from base_projects.workspace_errors import ProjectNotFoundError
 
 
 @dataclass(frozen=True)
@@ -31,8 +27,6 @@ def workspace_manifest_entries(workspace_root: Path) -> tuple[ManifestEntry, ...
         # symlink that resolves outside the workspace is not an in-workspace
         # repository and must not be inspected as an undeclared extra.
         try:
-            from base_projects.workspace_context import resolve_workspace_repo_root
-
             resolve_workspace_repo_root(workspace_root, candidate.name)
         except ValueError:
             continue
@@ -61,8 +55,6 @@ def workspace_repository_paths(workspace_root: Path) -> tuple[Path, ...]:
         if not candidate.is_dir():
             continue
         try:
-            from base_projects.workspace_context import resolve_workspace_repo_root
-
             resolve_workspace_repo_root(workspace_root, candidate.name)
         except ValueError:
             continue

--- a/cli/python/base_projects/workspace_scanner.py
+++ b/cli/python/base_projects/workspace_scanner.py
@@ -27,6 +27,15 @@ def workspace_manifest_entries(workspace_root: Path) -> tuple[ManifestEntry, ...
     for candidate in sorted(workspace_root.iterdir(), key=lambda path: path.name):
         if not candidate.is_dir():
             continue
+        # Keep read-only discovery aligned with workspace mutation paths.  A
+        # symlink that resolves outside the workspace is not an in-workspace
+        # repository and must not be inspected as an undeclared extra.
+        try:
+            from base_projects.workspace_context import resolve_workspace_repo_root
+
+            resolve_workspace_repo_root(workspace_root, candidate.name)
+        except ValueError:
+            continue
         manifest_path = candidate / "base_manifest.yaml"
         if not manifest_path.is_file():
             continue
@@ -51,9 +60,15 @@ def workspace_repository_paths(workspace_root: Path) -> tuple[Path, ...]:
     for candidate in sorted(workspace_root.iterdir(), key=lambda path: path.name):
         if not candidate.is_dir():
             continue
+        try:
+            from base_projects.workspace_context import resolve_workspace_repo_root
+
+            resolve_workspace_repo_root(workspace_root, candidate.name)
+        except ValueError:
+            continue
         git_marker = candidate / ".git"
         if git_marker.is_dir() or git_marker.is_file() or _looks_like_bare_repository(candidate):
-            repositories.append(candidate.resolve())
+            repositories.append(candidate)
 
     return tuple(repositories)
 

--- a/cli/python/base_projects/workspace_scanner.py
+++ b/cli/python/base_projects/workspace_scanner.py
@@ -15,7 +15,12 @@ class ManifestEntry:
     size: int
 
 
-def workspace_manifest_entries(workspace_root: Path) -> tuple[ManifestEntry, ...]:
+def workspace_manifest_entries(
+    workspace_root: Path,
+    *,
+    include_outside: bool = True,
+) -> tuple[ManifestEntry, ...]:
+    """Return manifest entries, optionally excluding outside-resolving symlinks."""
     if not workspace_root.is_dir():
         raise ProjectDiscoveryError(f"Workspace '{workspace_root}' is not a directory.")
 
@@ -29,7 +34,8 @@ def workspace_manifest_entries(workspace_root: Path) -> tuple[ManifestEntry, ...
         try:
             resolve_workspace_repo_root(workspace_root, candidate.name)
         except ValueError:
-            continue
+            if not include_outside:
+                continue
         manifest_path = candidate / "base_manifest.yaml"
         if not manifest_path.is_file():
             continue

--- a/cli/python/base_projects/workspace_scanner.py
+++ b/cli/python/base_projects/workspace_scanner.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from base_projects.workspace_context import resolve_workspace_repo_root
 from base_projects.workspace_errors import ProjectDiscoveryError
-from base_projects.workspace_errors import ProjectNotFoundError
+from base_projects.workspace_errors import ProjectNotFoundError  # pylint: disable=unused-import
 
 
 @dataclass(frozen=True)

--- a/cli/python/base_projects/workspace_statuses.py
+++ b/cli/python/base_projects/workspace_statuses.py
@@ -58,7 +58,7 @@ def workspace_manifest_project_statuses(
     probe_venv: bool = True,
 ) -> tuple[WorkspaceProjectStatus, ...]:
     entries_by_repo = {
-        entry.path.parent.resolve().name: entry
+        entry.path.parent.name: entry
         for entry in workspace_manifest_entries(workspace_root)
     }
     statuses: list[WorkspaceProjectStatus] = []
@@ -145,7 +145,7 @@ def workspace_extra_project_status(entry: ManifestEntry, *, probe_venv: bool = T
         expected=False,
         required=False,
         repo="present",
-        repository=entry.path.parent.resolve().name,
+        repository=entry.path.parent.name,
     )
 
 

--- a/cli/python/base_projects/workspace_statuses.py
+++ b/cli/python/base_projects/workspace_statuses.py
@@ -47,7 +47,10 @@ def workspace_project_statuses(
     workspace_manifest: WorkspaceManifest | None = None,
 ) -> tuple[WorkspaceProjectStatus, ...]:
     if workspace_manifest is None:
-        return tuple(workspace_project_status(entry) for entry in workspace_manifest_entries(workspace_root))
+        return tuple(
+            workspace_project_status(entry)
+            for entry in workspace_manifest_entries(workspace_root, include_outside=False)
+        )
     return workspace_manifest_project_statuses(workspace_root, workspace_manifest)
 
 
@@ -59,7 +62,7 @@ def workspace_manifest_project_statuses(
 ) -> tuple[WorkspaceProjectStatus, ...]:
     entries_by_repo = {
         entry.path.parent.name: entry
-        for entry in workspace_manifest_entries(workspace_root)
+        for entry in workspace_manifest_entries(workspace_root, include_outside=False)
     }
     statuses: list[WorkspaceProjectStatus] = []
 


### PR DESCRIPTION
## Summary

- Match manifest repositories by their logical workspace entry name.
- Apply the existing workspace containment resolver to read-only manifest and Git repository discovery.
- Preserve existing regular-directory, bare-repository, undeclared-repository, and extra detection behavior.

## Issue

Fixes #2185

## Validation

- `env -u BASE_HOME BASE_CACHE_DIR=/private/tmp/base-issue-2185-cache-6 PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q cli/python/base_projects/tests/test_workspace_status_manifest.py cli/python/base_projects/tests/test_workspace_checks.py cli/python/base_projects/tests/test_workspace_onboarding.py cli/python/base_projects/tests/test_workspace_agent_brief.py cli/python/base_projects/tests/test_workspace_configure.py`
- 59 passed, 8 subtests passed
- Changed-file Pylint passed
- `git diff --check`