### PR TITLE
fix(ci): make downstream bumps retry-safe

### DIFF
--- a/.github/workflows/downstream-version-bumps.yml
+++ b/.github/workflows/downstream-version-bumps.yml
@@ -120,6 +120,20 @@ jobs:
             printf '%s\n' "$commit"
           }
 
+          issue_number=""
+          issue_marker=""
+          cleanup_issue_on_failure() {
+            local status="$?"
+            if [[ "$status" -ne 0 && -n "${issue_number:-}" ]]; then
+              gh issue comment "$issue_number" --repo "$TARGET_REPOSITORY" --body "$(printf '%s\n' \
+                "Downstream version-bump automation failed after creating or reusing this issue." \
+                "The issue was preserved for retry; inspect the failed workflow run and rerun the automation." \
+                "Marker: $issue_marker")" || true
+            fi
+            exit "$status"
+          }
+          trap cleanup_issue_on_failure EXIT
+
           for component in "${selected_components[@]}"; do
             version_input="$EVENT_VERSION"
             ref_input="$EVENT_REF"
@@ -160,7 +174,9 @@ jobs:
             fi
 
             marker="<!-- base-release-bump:$component:$version:$ref_input -->"
-            all_prs="$(gh api "repos/$TARGET_REPOSITORY/pulls?state=all&per_page=100")"
+            issue_number=""
+            issue_marker="$marker"
+            all_prs="$(gh api --paginate "repos/$TARGET_REPOSITORY/pulls?state=all&per_page=100" | jq -s 'add')"
             existing_url="$(jq -r --arg marker "$marker" '[.[] | select((.body // "") | contains($marker)) | .html_url] | .[0] // empty' <<<"$all_prs")"
             if [[ -n "$existing_url" ]]; then
               echo "$component $tag already has a tracked downstream PR: $existing_url"
@@ -168,32 +184,45 @@ jobs:
             fi
 
             issue_title="ci: consume $component $tag"
-            issue_body="$(printf '%s\n' \
-              "$marker" \
-              "" \
-              "## Summary" \
-              "" \
-              "Update base-demo's immutable $component release pin to $tag ($ref_input)." \
-              "" \
-              "## Issue" \
-              "" \
-              "This issue was opened by Base's downstream release automation." \
-              "Upstream release: https://github.com/basefoundry/$component/releases/tag/$tag" \
-              "Parent: basefoundry/base#2119" \
-              "" \
-              "## Validation" \
-              "" \
-              "The downstream repository's required validation workflow must pass before merge." \
-              "" \
-              "## Notes" \
-              "" \
-              "The release pin is intentionally updated in the documented source, CI, and test contract together.")"
-            issue_url="$(gh issue create --repo "$TARGET_REPOSITORY" --label ci --title "$issue_title" --body "$issue_body")"
-            issue_number="${issue_url##*/}"
-            [[ "$issue_number" =~ ^[0-9]+$ ]] || {
-              echo "::error::Could not parse issue number from $issue_url"
-              exit 1
-            }
+            all_issues="$(gh api --paginate "repos/$TARGET_REPOSITORY/issues?state=all&per_page=100" | jq -s 'add')"
+            existing_issue="$(jq -r --arg marker "$marker" \
+              '[.[] | select((.pull_request? | not) and ((.body // "") | contains($marker))) | [.number, .state] | @tsv] | .[0] // empty' \
+              <<<"$all_issues")"
+            if [[ -n "$existing_issue" ]]; then
+              IFS=$'\t' read -r issue_number issue_state <<<"$existing_issue"
+              if [[ "$issue_state" == "closed" ]]; then
+                gh issue reopen "$issue_number" --repo "$TARGET_REPOSITORY"
+              fi
+              gh issue comment "$issue_number" --repo "$TARGET_REPOSITORY" --body \
+                "Retrying downstream version bump for $component $tag ($ref_input)."
+            else
+              issue_body="$(printf '%s\n' \
+                "$marker" \
+                "" \
+                "## Summary" \
+                "" \
+                "Update base-demo's immutable $component release pin to $tag ($ref_input)." \
+                "" \
+                "## Issue" \
+                "" \
+                "This issue was opened by Base's downstream release automation." \
+                "Upstream release: https://github.com/basefoundry/$component/releases/tag/$tag" \
+                "Parent: basefoundry/base#2119" \
+                "" \
+                "## Validation" \
+                "" \
+                "The downstream repository's required validation workflow must pass before merge." \
+                "" \
+                "## Notes" \
+                "" \
+                "The release pin is intentionally updated in the documented source, CI, and test contract together.")"
+              issue_url="$(gh issue create --repo "$TARGET_REPOSITORY" --label ci --title "$issue_title" --body "$issue_body")"
+              issue_number="${issue_url##*/}"
+              [[ "$issue_number" =~ ^[0-9]+$ ]] || {
+                echo "::error::Could not parse issue number from $issue_url"
+                exit 1
+              }
+            fi
 
             clone_dir="$(mktemp -d)"
             gh repo clone "$TARGET_REPOSITORY" "$clone_dir" -- --depth 1
