### PR TITLE
feat: require governed release BOMs when configured

### DIFF
--- a/base_manifest.yaml
+++ b/base_manifest.yaml
@@ -20,6 +20,8 @@ release:
   github:
     repository: basefoundry/base
     release_title: "Base v{version}"
+  bom:
+    required: true
   homebrew:
     required: true
     tap_repository: basefoundry/homebrew-base

--- a/cli/python/base_release/engine.py
+++ b/cli/python/base_release/engine.py
@@ -262,6 +262,8 @@ def release_publish_command(ctx: ReleaseContext, args: ReleaseArguments) -> int:
         print(f"Would create annotated tag: {ctx.tag_name}")
         print(f"Would push tag to origin: {ctx.tag_name}")
         print(f"Would create GitHub Release: {title}")
+        if ctx.release.bom is not None and ctx.release.bom.required:
+            print("Release BOM requirement: required by manifest")
         if ctx.bom_path is not None:
             print("Would upload release assets: release-bom.json, release-bom.sha256")
         print(f"Tag URL: {github_tag_url(ctx.release.github.repository, ctx.tag_name)}")

--- a/cli/python/base_release/release_parser.py
+++ b/cli/python/base_release/release_parser.py
@@ -146,6 +146,7 @@ def print_usage(file: TextIO = sys.stdout) -> None:
 
 Purpose:
   Inspect release readiness and guarded GitHub publishing for a Base-managed
-  project. Homebrew tap changes remain a manual handoff.""",
+  project. A manifest with release.bom.required: true requires --bom for
+  release check and publish. Homebrew tap changes remain a manual handoff.""",
         file=file,
     )

