### PR TITLE
test(release): centralize reusable BOM fixtures

### DIFF
--- a/cli/python/base_release/tests/_bom_fixtures.py
+++ b/cli/python/base_release/tests/_bom_fixtures.py
@@ -8,6 +8,7 @@ from base_release.release_bom import canonical_bom_bytes
 BASE_COMMIT = "a" * 40
 
 
+# pylint: disable=too-many-arguments
 def valid_bom(
     *,
     repository: str = "basefoundry/base",

--- a/cli/python/base_release/tests/_bom_fixtures.py
+++ b/cli/python/base_release/tests/_bom_fixtures.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any
+
+from base_release.release_bom import canonical_bom_bytes
+
+
+BASE_COMMIT = "a" * 40
+
+
+def valid_bom(
+    *,
+    repository: str = "basefoundry/base",
+    version: str = "1.9.0",
+    commit: str = BASE_COMMIT,
+    component_evidence: str = "run://base/123",
+    combination_name: str = "base-release-stack-ubuntu-24.04",
+    combination_evidence: str | None = None,
+) -> dict[str, Any]:
+    if combination_evidence is None:
+        combination_evidence = component_evidence
+    return {
+        "schema_version": 1,
+        "release": {
+            "repository": repository,
+            "version": version,
+            "tag": f"v{version}",
+            "commit": commit,
+        },
+        "components": [
+            {
+                "repository": repository,
+                "version": version,
+                "tag": f"v{version}",
+                "commit": commit,
+                "source_mode": "release",
+                "api_schema_version": "manifest-1",
+                "platforms": ["macos-14", "ubuntu-24.04"],
+                "required": True,
+                "result": "passed",
+                "evidence": component_evidence,
+            },
+            {
+                "repository": "basefoundry/base-cli",
+                "version": "0.4.3",
+                "tag": "v0.4.3",
+                "commit": "b" * 40,
+                "source_mode": "release",
+                "api_schema_version": "base-cli-api@0.4.3",
+                "platforms": ["macos-14", "ubuntu-24.04"],
+                "required": True,
+                "result": "passed",
+                "evidence": "run://base-cli/123",
+            },
+        ],
+        "combinations": [
+            {
+                "name": combination_name,
+                "participants": [repository, "basefoundry/base-cli"],
+                "platform": "ubuntu-24.04",
+                "required": True,
+                "result": "passed",
+                "evidence": combination_evidence,
+            }
+        ],
+    }
+
+
+def valid_bom_bytes(repository: str, version: str, commit: str) -> bytes:
+    return canonical_bom_bytes(
+        valid_bom(
+            repository=repository,
+            version=version,
+            commit=commit,
+            component_evidence="run://release/123",
+            combination_name="release-stack-ubuntu-24.04",
+            combination_evidence="run://release/123",
+        )
+    )

--- a/cli/python/base_release/tests/test_engine.py
+++ b/cli/python/base_release/tests/test_engine.py
@@ -23,7 +23,7 @@ from base_release import release_readiness
 from base_release.engine import ReleaseError
 from base_release.engine import ReleaseFinding
 from base_release.engine import main
-from base_release.release_bom import canonical_bom_bytes
+from base_release.tests._bom_fixtures import valid_bom_bytes
 
 
 READY_FINDINGS = (
@@ -75,55 +75,6 @@ def run_engine(args: list[str], cwd: Path, extra_env: dict[str, str] | None = No
 class TerminalStringIO(io.StringIO):
     def isatty(self) -> bool:
         return True
-
-
-def valid_release_bom_bytes(repository: str, version: str, commit: str) -> bytes:
-    document = {
-        "schema_version": 1,
-        "release": {
-            "repository": repository,
-            "version": version,
-            "tag": f"v{version}",
-            "commit": commit,
-        },
-        "components": [
-            {
-                "repository": repository,
-                "version": version,
-                "tag": f"v{version}",
-                "commit": commit,
-                "source_mode": "release",
-                "api_schema_version": "manifest-1",
-                "platforms": ["macos-14", "ubuntu-24.04"],
-                "required": True,
-                "result": "passed",
-                "evidence": "run://release/123",
-            },
-            {
-                "repository": "basefoundry/base-cli",
-                "version": "0.4.3",
-                "tag": "v0.4.3",
-                "commit": "b" * 40,
-                "source_mode": "release",
-                "api_schema_version": "base-cli-api@0.4.3",
-                "platforms": ["macos-14", "ubuntu-24.04"],
-                "required": True,
-                "result": "passed",
-                "evidence": "run://base-cli/123",
-            },
-        ],
-        "combinations": [
-            {
-                "name": "release-stack-ubuntu-24.04",
-                "participants": [repository, "basefoundry/base-cli"],
-                "platform": "ubuntu-24.04",
-                "required": True,
-                "result": "passed",
-                "evidence": "run://release/123",
-            }
-        ],
-    }
-    return canonical_bom_bytes(document)
 
 
 def add_origin(root: Path) -> None:
@@ -619,7 +570,7 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
             root = Path(tmpdir)
             manifest_path = self.manifest_factory.write_release(root)
             bom_path = root / "candidate-bom.json"
-            bom_bytes = valid_release_bom_bytes("codeforester/demo", "1.2.3", READY_SHA)
+            bom_bytes = valid_bom_bytes("codeforester/demo", "1.2.3", READY_SHA)
             bom_path.write_bytes(bom_bytes)
             commands: list[tuple[list[str], Path | None]] = []
             uploaded_contents: dict[str, bytes] = {}

--- a/cli/python/base_release/tests/test_release_readiness.py
+++ b/cli/python/base_release/tests/test_release_readiness.py
@@ -8,57 +8,12 @@ import pytest
 
 from base_release.release_bom import canonical_bom_bytes
 from base_release.release_readiness import bom_finding
+from base_release.tests._bom_fixtures import BASE_COMMIT, valid_bom
 
 
-BASE_COMMIT = "a" * 40
-
-
-def valid_bom(*, repository: str = "basefoundry/base", version: str = "1.9.0", commit: str = BASE_COMMIT) -> dict:
-    return {
-        "schema_version": 1,
-        "release": {
-            "repository": repository,
-            "version": version,
-            "tag": f"v{version}",
-            "commit": commit,
-        },
-        "components": [
-            {
-                "repository": repository,
-                "version": version,
-                "tag": f"v{version}",
-                "commit": commit,
-                "source_mode": "release",
-                "api_schema_version": "manifest-1",
-                "platforms": ["macos-14", "ubuntu-24.04"],
-                "required": True,
-                "result": "passed",
-                "evidence": "run://base/123",
-            },
-            {
-                "repository": "basefoundry/base-cli",
-                "version": "0.4.3",
-                "tag": "v0.4.3",
-                "commit": "b" * 40,
-                "source_mode": "release",
-                "api_schema_version": "base-cli-api@0.4.3",
-                "platforms": ["macos-14", "ubuntu-24.04"],
-                "required": True,
-                "result": "passed",
-                "evidence": "run://base-cli/123",
-            },
-        ],
-        "combinations": [
-            {
-                "name": "base-release-stack-ubuntu-24.04",
-                "participants": [repository, "basefoundry/base-cli"],
-                "platform": "ubuntu-24.04",
-                "required": True,
-                "result": "passed",
-                "evidence": "run://base/123",
-            }
-        ],
-    }
+def write_bom(path: Path, document: dict) -> Path:
+    path.write_bytes(canonical_bom_bytes(document))
+    return path
 
 
 def release_context(bom_path: Path | None):
@@ -67,11 +22,6 @@ def release_context(bom_path: Path | None):
         release=SimpleNamespace(github=SimpleNamespace(repository="basefoundry/base")),
         version="1.9.0",
     )
-
-
-def write_bom(path: Path, document: dict) -> Path:
-    path.write_bytes(canonical_bom_bytes(document))
-    return path
 
 
 def test_bom_finding_accepts_canonical_bom_bytes(tmp_path: Path) -> None:

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -1,3 +1,5 @@
+# pylint: disable=too-many-lines
+
 import re
 from pathlib import Path
 


### PR DESCRIPTION
Fixes #2207. Follow-up to PR #2176: https://github.com/basefoundry/base/pull/2176. Moves the near-duplicate valid BOM builders into one shared test fixture module while preserving the engine and readiness callers document shapes and configurable release identity. Validation: focused release engine/readiness tests passed (57 passed, 8 subtests); git diff --check passed.