@@ -221,6 +250,7 @@ jobs:
             if git -C "$clone_dir" diff --quiet; then
               gh issue close "$issue_number" --repo "$TARGET_REPOSITORY" \
                 --comment "No files required an update; the downstream pin already matches $tag at $ref_input."
+              issue_number=""
               echo "$component $tag is already current in $TARGET_REPOSITORY."
               continue
             fi
@@ -255,4 +285,5 @@ jobs:
             pr_url="$(gh pr create --repo "$TARGET_REPOSITORY" --base main --head "$branch" \
               --title "$issue_title" --body "$pr_body")"
             echo "Opened $pr_url"
+            issue_number=""
           done

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -128,9 +128,11 @@ Each run resolves the published `vX.Y.Z` tag to its full commit. Base bumps
 also resolve and record the `install.sh` SHA-256. The generated PR updates the
 downstream source, CI, documentation, and test assertions as one fail-closed
 change; a `base-cli` bump refreshes `uv.lock`. A marker containing the
-component, version, and commit makes reruns idempotent. The workflow never
-merges or force-updates a downstream branch; the downstream checks and normal
-review remain the merge gate.
+component, version, and commit is deduplicated across downstream issues and
+pull requests. If a run fails after issue creation, it comments the failure on
+the preserved issue; a retry reuses that issue and repairs the partial state.
+The workflow never merges or force-updates a downstream branch; the downstream
+checks and normal review remain the merge gate.
 
 Cross-repository writes require the explicitly configured
 `BASE_DOWNSTREAM_TOKEN` Actions secret. It must be limited to the known

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -188,6 +188,10 @@ def test_downstream_version_bumps_are_release_triggered_idempotent_and_review_ga
     assert "gh auth setup-git" in run_commands
     assert "base-release-bump:" in run_commands
     assert "gh issue create" in run_commands
+    assert "repos/$TARGET_REPOSITORY/issues?state=all&per_page=100" in run_commands
+    assert "gh issue reopen" in run_commands
+    assert "gh issue comment" in run_commands
+    assert "trap cleanup_issue_on_failure EXIT" in run_commands
     assert "gh pr create" in run_commands
     assert "uv lock --upgrade-package base-cli" in run_commands
     assert 'git -C "$clone_dir" push --set-upstream origin' in run_commands


### PR DESCRIPTION
## Summary

- Deduplicate the stable marker across all downstream issues and pull requests.
- Reopen and reuse an existing marked issue when a previous run stopped before PR publication.
- Comment actionable failure guidance on a preserved issue so retries can repair partial state.
- Document the retry policy and retain the no-diff close path.

## Issue

Fixes #2189

## Validation

- `bash -n .github/workflows/downstream-version-bumps.yml`
- `env -u BASE_HOME BASE_CACHE_DIR=/private/tmp/base-issue-2189-cache PYTHONPATH=lib/python:cli/python /Users/rameshhp/.base.d/base/.venv/bin/python -m pytest -q tests/test_github_workflows.py tests/test_downstream_version_bump.py`
- 46 passed
- `git diff --check`

## Docs Impact

Documented the cross-issue/PR marker lookup and preserved-issue retry policy in the release process.