--- a/cli/python/base_release/release_readiness.py
+++ b/cli/python/base_release/release_readiness.py
@@ -46,6 +46,12 @@ def release_findings(
 
 def bom_finding(ctx: ReleaseContext, reviewed_commit: str | None) -> ReleaseFinding:
     if ctx.bom_path is None:
+        if ctx.release.bom is not None and ctx.release.bom.required:
+            return ReleaseFinding(
+                "error",
+                "bom",
+                "Release BOM is required by release.bom.required; pass --bom <path>.",
+            )
         return ReleaseFinding("ok", "bom", "No release BOM was requested for this check.")
     if not ctx.bom_path.is_file():
         return ReleaseFinding("error", "bom", f"Release BOM is missing: {ctx.bom_path}")

--- a/cli/python/base_release/tests/test_engine.py
+++ b/cli/python/base_release/tests/test_engine.py
@@ -420,7 +420,7 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
     def test_publish_dry_run_prints_planned_actions_without_running_commands(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            manifest_path = self.manifest_factory.write_release(root)
+            manifest_path = self.manifest_factory.write_release(root, bom_required=True)
 
             with (
                 mock.patch("base_release.engine.release_findings", return_value=READY_FINDINGS),
@@ -443,8 +443,56 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
         self.assertIn("Would create annotated tag: v1.2.3", stdout)
         self.assertIn("Would push tag to origin: v1.2.3", stdout)
         self.assertIn("Would create GitHub Release: Demo v1.2.3", stdout)
+        self.assertIn("Release BOM requirement: required by manifest", stdout)
         self.assertIn("Homebrew handoff required after GitHub release", stdout)
         run_step.assert_not_called()
+
+    def test_check_blocks_missing_bom_when_manifest_requires_it(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = self.manifest_factory.write_release(root, bom_required=True)
+
+            with mock.patch(
+                "base_release.engine.gh_cli_finding",
+                return_value=ReleaseFinding("ok", "gh", "GitHub CLI is authenticated."),
+            ):
+                status, stdout, stderr = run_engine(
+                    ["check", "--version", "1.2.3", "--manifest", str(manifest_path)],
+                    root,
+                )
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        self.assertIn("error  bom", stdout)
+        self.assertIn("release.bom.required", stdout)
+        self.assertIn("--bom", stdout)
+
+    def test_publish_dry_run_blocks_missing_bom_when_manifest_requires_it(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            manifest_path = self.manifest_factory.write_release(root, bom_required=True)
+
+            with mock.patch(
+                "base_release.engine.gh_cli_finding",
+                return_value=ReleaseFinding("ok", "gh", "GitHub CLI is authenticated."),
+            ):
+                status, stdout, stderr = run_engine(
+                    [
+                        "publish",
+                        "--dry-run",
+                        "--version",
+                        "1.2.3",
+                        "--manifest",
+                        str(manifest_path),
+                    ],
+                    root,
+                )
+
+        self.assertEqual(status, 1)
+        self.assertEqual(stderr, "")
+        self.assertIn("Release publish blocked by readiness findings", stdout)
+        self.assertIn("release.bom.required", stdout)
+        self.assertNotIn("DRY RUN", stdout)
 
     def test_publish_with_invalid_bom_is_blocked_before_git_or_github_mutation(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -646,7 +694,7 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             bom_path = root / "candidate-bom.json"
-            bom_bytes = valid_release_bom_bytes("codeforester/demo", "1.2.3", READY_SHA)
+            bom_bytes = valid_bom_bytes("codeforester/demo", "1.2.3", READY_SHA)
             bom_path.write_bytes(bom_bytes)
             bom_path.with_suffix(".sha256").write_text(
                 f"{'0' * 64}  {bom_path.name}\n",

--- a/cli/python/base_release/tests/test_release_readiness.py
+++ b/cli/python/base_release/tests/test_release_readiness.py
@@ -16,10 +16,13 @@ def write_bom(path: Path, document: dict) -> Path:
     return path
 
 
-def release_context(bom_path: Path | None):
+def release_context(bom_path: Path | None, *, bom_required: bool = False):
     return SimpleNamespace(
         bom_path=bom_path,
-        release=SimpleNamespace(github=SimpleNamespace(repository="basefoundry/base")),
+        release=SimpleNamespace(
+            github=SimpleNamespace(repository="basefoundry/base"),
+            bom=SimpleNamespace(required=bom_required),
+        ),
         version="1.9.0",
     )
 
@@ -51,6 +54,15 @@ def test_bom_finding_accepts_an_unrequested_bom() -> None:
 
     assert finding.status == "ok"
     assert "No release BOM was requested" in finding.message
+
+
+def test_bom_finding_requires_bom_when_manifest_opts_in() -> None:
+    finding = bom_finding(release_context(None, bom_required=True), None)
+
+    assert finding.status == "error"
+    assert finding.name == "bom"
+    assert "release.bom.required" in finding.message
+    assert "--bom" in finding.message
 
 
 @pytest.mark.parametrize(

--- a/cli/python/base_setup/manifest.py
+++ b/cli/python/base_setup/manifest.py
@@ -24,6 +24,7 @@ from base_setup.manifest_model import IdeConfig
 from base_setup.manifest_model import PortHealthConfig
 from base_setup.manifest_model import PythonConfig
 from base_setup.manifest_model import ReleaseConfig  # pylint: disable=unused-import
+from base_setup.manifest_model import ReleaseBomConfig  # pylint: disable=unused-import
 from base_setup.manifest_model import ReleaseGithubConfig  # pylint: disable=unused-import
 from base_setup.manifest_model import ReleaseHomebrewConfig  # pylint: disable=unused-import
 from base_setup.manifest_model import TestConfig

--- a/cli/python/base_setup/manifest_model.py
+++ b/cli/python/base_setup/manifest_model.py
@@ -52,6 +52,11 @@ class ReleaseGithubConfig:
 
 
 @dataclass(frozen=True)
+class ReleaseBomConfig:
+    required: bool = False
+
+
+@dataclass(frozen=True)
 class ReleaseHomebrewConfig:
     required: bool
     tap_repository: str | None = None
@@ -65,6 +70,7 @@ class ReleaseConfig:
     changelog: str
     tag_prefix: str
     github: ReleaseGithubConfig
+    bom: ReleaseBomConfig | None = None
     homebrew: ReleaseHomebrewConfig | None = None
     runner: str | None = None
 

--- a/cli/python/base_setup/manifest_release.py
+++ b/cli/python/base_setup/manifest_release.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from base_setup.manifest_loader import ManifestError
 from base_setup.manifest_model import ReleaseConfig
+from base_setup.manifest_model import ReleaseBomConfig
 from base_setup.manifest_model import ReleaseGithubConfig
 from base_setup.manifest_model import ReleaseHomebrewConfig
 from base_setup.manifest_reader_common import read_optional_runner
@@ -20,7 +21,7 @@ def read_release_config(path: Path, release_data: Any) -> ReleaseConfig | None:
     if not isinstance(release_data, dict):
         raise ManifestError(f"{path}: release must be a mapping when provided.")
 
-    allowed_keys = {"version_file", "changelog", "tag_prefix", "github", "homebrew", "runner"}
+    allowed_keys = {"version_file", "changelog", "tag_prefix", "github", "bom", "homebrew", "runner"}
     unknown_keys = sorted(set(release_data) - allowed_keys)
     if unknown_keys:
         raise ManifestError(f"{path}: release has unsupported keys: {', '.join(unknown_keys)}.")
@@ -37,6 +38,7 @@ def read_release_config(path: Path, release_data: Any) -> ReleaseConfig | None:
     )
     tag_prefix = _read_release_string(path, "release.tag_prefix", release_data.get("tag_prefix", "v"))
     github = _read_release_github(path, release_data.get("github"))
+    bom = _read_release_bom(path, release_data.get("bom"))
     homebrew = _read_release_homebrew(path, release_data.get("homebrew"))
 
     return ReleaseConfig(
@@ -44,6 +46,7 @@ def read_release_config(path: Path, release_data: Any) -> ReleaseConfig | None:
         changelog=changelog,
         tag_prefix=tag_prefix,
         github=github,
+        bom=bom,
         homebrew=homebrew,
         runner=read_optional_runner(path, "release.runner", release_data.get("runner")),
     )
@@ -65,6 +68,23 @@ def _read_release_github(path: Path, github_data: Any) -> ReleaseGithubConfig:
         github_data.get("release_title", "{repository} v{version}"),
     )
     return ReleaseGithubConfig(repository=repository, release_title=release_title)
+
+
+def _read_release_bom(path: Path, bom_data: Any) -> ReleaseBomConfig | None:
+    if bom_data is None:
+        return None
+    if not isinstance(bom_data, dict):
+        raise ManifestError(f"{path}: release.bom must be a mapping when provided.")
+
+    allowed_keys = {"required"}
+    unknown_keys = sorted(set(bom_data) - allowed_keys)
+    if unknown_keys:
+        raise ManifestError(f"{path}: release.bom has unsupported keys: {', '.join(unknown_keys)}.")
+
+    required = bom_data.get("required", False)
+    if not isinstance(required, bool):
+        raise ManifestError(f"{path}: release.bom.required must be a boolean when provided.")
+    return ReleaseBomConfig(required=required)
 
 
 def _read_release_homebrew(path: Path, homebrew_data: Any) -> ReleaseHomebrewConfig | None:

--- a/cli/python/base_setup/tests/test_manifest.py
+++ b/cli/python/base_setup/tests/test_manifest.py
@@ -489,6 +489,8 @@ class ManifestParsingTests(unittest.TestCase):
                         "  github:",
                         "    repository: basefoundry/base",
                         "    release_title: \"Base v{version}\"",
+                        "  bom:",
+                        "    required: true",
                         "  homebrew:",
                         "    required: true",
                         "    tap_repository: basefoundry/homebrew-base",
@@ -511,6 +513,9 @@ class ManifestParsingTests(unittest.TestCase):
         self.assertEqual(manifest.release.github.repository, "basefoundry/base")
         self.assertEqual(manifest.release.github.release_title, "Base v{version}")
         self.assertIsNone(manifest.release.runner)
+        self.assertIsNotNone(manifest.release.bom)
+        assert manifest.release.bom is not None
+        self.assertTrue(manifest.release.bom.required)
         self.assertIsNotNone(manifest.release.homebrew)
         assert manifest.release.homebrew is not None
         self.assertTrue(manifest.release.homebrew.required)
@@ -668,6 +673,7 @@ class ManifestParsingTests(unittest.TestCase):
         self.assertEqual(manifest.release.tag_prefix, "v")
         self.assertEqual(manifest.release.github.repository, "codeforester/demo")
         self.assertEqual(manifest.release.github.release_title, "{repository} v{version}")
+        self.assertIsNone(manifest.release.bom)
         self.assertIsNone(manifest.release.homebrew)
 
 
@@ -687,6 +693,14 @@ class ManifestParsingTests(unittest.TestCase):
             ),
             "empty_tag_prefix": "release:\n  tag_prefix: ''\n  github:\n    repository: basefoundry/base",
             "homebrew_scalar": "release:\n  github:\n    repository: basefoundry/base\n  homebrew: true",
+            "bom_scalar": "release:\n  github:\n    repository: basefoundry/base\n  bom: true",
+            "bom_invalid_required": (
+                "release:\n"
+                "  github:\n"
+                "    repository: basefoundry/base\n"
+                "  bom:\n"
+                "    required: maybe"
+            ),
             "homebrew_required_missing_tap": (
                 "release:\n"
                 "  github:\n"

--- a/conftest.py
+++ b/conftest.py
@@ -106,13 +106,14 @@ class ManifestFactory:
             ],
         )
 
-    def write_release(
+    def write_release(  # pylint: disable=too-many-arguments
         self,
         root: Path,
         *,
         version_file_content: str = "1.2.3\n",
         changelog: str | None = None,
         homebrew: bool = True,
+        bom_required: bool = False,
     ) -> Path:
         """Write a release-ready project with an initial Git commit."""
 
@@ -146,6 +147,8 @@ class ManifestFactory:
             "    repository: codeforester/demo",
             "    release_title: \"Demo v{version}\"",
         ]
+        if bom_required:
+            manifest_lines.extend(["  bom:", "    required: true"])
         if homebrew:
             manifest_lines.extend(
                 [

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -248,10 +248,10 @@ daily project loop commands from the local checkout.
 
 | Command | What it does | Important flags |
 |---|---|---|
-| `basectl release check --version <version>` | Inspect release readiness without publishing. Supports all five report formats; JSON uses the shared v1 inspection envelope. | `--manifest <path>`, `--format <text\|csv\|tsv\|yaml\|json>` |
+| `basectl release check --version <version>` | Inspect release readiness without publishing. Supports all five report formats; JSON uses the shared v1 inspection envelope. Manifests with `release.bom.required: true` also require `--bom <path>`. | `--manifest <path>`, `--bom <path>`, `--format <text\|csv\|tsv\|yaml\|json>` |
 | `basectl release plan --version <version>` | Print the release plan and downstream handoff details. | `--manifest <path>` |
 | `basectl release notes --version <version>` | Extract release notes for the requested version. | `--manifest <path>` |
-| `basectl release publish --version <version>` | Create the annotated Git tag and GitHub Release only after the configured repository, origin fetch/push URLs, live remote default branch, and local full `HEAD` SHA match; recheck before tagging and verify the local, pushed, and GitHub tag SHAs. | `--manifest <path>`, `--dry-run`, `--yes` |
+| `basectl release publish --version <version>` | Create the annotated Git tag and GitHub Release only after the configured repository, origin fetch/push URLs, live remote default branch, and local full `HEAD` SHA match; recheck before tagging and verify the local, pushed, and GitHub tag SHAs. Manifests with `release.bom.required: true` also require `--bom <path>`. | `--manifest <path>`, `--bom <path>`, `--dry-run`, `--yes` |
 | `basectl docs` | Open the Base documentation home page on GitHub. | `--show-url` |
 | `basectl export-context [project]` | Export a project's `.ai-context/` directory as Markdown or Zip. | `--workspace <path>`, `--format <markdown\|zip>`, `--output <path>`, `--print`, `--list-files` |
 | `basectl prompt list` | List repo-owned Markdown prompts that Base can render for AI-assisted workflows. | none |
@@ -1153,12 +1153,12 @@ See [docs/local-config.md](local-config.md).
 Inspect release readiness for a Base-managed repository with:
 
 ```bash
-basectl release check --version 1.9.0
-basectl release check --version 1.9.0 --format json
+basectl release check --version 1.9.0 --bom path/to/release-bom.json
+basectl release check --version 1.9.0 --bom path/to/release-bom.json --format json
 basectl release plan --version 1.9.0
 basectl release notes --version 1.9.0
-basectl release publish --version 1.9.0 --dry-run
-basectl release publish --version 1.9.0 --yes
+basectl release publish --version 1.9.0 --bom path/to/release-bom.json --dry-run
+basectl release publish --version 1.9.0 --bom path/to/release-bom.json --yes
 ```
 
 `basectl release check|plan|notes` are read-only. They validate the manifest

--- a/docs/release-bom.md
+++ b/docs/release-bom.md
@@ -77,8 +77,10 @@ basectl release check --version 1.9.0 \
   --bom path/to/release-bom.json
 ```
 
-`release publish` accepts the same `--bom` option and refuses to publish when
-the BOM is missing, invalid, or does not match the reviewed release identity.
+`release publish` rejects a supplied BOM that is invalid or does not match the
+reviewed release identity. When the manifest sets `release.bom.required: true`,
+it also refuses to publish when `--bom` is missing. Manifests without that
+opt-in retain the backward-compatible optional BOM behavior.
 The supplied BOM must be the exact canonical artifact produced by `assemble`;
 pretty-printed or hand-edited JSON is rejected so its byte digest remains bound
 to the reviewed artifact. `assemble` writes a matching `*.sha256` sidecar next
@@ -86,7 +88,8 @@ to its output. When supplied, `release publish` validates and reuses that
 sidecar, then uploads `release-bom.json` and `release-bom.sha256` to the
 GitHub Release and verifies both assets after publication. Direct callers that
 supply a canonical BOM without a sidecar retain the compatibility fallback of
-having the stable publish asset generated from the BOM bytes. A BOM is
-intentionally opt-in for existing manifests so historical releases remain
-inspectable; Base 1.9.0 is the first Base release that requires this governed
-release path.
+having the stable publish asset generated from the BOM bytes. A BOM remains
+optional for manifests without the opt-in so historical releases remain
+inspectable; Base's own `base_manifest.yaml` requires this governed release
+path. Generate its artifact with the `Ecosystem Release BOM` workflow and pass
+the downloaded `release-bom.json` to both `release check` and `release publish`.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -68,7 +68,11 @@ release-prep PR moves them into a dated release section.
 
 Base-managed repositories can declare a `release:` section in
 `base_manifest.yaml` with the version file, changelog, tag prefix, GitHub
-repository, GitHub Release title, and optional Homebrew handoff metadata.
+repository, GitHub Release title, optional BOM enforcement, and optional
+Homebrew handoff metadata. Set `release.bom.required: true` when the release
+must use the governed cross-repository BOM path. When enabled, both
+`release check` and `release publish` require the exact BOM artifact through
+`--bom`.
 For an existing repository, `basectl repo configure --release --repo
 <owner/name>` adds the generic contract and a missing release guide without
 overwriting an existing declaration or guide. Use `basectl repo check --release`
@@ -101,7 +105,6 @@ Publishing is guarded:
 
 ```bash
 basectl release publish --version X.Y.Z --bom path/to/release-bom.json --dry-run
-basectl release publish --version X.Y.Z
 basectl release publish --version X.Y.Z --bom path/to/release-bom.json --yes
 ```
 
@@ -173,21 +176,41 @@ Complete these steps in `basefoundry/base`:
    `origin/main`. Do not publish from a feature branch, detached checkout,
    ahead/behind/diverged branch, stale remote-tracking ref, or a checkout whose
    `origin` does not match `release.github.repository`.
-7. Dry-run the guarded publish command:
+7. Dispatch the `Ecosystem Release BOM` workflow at the exact reviewed release
+   commit, wait for both required platform jobs to pass, and download the
+   `base-release-bom-X.Y.Z` artifact. Supply the exact component versions and
+   refs selected for this release:
 
    ```bash
-   basectl release publish --version X.Y.Z --dry-run
+   gh workflow run ecosystem-release-bom.yml \
+     --ref main \
+     -f base_version=X.Y.Z \
+     -f base_ref="$(git rev-parse HEAD)" \
+     -f base_cli_version=<version> -f base_cli_ref=<ref> \
+     -f base_bash_libs_version=<version> -f base_bash_libs_ref=<ref> \
+     -f base_demo_version=<version> -f base_demo_ref=<ref>
+   gh run download <run-id> --name base-release-bom-X.Y.Z \
+     --dir /private/tmp/base-release-bom-X.Y.Z
    ```
 
-8. Publish the GitHub-side release artifacts:
+8. Dry-run the guarded publish command with the downloaded BOM:
 
    ```bash
-   basectl release publish --version X.Y.Z
+   basectl release publish --version X.Y.Z \
+     --bom /private/tmp/base-release-bom-X.Y.Z/release-bom.json --dry-run
+   ```
+
+9. Publish the GitHub-side release artifacts with the same immutable BOM:
+
+   ```bash
+   basectl release publish --version X.Y.Z \
+     --bom /private/tmp/base-release-bom-X.Y.Z/release-bom.json
    ```
 
    Use `--yes` only when running from a trusted non-interactive release shell.
 
-9. Confirm the release tag and GitHub Release are visible on GitHub.
+10. Confirm the release tag, GitHub Release, and `release-bom.json` plus
+    `release-bom.sha256` assets are visible on GitHub.
 
 ## Homebrew Tap And Bottle Checklist
 


### PR DESCRIPTION
## Summary

- Add an optional `release.bom.required` manifest contract with a backward-compatible default of `false`.
- Enable the governed BOM requirement in Base's own manifest.
- Block `release check` and `release publish`, including publish dry-run, when a required BOM is omitted; make the dry-run output explicit.
- Document the workflow artifact download and the same BOM path for check, dry-run, and publish.
- Correct an existing release-engine test helper reference exposed by the full gate.

## Issue

Fixes #2170

## Validation

- `./bin/base-test`: 1,257 Python tests and 937 BATS tests passed.
- `tests/contracts/run.sh`: all contract groups passed.
- Focused BOM/release tests: 114 passed, 126 subtests passed.
- Targeted pylint and `git diff --check` passed.

## Docs Impact

Updated `docs/release-process.md`, `docs/release-bom.md`, and `docs/command-reference.md` with the required-BOM contract and the `base-release-bom-X.Y.Z` workflow artifact path.