### PR TITLE
fix(release): make BOM digest sidecars single-source

### DIFF
--- a/.github/workflows/ecosystem-release-bom.yml
+++ b/.github/workflows/ecosystem-release-bom.yml
@@ -377,10 +377,7 @@ jobs:
             --combination "$(jq -cn --arg evidence "$ubuntu_evidence" '{name:"base-release-stack-ubuntu-24.04",participants:["basefoundry/base","basefoundry/base-cli","basefoundry/base-bash-libs","basefoundry/base-demo"],platform:"ubuntu-24.04",required:true,result:"passed",evidence:$evidence}')" \
             --combination "$(jq -cn --arg evidence "$macos_evidence" '{name:"base-release-stack-macos-14",participants:["basefoundry/base","basefoundry/base-cli","basefoundry/base-bash-libs","basefoundry/base-demo"],platform:"macos-14",required:true,result:"passed",evidence:$evidence}')" \
             --output "$bom"
-          digest="$(./bin/base-release-bom digest "$bom")"
-          actual_digest="$(sha256sum "$bom" | awk '{print $1}')"
-          test "$digest" = "$actual_digest"
-          printf '%s  release-bom.json\n' "$digest" > "$RUNNER_TEMP/base-bom/release-bom.sha256"
+          (cd "$RUNNER_TEMP/base-bom" && sha256sum -c release-bom.sha256)
           cat "$bom"
           cat "$RUNNER_TEMP/base-bom/release-bom.sha256"
 

--- a/cli/python/base_release/release_bom.py
+++ b/cli/python/base_release/release_bom.py
@@ -12,6 +12,7 @@ REPOSITORY_RE = re.compile(r"^[^/\s]+/[^/\s]+$")
 TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+$")
 RESULTS = {"passed", "failed", "not_tested"}
 SOURCE_MODES = {"release", "tag", "moving"}
+DIGEST_LINE_RE = re.compile(r"^(?P<digest>[0-9a-f]{64})  (?P<name>[^/\n]+)$")
 
 
 class ReleaseBomError(ValueError):
@@ -162,6 +163,39 @@ def canonical_bom_bytes(document: dict[str, Any]) -> bytes:
 
 def bom_digest(document: dict[str, Any]) -> str:
     return hashlib.sha256(canonical_bom_bytes(document)).hexdigest()
+
+
+def bom_digest_sidecar_path(bom_path: Path) -> Path:
+    """Return the stable sidecar path for a BOM output path."""
+    if bom_path.suffix == ".json":
+        return bom_path.with_suffix(".sha256")
+    return bom_path.with_name(f"{bom_path.name}.sha256")
+
+
+def write_bom_digest_sidecar(bom_path: Path, digest: str | None = None) -> Path:
+    """Write the BOM's SHA-256 digest and referenced filename to its sidecar."""
+    if digest is None:
+        digest = hashlib.sha256(bom_path.read_bytes()).hexdigest()
+    if not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise ReleaseBomError("BOM digest must be a lowercase 64-character SHA-256 value")
+    sidecar_path = bom_digest_sidecar_path(bom_path)
+    sidecar_path.write_text(f"{digest}  {bom_path.name}\n", encoding="utf-8")
+    return sidecar_path
+
+
+def read_bom_digest_sidecar(bom_path: Path, *, bom_bytes: bytes | None = None) -> str:
+    """Validate and return a BOM digest sidecar's recorded digest."""
+    sidecar_path = bom_digest_sidecar_path(bom_path)
+    line = sidecar_path.read_text(encoding="utf-8").strip("\n")
+    match = DIGEST_LINE_RE.fullmatch(line)
+    if match is None or match.group("name") != bom_path.name:
+        raise ReleaseBomError(
+            f"BOM digest sidecar {sidecar_path} must contain '<sha256>  {bom_path.name}'"
+        )
+    actual_digest = hashlib.sha256(bom_bytes if bom_bytes is not None else bom_path.read_bytes()).hexdigest()
+    if match.group("digest") != actual_digest:
+        raise ReleaseBomError(f"BOM digest sidecar {sidecar_path} does not match {bom_path}")
+    return match.group("digest")
 
 
 def _mapping(document: dict[str, Any], key: str) -> dict[str, Any]:

--- a/cli/python/base_release/release_bom_cli.py
+++ b/cli/python/base_release/release_bom_cli.py
@@ -5,7 +5,14 @@ import json
 import sys
 from pathlib import Path
 
-from .release_bom import ReleaseBomError, bom_digest, canonical_bom_bytes, load_bom, validate_bom
+from .release_bom import (
+    ReleaseBomError,
+    bom_digest,
+    canonical_bom_bytes,
+    load_bom,
+    validate_bom,
+    write_bom_digest_sidecar,
+)
 
 EXIT_SUCCESS = 0
 EXIT_FAILURE = 1
