### PR TITLE
fix(ci): verify supplied installer checksums

### DIFF
--- a/.github/workflows/downstream-version-bumps.yml
+++ b/.github/workflows/downstream-version-bumps.yml
@@ -149,14 +149,21 @@ jobs:
 
             installer_sha256=""
             if [[ "$component" == "base" ]]; then
-              installer_sha256="${EVENT_INSTALLER_SHA256:-}"
-              if [[ -z "$installer_sha256" ]]; then
-                installer_sha256="$(curl -fsSL "https://raw.githubusercontent.com/basefoundry/base/$tag/install.sh" | sha256sum | awk '{print $1}')"
+              supplied_installer_sha256="${EVENT_INSTALLER_SHA256:-}"
+              if [[ -n "$supplied_installer_sha256" && ! "$supplied_installer_sha256" =~ ^[0-9a-f]{64}$ ]]; then
+                echo "::error::Base installer checksum is not a full SHA-256: $supplied_installer_sha256"
+                exit 2
               fi
-              [[ "$installer_sha256" =~ ^[0-9a-f]{64}$ ]] || {
-                echo "::error::Base installer checksum is not a full SHA-256: $installer_sha256"
+              downloaded_installer_sha256="$(curl -fsSL "https://raw.githubusercontent.com/basefoundry/base/$tag/install.sh" | sha256sum | awk '{print $1}')"
+              [[ "$downloaded_installer_sha256" =~ ^[0-9a-f]{64}$ ]] || {
+                echo "::error::Downloaded Base installer checksum is not a full SHA-256: $downloaded_installer_sha256"
                 exit 2
               }
+              if [[ -n "$supplied_installer_sha256" && "$supplied_installer_sha256" != "$downloaded_installer_sha256" ]]; then
+                echo "::error::Base $tag installer checksum mismatch: supplied $supplied_installer_sha256, downloaded release artifact is $downloaded_installer_sha256."
+                exit 2
+              fi
+              installer_sha256="$downloaded_installer_sha256"
             fi
 
             marker="<!-- base-release-bump:$component:$version:$ref_input -->"

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -187,6 +187,9 @@ def test_downstream_version_bumps_are_release_triggered_idempotent_and_review_ga
     assert "BASE_DOWNSTREAM_TOKEN is required" in run_commands
     assert "gh auth setup-git" in run_commands
     assert "base-release-bump:" in run_commands
+    assert "downloaded_installer_sha256=\"$(curl -fsSL" in run_commands
+    assert "supplied $supplied_installer_sha256" in run_commands
+    assert "installer_sha256=\"$downloaded_installer_sha256\"" in run_commands
     assert "gh issue create" in run_commands
     assert "gh pr create" in run_commands
     assert "uv lock --upgrade-package base-cli" in run_commands


### PR DESCRIPTION
## Summary

- Always hash the exact tagged Base install.sh bytes used by downstream automation.
- Reject malformed supplied checksums before the update.
- Reject valid-format supplied checksums that do not match the downloaded release artifact.
- Persist only the verified downloaded digest into downstream pins.

## Issue

Fixes #2188

## Validation

- `bash -n .github/workflows/downstream-version-bumps.yml`
- `env -u BASE_HOME BASE_CACHE_DIR=/private/tmp/base-issue-2188-cache PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q tests/test_github_workflows.py tests/test_downstream_version_bump.py`
- 46 passed
- `git diff --check`

## Security Notes

Supplied checksums are now verified against the immutable release-tag artifact before downstream pins are written.