### PR TITLE
fix(trust): revoke the full project approval history

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -49,7 +49,8 @@ the v1.x compatibility window; new automation should use `--debug-wrapper`.
 - `basectl trust status [project]` - inspect one project's manifest command
   trust or all discovered command-bearing projects.
 - `basectl trust <allow|revoke> <project>` - add or remove local approval for
-  manifest-declared project commands.
+  manifest-declared project commands. Revocation covers every approved contract
+  revision for that canonical checkout and manifest, preserving other checkouts.
 - `basectl prompt <list|name>` - list and render repo-owned Markdown prompts
   for AI-assisted Base workflows. `product-self-review` prints the periodic
   product assessment prompt with current Base metadata, and `--output <path>`

--- a/cli/python/base_trust/engine.py
+++ b/cli/python/base_trust/engine.py
@@ -163,7 +163,11 @@ def revoke_command(ctx: base_cli.Context, project: str, workspace: str | None) -
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
 
-    removed = ManifestCommandTrustStore().revoke(identity)
+    try:
+        removed = ManifestCommandTrustStore().revoke(identity)
+    except OSError as exc:
+        ctx.log.error("Unable to revoke manifest command trust for project '%s': %s", identity.project_name, exc)
+        return base_cli.ExitCode.FAILURE
     if removed:
         print(f"Revoked manifest command trust for project '{identity.project_name}'.")
     else:

--- a/cli/python/base_trust/tests/test_revocation.py
+++ b/cli/python/base_trust/tests/test_revocation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -80,25 +81,31 @@ def test_malformed_identity_record_cannot_remain_an_effective_approval(
     assert not store.status(identity).is_allowed
 
 
-def test_revoke_reports_deletion_errors_without_claiming_success(
-    tmp_path: Path, manifest_factory, monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize("operation", ["delete", "list", "read"])
+def test_revoke_reports_store_errors_without_claiming_success(
+    tmp_path: Path, manifest_factory, monkeypatch: pytest.MonkeyPatch, operation: str,
 ) -> None:
     home = tmp_path / "home"
     workspace = tmp_path / "work"
     identity = engine.compute_trust_identity_for_manifest(manifest_factory.write(workspace / "demo"))
     store = engine.ManifestCommandTrustStore(home)
     record = store.allow(identity, base_version="fixture")
-    unlink = Path.unlink
+    owner, method = (os, "scandir") if operation == "list" else (
+        Path, "unlink" if operation == "delete" else "read_text",
+    )
+    original = getattr(owner, method)
+    denied = store.root if operation == "list" else record
 
     def refuse_record(path, *args, **kwargs):
-        if path == record:
-            raise PermissionError("fixture deletion denied")
-        return unlink(path, *args, **kwargs)
+        if str(path) == str(denied):
+            raise PermissionError("fixture store access denied")
+        return original(path, *args, **kwargs)
 
-    monkeypatch.setattr(Path, "unlink", refuse_record)
-    result = invoke(engine.app, ["revoke", "demo", "--workspace", str(workspace)], home=home)
+    with monkeypatch.context() as patcher:
+        patcher.setattr(owner, method, refuse_record)
+        result = invoke(engine.app, ["revoke", "demo", "--workspace", str(workspace)], home=home)
     assert result.exit_code == 1
     assert "Unable to revoke" in result.stderr
-    assert "fixture deletion denied" in result.stderr
+    assert "fixture store access denied" in result.stderr
     assert "Revoked manifest command trust" not in result.stdout
     assert store.status(identity).is_allowed

--- a/cli/python/base_trust/tests/test_revocation.py
+++ b/cli/python/base_trust/tests/test_revocation.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import pytest
@@ -90,10 +89,8 @@ def test_revoke_reports_store_errors_without_claiming_success(
     identity = engine.compute_trust_identity_for_manifest(manifest_factory.write(workspace / "demo"))
     store = engine.ManifestCommandTrustStore(home)
     record = store.allow(identity, base_version="fixture")
-    owner, method = (os, "scandir") if operation == "list" else (
-        Path, "unlink" if operation == "delete" else "read_text",
-    )
-    original = getattr(owner, method)
+    method = {"list": "iterdir", "delete": "unlink", "read": "read_text"}[operation]
+    original = getattr(Path, method)
     denied = store.root if operation == "list" else record
 
     def refuse_record(path, *args, **kwargs):
@@ -102,7 +99,7 @@ def test_revoke_reports_store_errors_without_claiming_success(
         return original(path, *args, **kwargs)
 
     with monkeypatch.context() as patcher:
-        patcher.setattr(owner, method, refuse_record)
+        patcher.setattr(Path, method, refuse_record)
         result = invoke(engine.app, ["revoke", "demo", "--workspace", str(workspace)], home=home)
     assert result.exit_code == 1
     assert "Unable to revoke" in result.stderr

--- a/cli/python/base_trust/tests/test_revocation.py
+++ b/cli/python/base_trust/tests/test_revocation.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from base_cli.testing import invoke
+from base_trust import engine
+
+
+@pytest.mark.parametrize("revision", ["manifest", "requirements"])
+def test_project_revoke_removes_all_contract_revisions(
+    tmp_path: Path, manifest_factory, revision: str,
+) -> None:
+    home = tmp_path / "home"
+    workspace = tmp_path / "work"
+    manifest = manifest_factory.write(workspace / "demo")
+    manifest.write_text(manifest.read_text().replace(
+        "  command: pytest tests/", "  requirements: requirements.txt\n  command: pytest tests/",
+    ))
+    requirements = manifest.parent / "requirements.txt"
+    original = manifest.read_text()
+    store = engine.ManifestCommandTrustStore(home)
+    contracts = []
+    for index in range(4):
+        manifest.write_text(original + (f"# revision {index}\n" if revision == "manifest" else ""))
+        requirements.write_text(f"fixture=={index if revision == 'requirements' else 0}.0\n")
+        identity = engine.compute_trust_identity_for_manifest(manifest)
+        store.allow(identity, base_version="fixture")
+        contracts.append((manifest.read_text(), requirements.read_text(), identity))
+
+    unrelated = engine.compute_trust_identity_for_manifest(
+        manifest_factory.write(tmp_path / "other-workspace" / "demo"),
+    )
+    store.allow(unrelated, base_version="fixture")
+    result = invoke(engine.app, ["revoke", "demo", "--workspace", str(workspace)], home=home)
+    assert result.exit_code == 0, result.output
+    assert "Revoked manifest command trust" in result.stdout
+    for manifest_text, requirements_text, identity in contracts:
+        manifest.write_text(manifest_text)
+        requirements.write_text(requirements_text)
+        assert not store.status(identity).is_allowed
+        result = invoke(engine.app, ["require", "demo", "--manifest", str(manifest)], home=home)
+        assert result.exit_code == 1, result.output
+    assert store.status(unrelated).is_allowed
+    assert not store.revoke(contracts[-1][2])
+
+
+def test_revoke_preserves_unidentified_records_and_external_symlink_target(
+    tmp_path: Path, manifest_factory,
+) -> None:
+    identity = engine.compute_trust_identity_for_manifest(manifest_factory.write(tmp_path / "demo"))
+    store = engine.ManifestCommandTrustStore(tmp_path / "home")
+    record = store.allow(identity, base_version="fixture")
+    external = tmp_path / "external.json"
+    external.write_bytes(record.read_bytes())
+    alias = store.root / "alias.json"
+    alias.symlink_to(external)
+    invalid_records = [b"[]", b"null", b"{", b"\xff", b'{"schema_version":1,"project":[]}']
+    invalid_paths = []
+    for index, data in enumerate(invalid_records):
+        path = store.root / f"invalid-{index}.json"
+        path.write_bytes(data)
+        invalid_paths.append(path)
+    assert store.revoke(identity)
+    assert not record.exists()
+    assert not alias.is_symlink()
+    assert external.is_file()
+    assert all(path.is_file() for path in invalid_paths)
+
+
+def test_malformed_identity_record_cannot_remain_an_effective_approval(
+    tmp_path: Path, manifest_factory,
+) -> None:
+    identity = engine.compute_trust_identity_for_manifest(manifest_factory.write(tmp_path / "demo"))
+    store = engine.ManifestCommandTrustStore(tmp_path / "home")
+    record = store.allow(identity, base_version="fixture")
+    record.write_text(json.dumps({"schema_version": 1, "project": {"root": "unknown"}}))
+    assert not store.status(identity).is_allowed
+
+
+def test_revoke_reports_deletion_errors_without_claiming_success(
+    tmp_path: Path, manifest_factory, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    workspace = tmp_path / "work"
+    identity = engine.compute_trust_identity_for_manifest(manifest_factory.write(workspace / "demo"))
+    store = engine.ManifestCommandTrustStore(home)
+    record = store.allow(identity, base_version="fixture")
+    unlink = Path.unlink
+
+    def refuse_record(path, *args, **kwargs):
+        if path == record:
+            raise PermissionError("fixture deletion denied")
+        return unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", refuse_record)
+    result = invoke(engine.app, ["revoke", "demo", "--workspace", str(workspace)], home=home)
+    assert result.exit_code == 1
+    assert "Unable to revoke" in result.stderr
+    assert "fixture deletion denied" in result.stderr
+    assert "Revoked manifest command trust" not in result.stdout
+    assert store.status(identity).is_allowed

--- a/cli/python/base_trust/trust_store.py
+++ b/cli/python/base_trust/trust_store.py
@@ -95,9 +95,11 @@ class ManifestCommandTrustStore:
         path = self.record_path(identity)
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+        except (OSError, UnicodeError, json.JSONDecodeError):
             return None
         if not isinstance(payload, dict) or payload.get("schema_version") != SCHEMA_VERSION:
+            return None
+        if identity_key_from_record(payload) != identity.identity_key:
             return None
         return payload
 
@@ -123,7 +125,7 @@ class ManifestCommandTrustStore:
         for path in sorted(self.root.glob("*.json")):
             try:
                 payload = json.loads(path.read_text(encoding="utf-8"))
-            except (OSError, json.JSONDecodeError):
+            except (OSError, UnicodeError, json.JSONDecodeError):
                 continue
             if not isinstance(payload, dict) or payload.get("schema_version") != SCHEMA_VERSION:
                 continue
@@ -157,14 +159,22 @@ class ManifestCommandTrustStore:
 
     def revoke(self, identity: ManifestCommandTrustIdentity) -> bool:
         removed = False
-        paths = [self.record_path(identity)]
-        changed_record = self.find_changed_record(identity)
-        if changed_record is not None:
-            changed_identity_key = identity_key_from_record(changed_record)
-            if changed_identity_key is not None:
-                paths.append(self.root / f"{changed_identity_key}.json")
+        paths = {self.record_path(identity)}
+        for path in self.root.glob("*.json"):
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except (FileNotFoundError, UnicodeError, json.JSONDecodeError):
+                continue
+            if not isinstance(payload, dict) or payload.get("schema_version") != SCHEMA_VERSION:
+                continue
+            project = payload.get("project")
+            if isinstance(project, dict) and project.get("root") == str(identity.project_root) and project.get(
+                "manifest"
+            ) == str(identity.manifest_path):
+                # Unlink the record in this store, never a path from its contents.
+                paths.add(path)
 
-        for path in paths:
+        for path in sorted(paths):
             try:
                 path.unlink()
             except FileNotFoundError:

--- a/cli/python/base_trust/trust_store.py
+++ b/cli/python/base_trust/trust_store.py
@@ -160,7 +160,13 @@ class ManifestCommandTrustStore:
     def revoke(self, identity: ManifestCommandTrustIdentity) -> bool:
         removed = False
         paths = {self.record_path(identity)}
-        for path in self.root.glob("*.json"):
+        try:
+            records = tuple(self.root.iterdir())
+        except FileNotFoundError:
+            return False
+        for path in records:
+            if path.suffix != ".json":
+                continue
             try:
                 payload = json.loads(path.read_text(encoding="utf-8"))
             except (FileNotFoundError, UnicodeError, json.JSONDecodeError):

--- a/docs/manifest-command-trust.md
+++ b/docs/manifest-command-trust.md
@@ -143,6 +143,13 @@ are unchanged.
 supplied `--manifest-sha256` to match when that option is present. That flag is
 useful for scripted, non-interactive approval after a prior review step.
 
+`basectl trust revoke` removes all local approval records for the resolved
+canonical project root and manifest path, including earlier manifest and
+declared test-requirements revisions. Same-named projects in other checkouts
+retain their approvals. Repeating revocation is safe. Unidentified malformed
+records are left untouched and cannot supply a valid approval; a record read
+or deletion failure is reported as an error instead of successful revocation.
+
 When execution is blocked, commands fail before project environment activation
 and before changing into project directories:
 


### PR DESCRIPTION
## Summary

Project-level trust revocation now removes every approval record matching the canonical checkout and manifest, including earlier manifest and declared-requirements revisions. Other checkouts retain their approvals. Malformed identity records cannot authorize commands, and read/deletion errors produce controlled failure diagnostics.

## Issue

Fixes #2223

## Validation

- New regressions cover historical contract identities, unrelated-checkout preservation, malformed records, symlink target preservation, and listing/read/deletion errors. Reproduced the historical revocation failures and the directory-glob permission suppression before their fixes.
- Focused trust suite: 38 passed, 18 subtests passed.
- Pylint for changed Python files and `git diff --check`: passed.
- Full source-checkout suite: 1,261 Python and 937 BATS/integration tests passed. The focused trust suite was rerun after adjusting the directory-error fixture for older Python versions; production code was unchanged by that adjustment.
- All 20 hosted checks passed on the final head, including Python 3.10–3.13.

## Security Notes

Revocation matches canonical project and manifest paths and unlinks only records within the trust store. It does not broaden approval across same-named repositories or change the documented script/Git-state trust boundary. Validation uses synthetic local data.

## Demo Impact

None. Existing trust commands retain their public syntax.

## Notes

Updated the canonical trust guide and `.ai-context/COMMANDS.md` to describe project-wide historical revocation.
