### PR TITLE
fix(setup): reject unverified requirement extras

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -39,7 +39,7 @@ the v1.x compatibility window; new automation should use `--debug-wrapper`.
   fixes.
 - `basectl test [project]` - run a project's declared test command. A
   manifest may declare `test.requirements` as a repository-relative direct
-  requirements file; setup installs it, check/doctor report missing or
+  requirements file (package extras are unsupported); setup installs it, check/doctor report missing or
   mismatched packages, and test preflights it before execution.
 - `basectl build [project] [target...]` - run declared build targets for the positional, explicit, or nearest project.
 - `basectl demo [project]` - run a declared interactive demo script.

--- a/cli/python/base_setup/test_requirements.py
+++ b/cli/python/base_setup/test_requirements.py
@@ -21,7 +21,7 @@ from .uv import manifest_uses_uv_project_manager
 TEST_REQUIREMENTS_FILE_FINDING_ID = "BASE-P180"
 TEST_REQUIREMENTS_ENVIRONMENT_FINDING_ID = "BASE-P181"
 _DIRECT_REQUIREMENT_RE = re.compile(
-    r"^(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[A-Za-z0-9_,.-]+\])?"
+    r"^(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)"
     r"(?:(?P<operator>===|==)\s*(?P<version>[A-Za-z0-9][A-Za-z0-9.!+_-]*))?$"
 )
 
@@ -92,13 +92,15 @@ def read_test_requirements(manifest: BaseManifest) -> tuple[Path, tuple[Requirem
         if candidate.startswith(("-", "http://", "https://")):
             raise ArtifactError(
                 f"{path}:{line_number} uses unsupported requirement syntax '{candidate}'. "
-                "Base currently supports direct package names with optional == versions only."
+                "Base currently supports direct package names with optional == versions only; "
+                "package extras are not supported."
             )
         match = _DIRECT_REQUIREMENT_RE.fullmatch(candidate)
         if match is None:
             raise ArtifactError(
                 f"{path}:{line_number} uses unsupported requirement syntax '{candidate}'. "
-                "Base currently supports direct package names with optional == versions only."
+                "Base currently supports direct package names with optional == versions only; "
+                "package extras are not supported."
             )
         requirements.append(
             RequirementSpec(

--- a/cli/python/base_setup/tests/test_requirement_extras.py
+++ b/cli/python/base_setup/tests/test_requirement_extras.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import subprocess
+import venv
+from pathlib import Path
+
+import pytest
+
+from base_setup.errors import ArtifactError
+from base_setup.manifest import read_manifest
+from base_setup.python_artifacts import python_artifact_installed
+from base_setup.test_requirements import check_test_requirements
+from base_setup.test_requirements import read_test_requirements
+
+
+@pytest.mark.parametrize("requirement", [
+    "local-fixture[feature]",
+    "local-fixture[feature]==1.0",
+    "local-fixture[feature,other]==1.0",
+])
+def test_extras_are_rejected_when_only_base_distribution_is_installed(tmp_path, monkeypatch, requirement):
+    for variable in ("BASE_PROJECT", "BASE_PROJECT_ROOT", "BASE_PROJECT_MANIFEST", "BASE_PROJECT_VENV_DIR"):
+        monkeypatch.delenv(variable, raising=False)
+    manifest_path = tmp_path / "base_manifest.yaml"
+    manifest_path.write_text(
+        "project:\n  name: demo\ntest:\n  command: pytest\n  requirements: requirements.txt\nartifacts: []\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "requirements.txt").write_text(requirement + "\n", encoding="utf-8")
+    venv.EnvBuilder(with_pip=True).create(tmp_path / ".venv")
+    python_bin = tmp_path / ".venv" / "bin" / "python"
+    site_packages = Path(subprocess.check_output(
+        [str(python_bin), "-c", "import sysconfig; print(sysconfig.get_paths()['purelib'])"], text=True,
+    ).strip())
+    metadata = site_packages / "local_fixture-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: local-fixture\nVersion: 1.0\nProvides-Extra: feature\n"
+        'Requires-Dist: absent-extra-fixture==9.9; extra == "feature"\n',
+        encoding="utf-8",
+    )
+    assert python_artifact_installed(python_bin, "local-fixture", "1.0")
+    assert not python_artifact_installed(python_bin, "absent-extra-fixture", "latest")
+    manifest = read_manifest(manifest_path)
+
+    check = check_test_requirements(manifest)
+
+    assert check is not None
+    assert not check.ok
+    assert check.finding_id == "BASE-P180"
+    assert "unsupported requirement syntax" in check.message
+    assert "direct package names" in check.message
+    assert "Review test.requirements" in check.fix
+    with pytest.raises(ArtifactError, match="unsupported requirement syntax"):
+        read_test_requirements(manifest)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -170,7 +170,10 @@ test:
 ```
 
 Base supports direct package names with optional exact `==` versions in this
-file. `basectl setup <project>` installs the file into the routed project
+file. Package extras such as `package[feature]==1.0` are unsupported and produce
+`BASE-P180`; Base cannot verify their dependencies from the base distribution
+alone. Declare the required direct packages explicitly, or use the project's
+dependency manager for extras. `basectl setup <project>` installs the file into the routed project
 virtual environment. `basectl check <project>` and `basectl doctor <project>`
 report missing packages as `BASE-P181`, while `basectl test <project>` performs
 the same read-only preflight and does not execute the test command until the

--- a/tests/integration/base_workflows.bats
+++ b/tests/integration/base_workflows.bats
@@ -282,6 +282,27 @@ run_basectl_separate_stderr() {
     grep -Fqx "args=<tests/><-k><focused case>" "$TEST_STATE_DIR/fake-test.out"
 }
 
+@test "basectl test rejects unsupported requirement extras before running tests" {
+    cat > "$TEST_PROJECT_ROOT/base_manifest.yaml" <<'EOF'
+project:
+  name: demo
+test:
+  command: fake-test tests/
+  requirements: requirements.txt
+artifacts: []
+EOF
+    printf 'pip[feature]\n' > "$TEST_PROJECT_ROOT/requirements.txt"
+    run_basectl trust allow demo
+    [ "$status" -eq 0 ]
+
+    run_basectl test demo
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"unsupported requirement syntax 'pip[feature]'"* ]]
+    [[ "$output" == *"direct package names"* ]]
+    [ ! -e "$TEST_STATE_DIR/fake-test.out" ]
+}
+
 @test "basectl update-profile dry-run does not write real shell startup files" {
     run_basectl update-profile --dry-run
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

Requirements containing extras, such as `package[feature]==1.0`, now fail with `BASE-P180` instead of reporting success from the base distribution alone. The supported syntax remains direct package names with optional exact versions, and the error explains that extras are unsupported.

## Issue

Fixes #2228

## Validation

- Reproduced false success with local distribution metadata and an absent extra dependency for unpinned, pinned, and multiple-extra requirements; all three regressions now pass.
- Requirements pytest: 11 passed; public test-preflight regression passed and confirmed the test command did not run.
- Pylint and `git diff --check`: passed.
- Incorporated the merged setup-preview fix from main. All 20 hosted checks passed on `e0bdcd654bd3453320a870089af963ac03aae583`, including full Ubuntu source-checkout validation and macOS smoke tests.
- Local full source-checkout suite passed: 1267 Python tests and 939 BATS/integration tests.

## Demo Impact

None. Existing direct requirements continue to work.

## Notes

Updated `docs/testing.md` and `.ai-context/COMMANDS.md` to make the supported syntax explicit. No dependency installation or resolution was added to preflight.
