### PR TITLE
test: support newer sibling base-cli metadata

### DIFF
--- a/cli/python/base_cli_adapters/tests/test_run_index.py
+++ b/cli/python/base_cli_adapters/tests/test_run_index.py
@@ -38,7 +38,21 @@ class RunIndexTests(unittest.TestCase):
             )
 
         self.assertEqual(status, 0)
-        self.assertEqual(payload, {"version": 1, "bundles": []})
+        self.assertEqual(payload["version"], 1)
+        self.assertEqual(payload["bundles"], [])
+
+        # Newer base-cli providers may add summary metadata while preserving
+        # the stable version and bundles fields. Keep the compatibility test
+        # valid for both the pinned release and a newer sibling checkout.
+        additive_fields = set(payload) - {"version", "bundles"}
+        self.assertTrue(
+            additive_fields <= {"complete", "omitted_bundles"},
+            additive_fields,
+        )
+        if "complete" in payload:
+            self.assertTrue(payload["complete"])
+        if "omitted_bundles" in payload:
+            self.assertEqual(payload["omitted_bundles"], 0)
 
     def test_main_rejects_invalid_arguments(self) -> None:
         self.assertEqual(run_index.main([]), 2)

--- a/tests/test_base_cli_docs.py
+++ b/tests/test_base_cli_docs.py
@@ -13,6 +13,7 @@ INTERNAL_CONTEXT_FIELDS = {
     "_owns_temp_dir",
     "_owned_temp_identity",
     "_owned_temp_descriptor",
+    "_run_lease",
 }
 
 


### PR DESCRIPTION
## Summary

- make the run-index compatibility test assert stable fields while allowing known additive summary metadata
- classify the newer _run_lease Context field as internal
- keep the contract valid for both pinned and newer sibling base-cli providers

## Root cause

Base intentionally prefers a sibling base-cli source checkout during development. A sibling checkout can be ahead of the pinned base-cli==0.4.3 release, so exact equality against the older payload and documentation field set makes the Base suite fail even though the stable contracts are unchanged.

## Validation

- newer sibling base-cli source provider: 1250 passed, 351 subtests passed
- installed pinned base-cli==0.4.3 provider: 1250 passed, 351 subtests passed
- focused Pylint: passed

Fixes #2197