### PR TITLE
test(release): repair the BOM sidecar regression fixture

### DIFF
--- a/cli/python/base_release/tests/test_engine.py
+++ b/cli/python/base_release/tests/test_engine.py
@@ -646,7 +646,7 @@ class ReleaseEngineTests(unittest.TestCase):  # pylint: disable=too-many-public-
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             bom_path = root / "candidate-bom.json"
-            bom_bytes = valid_release_bom_bytes("codeforester/demo", "1.2.3", READY_SHA)
+            bom_bytes = valid_bom_bytes("codeforester/demo", "1.2.3", READY_SHA)
             bom_path.write_bytes(bom_bytes)
             bom_path.with_suffix(".sha256").write_text(
                 f"{'0' * 64}  {bom_path.name}\n",


### PR DESCRIPTION
## Summary

The mismatched BOM sidecar regression called a fixture name removed during consolidation, so it failed before testing digest validation. Use the already imported shared `valid_bom_bytes` fixture with the existing repository, version, and commit arguments. The regression now reaches the expected invalid-sidecar error.

## Issue

Fixes #2220

## Validation

- Reproduced the undefined fixture failure before the change.
- Release pytest suite: 79 passed, 8 subtests passed.
- Pylint on the changed test module and `git diff --check`: passed.
- Full source-checkout `env -u BASE_HOME ./bin/base-test` with explicit sibling providers: 1,254 Python tests and 937 BATS/integration tests passed.
- All 20 hosted checks passed on the reviewed head.

## Demo Impact

None. This repairs an existing release test.

## Notes

No `.ai-context/` update is needed: this is a test-only fixture correction with no product or release-contract change.