@@ -78,11 +85,7 @@ def main() -> int:
             assembled = assemble(args)
             args.output.parent.mkdir(parents=True, exist_ok=True)
             args.output.write_bytes(canonical_bom_bytes(assembled))
-            digest_path = args.output.with_suffix(".sha256")
-            digest_path.write_text(
-                f"{bom_digest(assembled)}  {args.output.name}\n",
-                encoding="utf-8",
-            )
+            digest_path = write_bom_digest_sidecar(args.output, bom_digest(assembled))
             print(f"release BOM assembled and validated: {args.output}")
             print(f"sha256: {bom_digest(assembled)}")
             print(f"digest sidecar: {digest_path}")

--- a/cli/python/base_release/release_publish.py
+++ b/cli/python/base_release/release_publish.py
@@ -12,6 +12,7 @@ from urllib.parse import quote
 import base_cli
 from base_setup import process
 
+from .release_bom import ReleaseBomError, read_bom_digest_sidecar
 from .release_model import ReleaseContext, ReleaseError
 from .release_readiness import last_non_empty_line
 
@@ -275,13 +276,20 @@ def write_temp_release_notes(notes: str) -> Path:
 
 
 def write_release_bom_assets(bom_path: Path, directory: Path) -> tuple[Path, Path]:
-    """Copy a validated BOM to stable asset names and write its byte digest."""
+    """Copy a validated BOM to stable asset names and reuse its digest sidecar."""
     bom_bytes = bom_path.read_bytes()
+    try:
+        digest = read_bom_digest_sidecar(bom_path, bom_bytes=bom_bytes)
+    except FileNotFoundError:
+        # Keep direct canonical-BOM callers working when they predate assemble's sidecar.
+        digest = hashlib.sha256(bom_bytes).hexdigest()
+    except ReleaseBomError as exc:
+        raise ReleaseError(f"Release BOM digest sidecar is invalid: {exc}") from exc
     bom_asset = directory / RELEASE_BOM_ASSET_NAME
     digest_asset = directory / RELEASE_BOM_DIGEST_ASSET_NAME
     bom_asset.write_bytes(bom_bytes)
     digest_asset.write_text(
-        f"{hashlib.sha256(bom_bytes).hexdigest()}  {RELEASE_BOM_ASSET_NAME}\n",
+        f"{digest}  {RELEASE_BOM_ASSET_NAME}\n",
         encoding="utf-8",
     )
     return bom_asset, digest_asset

--- a/cli/python/base_release/tests/test_engine.py
+++ b/cli/python/base_release/tests/test_engine.py
@@ -621,6 +621,10 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
             bom_path = root / "candidate-bom.json"
             bom_bytes = valid_release_bom_bytes("codeforester/demo", "1.2.3", READY_SHA)
             bom_path.write_bytes(bom_bytes)
+            bom_path.with_suffix(".sha256").write_text(
+                f"{hashlib.sha256(bom_bytes).hexdigest()}  {bom_path.name}\n",
+                encoding="utf-8",
+            )
             commands: list[tuple[list[str], Path | None]] = []
             uploaded_contents: dict[str, bytes] = {}
 
@@ -685,6 +689,23 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
             ("release-bom.json", "release-bom.sha256"),
         )
         self.assertIn("release-bom.json", stdout)
