### PR TITLE
fix(setup): isolate pip from sibling source metadata

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup_venv.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_venv.sh
@@ -281,7 +281,7 @@ setup_upgrade_pip_in_virtualenv() {
     }
 
     base_std_log_info "Upgrading pip in the $description virtual environment."
-    "$python_bin" -m pip install --disable-pip-version-check --upgrade pip || {
+    env -u PYTHONPATH "$python_bin" -m pip install --disable-pip-version-check --upgrade pip || {
         base_std_log_error "Unable to upgrade pip in the $description virtual environment."
         return 1
     }
@@ -325,7 +325,7 @@ setup_base_python_package_installed() {
     setup_ensure_cached_paths
     venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
     python_bin="$(setup_base_venv_python_bin "$venv_dir")" || return 1
-    "$python_bin" -m pip show "$package" >/dev/null 2>&1
+    env -u PYTHONPATH "$python_bin" -m pip show "$package" >/dev/null 2>&1
 }
 
 setup_install_base_python_package() {
@@ -348,7 +348,7 @@ setup_install_base_python_package() {
     python_bin="$(setup_base_venv_python_bin "$venv_dir")" || base_std_fatal_error "Base virtual environment Python was not found at '$venv_dir/bin/python'. $(setup_recovery_venv)"
 
     base_std_log_info "Installing Python package '$package' in the Base virtual environment."
-    "$python_bin" -m pip install --disable-pip-version-check "$package" ||
+    env -u PYTHONPATH "$python_bin" -m pip install --disable-pip-version-check "$package" ||
         base_std_fatal_error "Unable to install Python package '$package' in the Base virtual environment."
 }
 

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -519,6 +519,10 @@ EOF
     : > "$venv_dir/pyvenv.cfg"
     cat > "$venv_dir/bin/python" <<'EOF'
 #!/usr/bin/env bash
+if [[ -n "${PYTHONPATH:-}" ]]; then
+    printf 'pip subprocess inherited PYTHONPATH: %s\n' "$PYTHONPATH" >&2
+    exit 1
+fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
     exit 1
 fi
@@ -533,6 +537,7 @@ EOF
 
     run env \
         HOME="$TEST_HOME" \
+        PYTHONPATH="$TEST_TMPDIR/stale-source-provider" \
         PATH="$TEST_MOCKBIN:$TEST_BASH_BIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
         OSTYPE=darwin24 \
         BASE_HOME="$BASE_REPO_ROOT" \

--- a/cli/python/base_setup/process.py
+++ b/cli/python/base_setup/process.py
@@ -59,6 +59,20 @@ def command_exists(name: str) -> bool:
     return shutil.which(name) is not None
 
 
+def python_package_environment() -> dict[str, str]:
+    """Return an environment for package-manager subprocesses.
+
+    Base may add source-only providers such as a sibling ``base-cli`` checkout
+    to ``PYTHONPATH`` while running its control-plane packages.  pip must not
+    treat those source paths as installed distributions when it reconciles or
+    probes a virtual environment.
+    """
+
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    return environment
+
+
 def run_check(
     command: list[str],
     cwd: Path | None = None,

--- a/cli/python/base_setup/python_artifacts.py
+++ b/cli/python/base_setup/python_artifacts.py
@@ -95,7 +95,7 @@ def reconcile_python_artifacts(
     ctx.log.info("Installing Python artifacts into project virtual environment: %s.", names)
     command = pip_install_command(python_bin, requirements)
     try:
-        process.run_command(ctx, command)
+        process.run_command(ctx, command, env=process.python_package_environment())
     except ArtifactError as exc:
         if len(missing) == 1:
             raise
@@ -202,7 +202,11 @@ def reconcile_python_artifacts_sequential(
             )
             continue
         ctx.log.info("Installing Python artifact '%s' into project virtual environment.", definition.name)
-        process.run_command(ctx, pip_install_command(python_bin, (requirement,)))
+        process.run_command(
+            ctx,
+            pip_install_command(python_bin, (requirement,)),
+            env=process.python_package_environment(),
+        )
 
 
 def python_package_requirement(definition: ArtifactDefinition, version: str) -> str:
@@ -227,6 +231,7 @@ def python_artifact_installed(python_bin: Path, package: str, version: str) -> b
     try:
         completed = subprocess.run(
             command,
+            env=process.python_package_environment(),
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             text=True,

--- a/cli/python/base_setup/test_requirements.py
+++ b/cli/python/base_setup/test_requirements.py
@@ -195,7 +195,19 @@ def reconcile_test_requirements(ctx: base_cli.Context, manifest: BaseManifest, d
         path.relative_to(route.project_root),
         route.project_venv_dir,
     )
-    process.run_command(ctx, command, cwd=route.project_root)
+    process.run_command(
+        ctx,
+        command,
+        cwd=route.project_root,
+        env=process.python_package_environment(),
+    )
+
+    check = check_test_requirements(manifest)
+    if check is not None and not check.ok:
+        raise ArtifactError(
+            f"Test requirements installation completed, but verification failed: {check.message} "
+            f"Fix: {check.fix}"
+        )
 
 
 __all__ = [

--- a/cli/python/base_setup/tests/test_artifact_probe_timeouts.py
+++ b/cli/python/base_setup/tests/test_artifact_probe_timeouts.py
@@ -20,6 +20,7 @@ def test_python_artifact_installed_passes_timeout_to_pip_show(tmp_path: Path) ->
     with mock.patch("base_setup.python_artifacts.subprocess.run", return_value=completed) as run:
         assert artifacts.python_artifact_installed(python_bin, "requests", "2.32.4")
 
+    assert "PYTHONPATH" not in run.call_args.kwargs["env"]
     assert run.call_args.kwargs["timeout"] == artifacts.PYTHON_ARTIFACT_PROBE_TIMEOUT_SECONDS
 
 

--- a/cli/python/base_setup/tests/test_artifacts.py
+++ b/cli/python/base_setup/tests/test_artifacts.py
@@ -776,6 +776,7 @@ class ArtifactReconcileTests(unittest.TestCase):
                 "--disable-pip-version-check",
                 "requests",
             ],
+            env=mock.ANY,
         )
 
     def test_reconcile_artifacts_batches_python_installs(self) -> None:
@@ -818,6 +819,7 @@ class ArtifactReconcileTests(unittest.TestCase):
                 "click==8.4.1",
                 "requests",
             ],
+            env=mock.ANY,
         )
 
     def test_reconcile_artifacts_retries_python_installs_sequentially_after_batch_failure(self) -> None:
@@ -864,6 +866,7 @@ class ArtifactReconcileTests(unittest.TestCase):
                         "click==8.4.1",
                         "requests",
                     ],
+                    env=mock.ANY,
                 ),
                 mock.call(
                     ctx,
@@ -875,6 +878,7 @@ class ArtifactReconcileTests(unittest.TestCase):
                         "--disable-pip-version-check",
                         "click==8.4.1",
                     ],
