### PR TITLE
fix(trust): preserve workspace in generated guidance

### DIFF
--- a/cli/python/base_trust/engine.py
+++ b/cli/python/base_trust/engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import sys
 from pathlib import Path
 from typing import Any
@@ -317,7 +318,18 @@ def trust_output_record(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def allow_command_text(identity: ManifestCommandTrustIdentity) -> str:
-    return f"basectl trust allow {identity.project_name} --manifest-sha256 {identity.manifest_sha256}"
+    return shlex.join(
+        [
+            "basectl",
+            "trust",
+            "allow",
+            identity.project_name,
+            "--manifest-sha256",
+            identity.manifest_sha256,
+            "--workspace",
+            str(identity.project_root.parent),
+        ]
+    )
 
 
 def print_status_text(trust_status: TrustStatus, surfaces: tuple[str, ...]) -> None:
@@ -403,15 +415,28 @@ def print_review_guidance(
     *,
     stream: Any,
 ) -> None:
+    workspace = str(identity.project_root.parent)
     print("Review first:", file=stream)
     if "run" in surfaces:
-        print(f"  basectl run {identity.project_name} --list", file=stream)
+        print(
+            f"  {shlex.join(['basectl', 'run', identity.project_name, '--list', '--workspace', workspace])}",
+            file=stream,
+        )
     if "build" in surfaces:
-        print(f"  basectl build {identity.project_name} --list", file=stream)
+        print(
+            f"  {shlex.join(['basectl', 'build', identity.project_name, '--list', '--workspace', workspace])}",
+            file=stream,
+        )
     if "test" in surfaces:
-        print(f"  basectl test {identity.project_name} --dry-run", file=stream)
+        print(
+            f"  {shlex.join(['basectl', 'test', identity.project_name, '--dry-run', '--workspace', workspace])}",
+            file=stream,
+        )
     if "demo" in surfaces:
-        print(f"  basectl demo {identity.project_name} --dry-run", file=stream)
+        print(
+            f"  {shlex.join(['basectl', 'demo', identity.project_name, '--dry-run', '--workspace', workspace])}",
+            file=stream,
+        )
     if "activate" in surfaces:
         print(
             f"  Inspect activate.source entries in {identity.manifest_path} before running "

--- a/cli/python/base_trust/tests/test_engine.py
+++ b/cli/python/base_trust/tests/test_engine.py
@@ -211,7 +211,7 @@ class ManifestCommandTrustTests(unittest.TestCase):
         self.assertEqual(payload["project"]["manifest_sha256"], expected_digest)
         self.assertEqual(
             payload["allow_command"],
-            f"basectl trust allow demo --manifest-sha256 {expected_digest}",
+            f"basectl trust allow demo --manifest-sha256 {expected_digest} --workspace {workspace.resolve()}",
         )
 
     def test_workspace_status_reports_only_projects_with_executable_manifest_surfaces(self) -> None:
@@ -386,12 +386,15 @@ class ManifestCommandTrustTests(unittest.TestCase):
         self.assertIn("Manifest-declared commands are not allowed for project 'demo'", stderr.getvalue())
         self.assertIn(f"Manifest SHA-256: {expected_digest}", stderr.getvalue())
         self.assertIn("Review first:", stderr.getvalue())
-        self.assertIn("  basectl test demo --dry-run", stderr.getvalue())
+        self.assertIn(f"  basectl test demo --dry-run --workspace {workspace.resolve()}", stderr.getvalue())
         self.assertIn("Trust scope:", stderr.getvalue())
         self.assertIn("referenced scripts", stderr.getvalue())
         self.assertNotIn("  basectl run demo --list", stderr.getvalue())
         self.assertIn("Allow after review:", stderr.getvalue())
-        self.assertIn(f"  basectl trust allow demo --manifest-sha256 {expected_digest}", stderr.getvalue())
+        self.assertIn(
+            f"  basectl trust allow demo --manifest-sha256 {expected_digest} --workspace {workspace.resolve()}",
+            stderr.getvalue(),
+        )
 
     def test_status_guidance_covers_demo_and_manifest_backed_activation(self) -> None:
         from base_trust import engine
@@ -412,10 +415,10 @@ class ManifestCommandTrustTests(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("Manifest command trust is blocked for project 'demo'.", result.stdout)
-        self.assertIn("basectl run demo --list", result.stdout)
-        self.assertIn("basectl build demo --list", result.stdout)
-        self.assertIn("basectl test demo --dry-run", result.stdout)
-        self.assertIn("basectl demo demo --dry-run", result.stdout)
+        self.assertIn(f"basectl run demo --list --workspace {workspace.resolve()}", result.stdout)
+        self.assertIn(f"basectl build demo --list --workspace {workspace.resolve()}", result.stdout)
+        self.assertIn(f"basectl test demo --dry-run --workspace {workspace.resolve()}", result.stdout)
+        self.assertIn(f"basectl demo demo --dry-run --workspace {workspace.resolve()}", result.stdout)
         self.assertIn(f"Inspect activate.source entries in {manifest_path.resolve()}", result.stdout)
         self.assertIn("basectl trust allow demo --manifest-sha256", result.stdout)
         self.assertIn("Trust scope:", result.stdout)
@@ -452,9 +455,9 @@ class ManifestCommandTrustTests(unittest.TestCase):
         )
         self.assertIn(f"Recorded Manifest SHA-256: {identity.manifest_sha256}", result.stdout)
         self.assertIn(f"Manifest SHA-256: {current_digest}", result.stdout)
-        self.assertIn("basectl test demo --dry-run", result.stdout)
+        self.assertIn(f"basectl test demo --dry-run --workspace {workspace.resolve()}", result.stdout)
         self.assertIn(
-            f"basectl trust allow demo --manifest-sha256 {current_digest}",
+            f"basectl trust allow demo --manifest-sha256 {current_digest} --workspace {workspace.resolve()}",
             result.stdout,
         )
 


### PR DESCRIPTION
## Summary

- Include the resolved workspace in generated trust allow commands.
- Include the same workspace context in review commands emitted by status and blocked-command guidance.
- Shell-quote generated command arguments so non-default workspaces and paths with spaces remain executable.

The current affected surface is base trust status and blocked guidance; workspace onboarding does not currently emit trust commands on main.

## Issue

Fixes #2187

## Validation

- `env -u BASE_HOME BASE_CACHE_DIR=/private/tmp/base-issue-2187-cache PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q cli/python/base_trust/tests/test_engine.py cli/python/base_trust/tests/test_command_error_paths.py`
- 31 passed, 18 subtests passed
- `git diff --check`