### PR TITLE
fix(setup): make fresh-project previews complete and non-mutating

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -29,7 +29,9 @@ the v1.x compatibility window; new automation should use `--debug-wrapper`.
 - `basectl activate <project>` - start an interactive Base Bash runtime shell
   for a project.
 - `basectl setup [project]` - install and bootstrap the local Base CLI
-  environment and optional project artifacts.
+  environment and optional project artifacts. Project `--dry-run` previews run
+  through Base's interpreter and work before the project virtualenv exists,
+  without creating or recreating that environment.
 - `basectl check [project]` - check Base readiness only by default; pass a
   project name or `--manifest` to also check manifest-declared project
   requirements. It does not install or repair prerequisites, modify project

--- a/cli/bash/commands/basectl/subcommands/setup_project_artifacts.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_project_artifacts.sh
@@ -163,13 +163,12 @@ setup_project_artifact_prepare_bootstrap() {
 setup_project_artifact_handle_unhealthy_venv() {
     local precheck_json
 
+    if [[ "$_BASE_SETUP_PROJECT_ARTIFACT_ACTION" == setup ]] && setup_is_dry_run; then
+        return 0
+    fi
     if [[ "$_BASE_SETUP_PROJECT_ARTIFACT_REQUIRES_PYTHON" == true &&
         "$_BASE_SETUP_PROJECT_ARTIFACT_USES_UV_MANAGER" != true ]] &&
         ! setup_virtualenv_healthy_path "$_BASE_SETUP_PROJECT_ARTIFACT_PROJECT_VENV_DIR"; then
-        if setup_is_dry_run && [[ "$_BASE_SETUP_PROJECT_ARTIFACT_ACTION" == setup ]]; then
-            base_std_log_info "[DRY-RUN] Would run Python project setup layer through base-wrapper for project '$_BASE_SETUP_PROJECT_ARTIFACT_PROJECT'."
-            return 0
-        fi
         if [[ "$_BASE_SETUP_PROJECT_ARTIFACT_OUTPUT_FORMAT" == json ]]; then
             if [[ "$_BASE_SETUP_PROJECT_ARTIFACT_ACTION" == doctor ]]; then
                 precheck_json="$(setup_run_project_pre_venv_layer predoctor json \
@@ -246,7 +245,8 @@ setup_project_artifact_handle_unhealthy_venv() {
 
 setup_project_artifact_execute() {
     if [[ "$_BASE_SETUP_PROJECT_ARTIFACT_USES_UV_MANAGER" == true ||
-        "$_BASE_SETUP_PROJECT_ARTIFACT_REQUIRES_PYTHON" != true ]]; then
+        "$_BASE_SETUP_PROJECT_ARTIFACT_REQUIRES_PYTHON" != true ]] ||
+        { [[ "$_BASE_SETUP_PROJECT_ARTIFACT_ACTION" == setup ]] && setup_is_dry_run; }; then
         env "${_BASE_SETUP_PROJECT_ARTIFACT_PROJECT_ENV_ARGS[@]}" \
             BASE_HOME="$BASE_HOME" \
             BASE_PLATFORM="$_BASE_SETUP_PROJECT_ARTIFACT_PLATFORM" \

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -482,6 +482,8 @@ EOF
     local demo_venv_dir="$TEST_TMPDIR/.venv"
     local inherited_venv="$TEST_TMPDIR/active-base-venv"
     local manifest_path="$TEST_TMPDIR/demo_manifest.yaml"
+    local mode expected_python actual_python
+    local preview_args=()
 
     create_brew_stub
     create_xcode_stubs
@@ -495,19 +497,30 @@ EOF
     create_project_setup_venv_stub "$inherited_venv"
     printf 'project:\n  name: demo\npython: {}\nartifacts: []\n' > "$manifest_path"
 
-    run_base_command \
-        BASE_PROJECT=base \
-        BASE_PROJECT_VENV_DIR="$inherited_venv" \
-        setup --dry-run --manifest "$manifest_path" demo
+    for mode in apply preview; do
+        preview_args=()
+        expected_python="$demo_venv_dir/bin/python"
+        if [[ "$mode" == preview ]]; then
+            preview_args=(--dry-run)
+            expected_python="$base_venv_dir/bin/python"
+        fi
+        : > "$TEST_STATE_DIR/project-setup-python"
+        run_base_command \
+            BASE_PROJECT=base \
+            BASE_PROJECT_VENV_DIR="$inherited_venv" \
+            setup "${preview_args[@]}" --manifest "$manifest_path" demo
 
-    [ "$status" -eq 0 ]
-    [ -f "$TEST_STATE_DIR/project-setup-python" ]
-    actual_python="$(cat "$TEST_STATE_DIR/project-setup-python")"
-    [[ "$actual_python" == *"$demo_venv_dir/bin/python"* ]] || {
-        printf 'actual project setup python: %s\n' "$actual_python" >&3
-        false
-    }
-    [[ "$actual_python" != *"$inherited_venv/bin/python"* ]]
+        [ "$status" -eq 0 ]
+        actual_python="$(cat "$TEST_STATE_DIR/project-setup-python")"
+        [[ "$actual_python" == *"$expected_python"* ]] || {
+            printf 'actual %s setup python: %s\n' "$mode" "$actual_python" >&3
+            false
+        }
+        [[ "$actual_python" != *"$inherited_venv/bin/python"* ]]
+        if [[ "$mode" == preview ]]; then
+            [[ "$actual_python" != *"$demo_venv_dir/bin/python"* ]]
+        fi
+    done
 }
 
 @test "setup installs Base Python packages without pip self-version notices" {

--- a/cli/python/base_setup/test_requirements.py
+++ b/cli/python/base_setup/test_requirements.py
@@ -184,12 +184,15 @@ def reconcile_test_requirements(ctx: base_cli.Context, manifest: BaseManifest, d
     path, _requirements = parsed
     route = route_for_manifest(manifest)
     python_bin = route.project_venv_dir / "bin" / "python"
-    if project_venv_recreate_enabled() or not python_bin.exists():
-        create_project_virtualenv(ctx, route.project_venv_dir, manifest.python.requires_python)
+    needs_venv = project_venv_recreate_enabled() or not python_bin.exists()
     command = [str(python_bin), "-m", "pip", "install", "--disable-pip-version-check", "-r", str(path)]
     if dry_run:
+        if needs_venv:
+            ctx.log.info("[DRY-RUN] Would create project virtual environment at '%s'.", route.project_venv_dir)
         process.dry_run_command(ctx, command, cwd=route.project_root)
         return
+    if needs_venv:
+        create_project_virtualenv(ctx, route.project_venv_dir, manifest.python.requires_python)
     ctx.log.info(
         "Installing project test requirements from '%s' into '%s'.",
         path.relative_to(route.project_root),

--- a/cli/python/base_setup/tests/test_requirements_preview.py
+++ b/cli/python/base_setup/tests/test_requirements_preview.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+import venv
+
+import pytest
+
+from base_setup.manifest import read_manifest
+from base_setup.test_requirements import reconcile_test_requirements
+from base_setup.tests.helpers import fake_context
+
+
+def snapshot(root: Path) -> dict[str, tuple[int, int, bytes | str | None]]:
+    result = {}
+    for path in root.rglob("*"):
+        stat = path.lstat()
+        content = str(path.readlink()) if path.is_symlink() else path.read_bytes() if path.is_file() else None
+        result[str(path.relative_to(root))] = (stat.st_mode, stat.st_mtime_ns, content)
+    return result
+
+
+@pytest.mark.parametrize("state", ["missing", "existing", "recreate"])
+def test_requirements_preview_preserves_real_filesystem(
+    tmp_path: Path, manifest_factory, monkeypatch: pytest.MonkeyPatch, state: str,
+) -> None:
+    manifest_path = manifest_factory.write(tmp_path / "demo")
+    manifest_path.write_text(manifest_path.read_text().replace(
+        "  command:", "  requirements: requirements.txt\n  command:",
+    ))
+    (manifest_path.parent / "requirements.txt").write_text("fixture==1.0\n")
+    venv_path = manifest_path.parent / ".venv"
+    if state != "missing":
+        venv.EnvBuilder(with_pip=False).create(venv_path)
+        (venv_path / "keep.txt").write_text("preserve existing environment\n")
+    for name in ("BASE_PROJECT", "BASE_PROJECT_VENV_DIR", "BASE_SETUP_RECREATE_PROJECT_VENV"):
+        monkeypatch.delenv(name, raising=False)
+    if state == "recreate":
+        monkeypatch.setenv("BASE_SETUP_RECREATE_PROJECT_VENV", "true")
+    before = snapshot(venv_path)
+
+    reconcile_test_requirements(fake_context(), read_manifest(manifest_path), dry_run=True)
+
+    assert snapshot(venv_path) == before
+    assert venv_path.exists() == (state != "missing")

--- a/cli/python/base_setup/tests/test_test_requirements.py
+++ b/cli/python/base_setup/tests/test_test_requirements.py
@@ -127,7 +127,7 @@ class TestRequirementsTests(unittest.TestCase):
 
         expected_root = root.resolve()
         expected_venv = expected_root / ".venv"
-        create_virtualenv.assert_called_once_with(ctx, expected_venv, None)
+        create_virtualenv.assert_not_called()
         dry_run_command.assert_called_once_with(
             ctx,
             [

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -178,6 +178,12 @@ environment is ready. Paths outside the project root, unsupported requirement
 syntax, and uv-managed projects using this field fail closed; uv projects
 should declare test dependencies in `pyproject.toml` and use `uv sync`.
 
+`basectl setup --dry-run --manifest <path>` previews virtualenv creation and
+requirements installation even before the project's virtualenv exists. The
+preview runs through Base's interpreter and does not create, recreate, or
+install into the project environment; `--recreate-venv --dry-run` also preserves
+an existing environment.
+
 Base deliberately uses command-focused BATS regression coverage plus ShellCheck
 as the Bash equivalent instead of a line percentage. Contributors changing a
 public command or runtime branch must add or update a focused BATS assertion,

--- a/tests/integration/base_workflows.bats
+++ b/tests/integration/base_workflows.bats
@@ -245,6 +245,27 @@ run_basectl_separate_stderr() {
     [[ "$output" == *"Base doctor found no blocking issues for project 'demo'."* ]]
 }
 
+@test "fresh project setup preview completes without creating its runtime" {
+    rm -rf "$TEST_PROJECT_ROOT/.venv"
+    cat > "$TEST_PROJECT_ROOT/base_manifest.yaml" <<'YAML'
+project:
+  name: demo
+test:
+  command: 'true'
+  requirements: requirements.txt
+artifacts: []
+YAML
+    printf 'fixture==1.0\n' > "$TEST_PROJECT_ROOT/requirements.txt"
+
+    run_basectl setup --dry-run --manifest "$TEST_PROJECT_ROOT/base_manifest.yaml"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Would create project virtual environment at '$TEST_PROJECT_ROOT/.venv'"* ]]
+    [[ "$output" == *"-r $TEST_PROJECT_ROOT/requirements.txt"* ]]
+    [[ "$output" == *"Project 'demo' setup is complete."* ]]
+    [ ! -e "$TEST_PROJECT_ROOT/.venv" ]
+}
+
 @test "basectl check and doctor emit structured project JSON" {
     run_basectl_separate_stderr check demo --format json
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

Fresh projects can now complete `basectl setup --dry-run` before their virtualenv exists. Setup previews use Base's interpreter and skip project-interpreter health probes. Requirements reconciliation prints virtualenv and pip plans before either mutator can run, preserving existing environments during recreate previews as well.

## Issue

Fixes #2221

## Validation

- Reproduced fresh-preview launcher failure and missing/recreate virtualenv mutation before the fix.
- Requirements pytest: 11 passed, including real filesystem snapshots for missing, existing, and recreate previews.
- Focused setup BATS: 17 passed; new public-launcher integration regression passed.
- Pylint on changed Python files, warning-level ShellCheck on the changed Bash module, and `git diff --check`: passed.
- Full hosted Ubuntu source-checkout suite, macOS smoke tests, and all 20 hosted checks passed on `6d242b7261204931b51b910a89f27a1cd81ddd53`.
- Local full source-checkout suite passed: 1264 Python tests and 938 BATS/integration tests.
- Updated the existing inherited-environment regression to verify both apply and preview runtime selection; it passes locally.

## Demo Impact

None. The existing setup preview command works for fresh projects.

## Notes

Apply-mode runtime ownership is unchanged; the broader redesign remains in #1611. Updated `docs/testing.md` and `.ai-context/COMMANDS.md` for the preview contract.