+                    env=mock.ANY,
                 ),
                 mock.call(
                     ctx,
@@ -886,6 +890,7 @@ class ArtifactReconcileTests(unittest.TestCase):
                         "--disable-pip-version-check",
                         "requests",
                     ],
+                    env=mock.ANY,
                 ),
             ],
         )

--- a/cli/python/base_setup/tests/test_python_version_artifacts.py
+++ b/cli/python/base_setup/tests/test_python_version_artifacts.py
@@ -54,9 +54,11 @@ class PythonVersionArtifactTests(unittest.TestCase):
                         "--disable-pip-version-check",
                         "requests",
                     ],
+                    env=mock.ANY,
                 ),
             ],
         )
+        self.assertNotIn("PYTHONPATH", run_command.call_args_list[1].kwargs["env"])
 
     def test_python_artifact_rejects_existing_venv_with_wrong_python_version(self) -> None:
         definition = get_artifact_definition("python-package", "requests")

--- a/cli/python/base_setup/tests/test_test_requirements.py
+++ b/cli/python/base_setup/tests/test_test_requirements.py
@@ -5,6 +5,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from base_setup.checks import ArtifactCheck
+from base_setup.errors import ArtifactError
 from base_setup.manifest import read_manifest
 from base_setup.manifest_model import BaseManifest
 from base_setup.manifest_model import TestConfig as ManifestTestConfig
@@ -139,3 +141,63 @@ class TestRequirementsTests(unittest.TestCase):
             ],
             cwd=expected_root,
         )
+
+    def test_reconcile_installs_without_source_provider_and_verifies_result(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            requirements_path = root / "requirements-dev.txt"
+            requirements_path.write_text("jsonschema==4.25.1\n", encoding="utf-8")
+            python_bin = root / ".venv" / "bin" / "python"
+            python_bin.parent.mkdir(parents=True)
+            python_bin.touch()
+            manifest = self.write_manifest(root)
+            ctx = fake_context()
+
+            with (
+                mock.patch.dict("os.environ", {"PYTHONPATH": "/stale/source/provider"}),
+                mock.patch("base_setup.test_requirements.process.run_command") as run_command,
+                mock.patch("base_setup.test_requirements.check_test_requirements", return_value=None) as check,
+            ):
+                reconcile_test_requirements(ctx, manifest, dry_run=False)
+
+        expected_root = root.resolve()
+        expected_python_bin = expected_root / ".venv" / "bin" / "python"
+        run_command.assert_called_once_with(
+            ctx,
+            [
+                str(expected_python_bin),
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "-r",
+                str(requirements_path.resolve()),
+            ],
+            cwd=expected_root,
+            env=mock.ANY,
+        )
+        self.assertNotIn("PYTHONPATH", run_command.call_args.kwargs["env"])
+        check.assert_called_once_with(manifest)
+
+    def test_reconcile_reports_failed_postflight_verification(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "requirements-dev.txt").write_text("jsonschema==4.25.1\n", encoding="utf-8")
+            python_bin = root / ".venv" / "bin" / "python"
+            python_bin.parent.mkdir(parents=True)
+            python_bin.touch()
+            manifest = self.write_manifest(root)
+            failed_check = ArtifactCheck(
+                name="test requirements environment",
+                ok=False,
+                message="jsonschema==4.25.1 is missing",
+                fix="Run 'basectl setup demo'",
+                finding_id="BASE-P181",
+            )
+
+            with (
+                mock.patch("base_setup.test_requirements.process.run_command"),
+                mock.patch("base_setup.test_requirements.check_test_requirements", return_value=failed_check),
+            ):
+                with self.assertRaisesRegex(ArtifactError, "verification failed: jsonschema==4.25.1 is missing"):
+                    reconcile_test_requirements(fake_context(), manifest, dry_run=False)


### PR DESCRIPTION
## Summary

- Isolate Base pip installs and probes from source-only providers on PYTHONPATH.
- Verify test requirements after installation.
- Add Python and BATS regression coverage for stale sibling base-cli metadata.

## Issue

Fixes #2194

## Validation

- Full Python gate: 1,250 passed.
- Focused setup Python tests: 65 passed, 23 subtests.
- Setup BATS suites: 89 passed.
- pylint and shellcheck passed.