### PR TITLE
test(ci): protect ecosystem BOM peer checkout layout

### DIFF
--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -159,6 +159,9 @@ def test_ecosystem_release_bom_workflow_owns_base_and_required_platform_matrix()
         any(step.get("with", {}).get("path") == ".dependencies/base-demo" for step in job["steps"])
         for job in (compatibility, assemble)
     )
+    assert 'ln -s "$GITHUB_WORKSPACE/.dependencies/base-cli" "$GITHUB_WORKSPACE/../base-cli"' in compatibility_commands
+    assert 'ln -s "$GITHUB_WORKSPACE/.dependencies/base-bash-libs" "$GITHUB_WORKSPACE/../base-bash-libs"' in compatibility_commands
+    assert 'ln -s "$GITHUB_WORKSPACE/.dependencies/base-demo" "$GITHUB_WORKSPACE/../base-demo"' in compatibility_commands
     assert "yaml.safe_load" in run_commands and "Install BOM YAML parser" in str(assemble["steps"])
     assert "--format json --no-notify --yes" in compatibility_commands
     assert 'base_demo_commit="$(git -C "$GITHUB_WORKSPACE/../base-demo" rev-parse HEAD)"' in compatibility_commands

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -1,3 +1,5 @@
+# pylint: disable=too-many-lines
+
 import re
 from pathlib import Path
 
@@ -159,9 +161,14 @@ def test_ecosystem_release_bom_workflow_owns_base_and_required_platform_matrix()
         any(step.get("with", {}).get("path") == ".dependencies/base-demo" for step in job["steps"])
         for job in (compatibility, assemble)
     )
-    assert 'ln -s "$GITHUB_WORKSPACE/.dependencies/base-cli" "$GITHUB_WORKSPACE/../base-cli"' in compatibility_commands
-    assert 'ln -s "$GITHUB_WORKSPACE/.dependencies/base-bash-libs" "$GITHUB_WORKSPACE/../base-bash-libs"' in compatibility_commands
-    assert 'ln -s "$GITHUB_WORKSPACE/.dependencies/base-demo" "$GITHUB_WORKSPACE/../base-demo"' in compatibility_commands
+    assert all(
+        command in compatibility_commands
+        for command in (
+            'ln -s "$GITHUB_WORKSPACE/.dependencies/base-cli" "$GITHUB_WORKSPACE/../base-cli"',
+            'ln -s "$GITHUB_WORKSPACE/.dependencies/base-bash-libs" "$GITHUB_WORKSPACE/../base-bash-libs"',
+            'ln -s "$GITHUB_WORKSPACE/.dependencies/base-demo" "$GITHUB_WORKSPACE/../base-demo"',
+        )
+    )
     assert "yaml.safe_load" in run_commands and "Install BOM YAML parser" in str(assemble["steps"])
     assert "--format json --no-notify --yes" in compatibility_commands
     assert 'base_demo_commit="$(git -C "$GITHUB_WORKSPACE/../base-demo" rev-parse HEAD)"' in compatibility_commands


### PR DESCRIPTION
Fixes #2209. Follow-up to PR #2178: https://github.com/basefoundry/base/pull/2178. Adds workflow-contract assertions for the three compatibility-job peer symlinks required by the Base and base-demo validation steps: base-cli, base-bash-libs, and base-demo. Validation: workflow and BOM-row tests passed (44 passed); git diff --check passed.