+
+
+    def test_publish_rejects_a_mismatched_bom_digest_sidecar(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            bom_path = root / "candidate-bom.json"
+            bom_bytes = valid_release_bom_bytes("codeforester/demo", "1.2.3", READY_SHA)
+            bom_path.write_bytes(bom_bytes)
+            bom_path.with_suffix(".sha256").write_text(
+                f"{'0' * 64}  {bom_path.name}\n",
+                encoding="utf-8",
+            )
+            asset_directory = root / "assets"
+            asset_directory.mkdir()
+
+            with self.assertRaisesRegex(ReleaseError, "digest sidecar is invalid"):
+                release_publish.write_release_bom_assets(bom_path, asset_directory)
 
 
     def test_publish_yes_reports_recovery_when_github_release_create_fails_after_tag_push(self) -> None:

--- a/cli/python/base_release/tests/test_release_bom.py
+++ b/cli/python/base_release/tests/test_release_bom.py
@@ -8,8 +8,16 @@ from pathlib import Path
 
 import pytest
 
-from base_release.release_bom import ReleaseBomError, bom_digest, validate_bom
-from base_release.release_bom import load_bom, validate_bom_file
+from base_release.release_bom import (
+    ReleaseBomError,
+    bom_digest,
+    bom_digest_sidecar_path,
+    load_bom,
+    read_bom_digest_sidecar,
+    validate_bom,
+    validate_bom_file,
+    write_bom_digest_sidecar,
+)
 from base_release.release_bom_cli import main
 
 
@@ -208,6 +216,21 @@ def test_assemble_writes_bytes_matching_reported_digest(tmp_path: Path, monkeypa
     assert (tmp_path / "release-bom.sha256").read_text(encoding="utf-8") == (
         f"{bom_digest(load_bom(output_path))}  release-bom.json\n"
     )
+
+
+def test_digest_sidecar_uses_unambiguous_path_and_rejects_mismatches(tmp_path: Path) -> None:
+    output_path = tmp_path / "bom.tar.gz"
+    output_path.write_bytes(b"canonical BOM bytes\n")
+
+    sidecar_path = write_bom_digest_sidecar(output_path)
+
+    assert sidecar_path == bom_digest_sidecar_path(output_path)
+    assert sidecar_path.name == "bom.tar.gz.sha256"
+    assert read_bom_digest_sidecar(output_path) == hashlib.sha256(output_path.read_bytes()).hexdigest()
+
+    sidecar_path.write_text(f"{'0' * 64}  bom.tar.gz\n", encoding="utf-8")
+    with pytest.raises(ReleaseBomError, match="does not match"):
+        read_bom_digest_sidecar(output_path)
 
 
 def test_duplicate_component_and_unknown_participant_are_rejected() -> None:

--- a/docs/release-bom.md
+++ b/docs/release-bom.md
@@ -52,8 +52,9 @@ bin/base-release-bom digest path/to/release-bom.json
 For Base 1.9.0, the release coordinator assembles rows for Base, base-cli,
 base-bash-libs, and base-demo. The required release-stack combinations are
 tested on Ubuntu 24.04 and macOS 14; both must report `passed`. Each combination
-is a JSON object. Assembly writes canonical deterministic bytes, so the printed
-digest matches `sha256sum` of the attached BOM artifact:
+is a JSON object. Assembly writes canonical deterministic bytes and a matching
+digest sidecar, so the sidecar can be verified directly with `sha256sum` and
+the printed digest matches the attached BOM artifact:
 
 ```bash
 bin/base-release-bom assemble \
@@ -81,9 +82,11 @@ the BOM is missing, invalid, or does not match the reviewed release identity.
 The supplied BOM must be the exact canonical artifact produced by `assemble`;
 pretty-printed or hand-edited JSON is rejected so its byte digest remains bound
 to the reviewed artifact. `assemble` writes a matching `*.sha256` sidecar next
-to its output. When supplied, `release publish` uploads `release-bom.json` and
-`release-bom.sha256` to the GitHub Release and verifies both assets after
-publication. A BOM is
+to its output. When supplied, `release publish` validates and reuses that
+sidecar, then uploads `release-bom.json` and `release-bom.sha256` to the
+GitHub Release and verifies both assets after publication. Direct callers that
+supply a canonical BOM without a sidecar retain the compatibility fallback of
+having the stable publish asset generated from the BOM bytes. A BOM is
 intentionally opt-in for existing manifests so historical releases remain
 inspectable; Base 1.9.0 is the first Base release that requires this governed
 release path.

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -1,3 +1,5 @@
+# pylint: disable=too-many-lines
+
 import re
 from pathlib import Path
 

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -153,6 +153,8 @@ def test_ecosystem_release_bom_workflow_owns_base_and_required_platform_matrix()
     assert "--repository basefoundry/base-bash-libs" in run_commands
     assert "--repository basefoundry/base-demo" in run_commands
     assert "release-bom.sha256" in run_commands
+    assert "sha256sum -c release-bom.sha256" in run_commands
+    assert "printf '%s  release-bom.json" not in run_commands
     assert "^\u005b0-9a-f\u005d{40}$" in run_commands
     assert "awk -F': '" not in run_commands
     assert all(


### PR DESCRIPTION
Fixes #2208. Follow-up to PR #2177: https://github.com/basefoundry/base/pull/2177. Makes assemble the owner of BOM digest sidecar creation, adds shared sidecar path and validation helpers, removes the workflow digest producer, and makes release publishing validate and reuse a supplied sidecar while retaining a compatibility fallback for direct canonical BOM callers. Stable release asset names remain unchanged. Validation: focused release BOM, release engine, and workflow tests passed (107 passed, 8 subtests); targeted Pylint, Python compilation, and git diff --check passed. The existing test_github_workflows module-length warning remains outside this change.