### PR TITLE
fix(security): require consent for project runtime inspection

### DIFF
--- a/.ai-context/COMMANDS.md
+++ b/.ai-context/COMMANDS.md
@@ -261,3 +261,14 @@ Important Python packages include:
   provider integration are intentionally out of scope.
 - `base_github_projects` - GitHub Project V2 schema inspection, configuration,
   and issue field updates for Base roadmap metadata.
+
+### Project runtime inspection
+
+Project and workspace `check`/`doctor` use static inspection by default. Present
+project interpreters and installed-package/tool checks remain unverified until
+`--verify-project-runtime` explicitly authorizes executable probes for that
+invocation. Workspace status/onboarding remain static. Neither `--yes` nor saved
+manifest approval grants runtime verification consent. `test` requires manifest
+approval before its requirements preflight. Base-owned Python engines use an
+isolated entry point and the Base interpreter, including from an active project
+checkout. See `docs/manifest-command-trust.md#runtime-verification-consent`.

--- a/bin/base-wrapper
+++ b/bin/base-wrapper
@@ -118,7 +118,11 @@ main() {
     BASE_CLI_RUNTIME_OWNER=base
     export BASE_HOME BASE_PROJECT BASE_CLI_RUNTIME_OWNER
 
-    python_bin="${BASE_PROJECT_VENV_DIR:-$HOME/.base.d/$project/.venv}/bin/python"
+    if [[ "$project" == base ]]; then
+        python_bin="${BASE_SETUP_VENV_DIR:-$HOME/.base.d/base/.venv}/bin/python"
+    else
+        python_bin="${BASE_PROJECT_VENV_DIR:-$HOME/.base.d/$project/.venv}/bin/python"
+    fi
     [[ -x "$python_bin" ]] || base_wrapper_die "Project virtual environment Python was not found at '$python_bin'. Run 'basectl setup'."
 
     base_cli_path="$(base_cli_runtime_source_root)" || base_wrapper_die "Unable to resolve the Base CLI provider."
@@ -136,6 +140,10 @@ main() {
     fi
     export PYTHONPATH
 
+    if [[ "$project" == base && "$package" == base_* ]]; then
+        export BASE_CLI_RUNTIME_SOURCE_ROOT="$base_cli_path"
+        exec "$python_bin" -I "$BASE_HOME/cli/python/base_cli_adapters/module_entrypoint.py" "$package" "$@"
+    fi
     exec "$python_bin" -m "$package" "$@"
 }
 

--- a/cli/bash/commands/basectl/subcommands/check.sh
+++ b/cli/bash/commands/basectl/subcommands/check.sh
@@ -91,7 +91,7 @@ base_check_usage_error() {
 base_check_subcommand_main() {
     local output_format="text"
     local project=""
-    local remote_network=false
+    local remote_network=false verify_project_runtime=false
 
     setup_clear_run_state
 
@@ -143,6 +143,9 @@ base_check_subcommand_main() {
             --remote-network)
                 remote_network=true
                 ;;
+            --verify-project-runtime)
+                verify_project_runtime=true
+                ;;
             -v)
                 setup_enable_debug_logging
                 ;;
@@ -165,6 +168,12 @@ base_check_subcommand_main() {
         base_check_usage_error "Option '--remote-network' requires a project or '--manifest <path>'."
         return $?
     fi
+    if [[ "$verify_project_runtime" == true && -z "$project" && -z "${BASE_SETUP_MANIFEST:-}" ]]; then
+        base_check_usage_error "Option '--verify-project-runtime' requires a project or '--manifest <path>'."
+        return $?
+    fi
+    BASE_SETUP_VERIFY_PROJECT_RUNTIME="$verify_project_runtime"
+    export BASE_SETUP_VERIFY_PROJECT_RUNTIME
     BASE_SETUP_PROJECT_NAME="$project"
     BASE_SETUP_REMOTE_NETWORK="$remote_network"
     export BASE_SETUP_PROJECT_NAME

--- a/cli/bash/commands/basectl/subcommands/check.sh
+++ b/cli/bash/commands/basectl/subcommands/check.sh
@@ -19,7 +19,7 @@ Description:
   --manifest to also check that project's manifest-declared requirements.
 
   Check does not install or repair prerequisites, modify project files, or run
-  project tests.
+  project tests. Project runtime checks remain unverified by default.
 
 Arguments:
   project               Select a Base project by name. Omit it for a Base-only
@@ -33,6 +33,9 @@ Options:
                         Defaults to text.
   --manifest <path>     Use this base_manifest.yaml for project checks. When
                         project is omitted, infer it from manifest project.name.
+  --verify-project-runtime
+                        Authorize execution of reviewed project runtimes and tool
+                        configuration for this invocation.
   --remote-network      Also run a bounded Git origin reachability check.
                         Off by default; requires project or --manifest.
   -v                    Enable DEBUG logging for this subcommand.

--- a/cli/bash/commands/basectl/subcommands/doctor.sh
+++ b/cli/bash/commands/basectl/subcommands/doctor.sh
@@ -20,6 +20,8 @@ Options:
   --format <text|json>  Select output format. Defaults to text.
   --manifest <path>     Use this base_manifest.yaml; infer an omitted project.
   --remote-network      Check project Git origin; requires project or --manifest.
+  --verify-project-runtime
+                        Authorize project runtime/configuration execution for this check.
   --no-color            Disable doctor status colors and symbols in text output.
   -v                    Enable DEBUG logging for this subcommand.
   -h, --help            Show this help text.
@@ -76,7 +78,7 @@ base_doctor_explain_finding() {
         base_std_fatal_error "Python is required to render Base finding explanations."
     setup_ensure_cached_paths
     env BASE_HOME="$BASE_HOME" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
-        "$python_bin" -m base_setup.finding_explanations "$finding_id" --format "$output_format"
+        "$python_bin" -I "$BASE_HOME/cli/python/base_cli_adapters/module_entrypoint.py" base_setup.finding_explanations "$finding_id" --format "$output_format"
 }
 
 base_doctor_explain_main() {
@@ -298,7 +300,7 @@ base_doctor_run_json() {
 
 base_doctor_subcommand_main() {
     local errors=0 output_format="text" profile_errors=0 project=""
-    local remote_network=false
+    local remote_network=false verify_project_runtime=false
 
     setup_clear_run_state
 
@@ -356,6 +358,9 @@ base_doctor_subcommand_main() {
             --remote-network)
                 remote_network=true
                 ;;
+            --verify-project-runtime)
+                verify_project_runtime=true
+                ;;
             --no-color)
                 BASE_SETUP_DOCTOR_NO_COLOR=true
                 export BASE_SETUP_DOCTOR_NO_COLOR
@@ -382,6 +387,12 @@ base_doctor_subcommand_main() {
         base_doctor_usage_error "Option '--remote-network' requires a project or '--manifest <path>'."
         return $?
     fi
+    if [[ "$verify_project_runtime" == true && -z "$project" && -z "${BASE_SETUP_MANIFEST:-}" ]]; then
+        base_doctor_usage_error "Option '--verify-project-runtime' requires a project or '--manifest <path>'."
+        return $?
+    fi
+    BASE_SETUP_VERIFY_PROJECT_RUNTIME="$verify_project_runtime"
+    export BASE_SETUP_VERIFY_PROJECT_RUNTIME
     BASE_SETUP_PROJECT_NAME="$project"
     BASE_SETUP_REMOTE_NETWORK="$remote_network"
     export BASE_SETUP_PROJECT_NAME

--- a/cli/bash/commands/basectl/subcommands/projects.sh
+++ b/cli/bash/commands/basectl/subcommands/projects.sh
@@ -28,7 +28,7 @@ base_projects_usage_error() {
 }
 
 base_projects_base_venv_python() {
-    local venv_dir="${BASE_PROJECT_VENV_DIR:-$HOME/.base.d/base/.venv}"
+    local venv_dir="${BASE_SETUP_VENV_DIR:-$HOME/.base.d/base/.venv}"
 
     printf '%s\n' "$venv_dir/bin/python"
 }
@@ -60,9 +60,11 @@ base_projects_source_python() {
 
     base_std_command_path python_bin python3 || return 1
 
+    base_cli_runtime_prepare || return 1
     base_pythonpath="$(base_projects_source_pythonpath)"
     env BASE_HOME="$BASE_HOME" BASE_PROJECT=base PYTHONPATH="$base_pythonpath" \
-        "$python_bin" -c 'import click; import yaml; import base_projects' >/dev/null 2>&1 || return 1
+        "$python_bin" -I "$BASE_HOME/cli/python/base_cli_adapters/module_entrypoint.py" \
+        base_projects --help >/dev/null 2>&1 || return 1
 
     printf '%s\n' "$python_bin"
 }
@@ -88,9 +90,10 @@ base_projects_run_list() {
     fi
 
     if base_projects_source_checkout_available && python_bin="$(base_projects_source_python)"; then
+        base_cli_runtime_prepare || return 1
         base_pythonpath="$(base_projects_source_pythonpath)"
         env BASE_HOME="$BASE_HOME" BASE_PROJECT=base PYTHONPATH="$base_pythonpath" \
-            "$python_bin" -m base_projects list "$@"
+            "$python_bin" -I "$BASE_HOME/cli/python/base_cli_adapters/module_entrypoint.py" base_projects list "$@"
         return $?
     fi
 

--- a/cli/bash/commands/basectl/subcommands/setup.sh
+++ b/cli/bash/commands/basectl/subcommands/setup.sh
@@ -77,7 +77,7 @@ base_setup_print_ci_json() {
         base_std_fatal_error "Python is required to render Base CI setup JSON."
     setup_ensure_cached_paths
     env BASE_HOME="$BASE_HOME" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
-        "$python_bin" -m base_setup.ci_json setup-json \
+        "$python_bin" -I "$BASE_HOME/cli/python/base_cli_adapters/module_entrypoint.py" base_setup.ci_json setup-json \
         --project "${BASE_SETUP_PROJECT_NAME:-}" \
         --exit-code "$exit_code" \
         --stdout-file "$stdout_file" \

--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -58,7 +58,7 @@ setup_ensure_cached_paths() {
 setup_clear_run_state() {
     # Clear legacy lowercase state too so inherited environments cannot trigger
     # lib_std.sh dry-run behavior unless this command explicitly enables it.
-    unset BASE_BASH_LIBS_DRY_RUN BASE_SETUP_CHECK_STATUS_FILE BASE_SETUP_PROFILE_ERROR BASE_SETUP_PROFILES BASE_SETUP_PROJECT_NAME BASE_SETUP_MANIFEST BASE_SETUP_REMOTE_NETWORK BASE_SETUP_RECREATE_VENV BASE_SETUP_UPGRADE_PIP BASE_SETUP_YES BASE_SETUP_ALLOW_PROJECT_IDE_MUTATIONS
+    unset BASE_BASH_LIBS_DRY_RUN BASE_SETUP_CHECK_STATUS_FILE BASE_SETUP_PROFILE_ERROR BASE_SETUP_PROFILES BASE_SETUP_PROJECT_NAME BASE_SETUP_MANIFEST BASE_SETUP_REMOTE_NETWORK BASE_SETUP_VERIFY_PROJECT_RUNTIME BASE_SETUP_RECREATE_VENV BASE_SETUP_UPGRADE_PIP BASE_SETUP_YES BASE_SETUP_ALLOW_PROJECT_IDE_MUTATIONS
     setup_refresh_cached_paths
 }
 
@@ -496,14 +496,14 @@ setup_diagnostics_python_bin() {
     candidates+=("/usr/bin/python3")
     for candidate in "${candidates[@]}"; do
         if [[ -x "$candidate" ]] && env BASE_HOME="$BASE_HOME" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
-            "$candidate" -c 'import base_setup.diagnostics' >/dev/null 2>&1; then
+            "$candidate" -I "$BASE_HOME/cli/python/base_cli_adapters/module_entrypoint.py" base_setup.diagnostics --help >/dev/null 2>&1; then
             printf '%s\n' "$candidate"
             return 0
         fi
     done
     venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
     if python_bin="$(setup_base_venv_python_bin "$venv_dir")" && env BASE_HOME="$BASE_HOME" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
-        "$python_bin" -c 'import base_setup.diagnostics' >/dev/null 2>&1; then
+        "$python_bin" -I "$BASE_HOME/cli/python/base_cli_adapters/module_entrypoint.py" base_setup.diagnostics --help >/dev/null 2>&1; then
         printf '%s\n' "$python_bin"
         return 0
     fi
@@ -519,7 +519,7 @@ setup_run_diagnostics_json() {
     fi
     setup_ensure_cached_paths
     env BASE_HOME="$BASE_HOME" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
-        "$python_bin" -m base_setup.diagnostics "$@"
+        "$python_bin" -I "$BASE_HOME/cli/python/base_cli_adapters/module_entrypoint.py" base_setup.diagnostics "$@"
 }
 
 setup_base_check_metadata_fallback_finding_id() {
@@ -649,7 +649,7 @@ setup_base_check_metadata() {
     if python_bin="$(setup_diagnostics_python_bin)"; then
         setup_ensure_cached_paths
         if env BASE_HOME="$BASE_HOME" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
-            "$python_bin" -m base_setup.diagnostics base-check-metadata "${args[@]}"; then
+            "$python_bin" -I "$BASE_HOME/cli/python/base_cli_adapters/module_entrypoint.py" base_setup.diagnostics base-check-metadata "${args[@]}"; then
             return 0
         fi
     fi
@@ -670,7 +670,7 @@ setup_resolve_project_manifest() {
             setup_ensure_cached_paths
             protocol_output="$(
                 env BASE_HOME="$BASE_HOME" BASE_PROJECT=base PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
-                    "$python_bin" -m base_projects manifest "$BASE_SETUP_MANIFEST" --format command-protocol
+                    "$python_bin" -I "$BASE_HOME/cli/python/base_cli_adapters/module_entrypoint.py" base_projects manifest "$BASE_SETUP_MANIFEST" --format command-protocol
             )" || return $?
             base_command_protocol_decode_one project-reference "$protocol_output" || return 1
             result_name="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
@@ -691,7 +691,7 @@ setup_resolve_project_manifest() {
             setup_ensure_cached_paths
             protocol_output="$(
                 env BASE_HOME="$BASE_HOME" BASE_PROJECT=base PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
-                    "$python_bin" -m base_projects resolve "$requested_project" --format command-protocol
+                    "$python_bin" -I "$BASE_HOME/cli/python/base_cli_adapters/module_entrypoint.py" base_projects resolve "$requested_project" --format command-protocol
             )" || return 1
             base_command_protocol_decode_one project-route "$protocol_output" || return 1
             result_name="${BASE_COMMAND_PROTOCOL_FIELDS[project_name]}"
@@ -730,7 +730,7 @@ setup_resolve_project_route() {
 
     setup_ensure_cached_paths
     env BASE_HOME="$BASE_HOME" PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
-        "$python_bin" -m base_setup --manifest "$manifest_path" --action route --format command-protocol "$project"
+        "$python_bin" -I "$BASE_HOME/cli/python/base_cli_adapters/module_entrypoint.py" base_setup --manifest "$manifest_path" --action route --format command-protocol "$project"
 }
 
 setup_project_check_record_path() {
@@ -966,7 +966,7 @@ setup_run_project_pre_venv_layer() {
         BASE_PROJECT_MANIFEST="$manifest_path" \
         BASE_PROJECT_VENV_DIR="$project_venv_dir" \
         PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
-        "$python_bin" -m base_setup "${args[@]}"
+        "$python_bin" -I "$BASE_HOME/cli/python/base_cli_adapters/module_entrypoint.py" base_setup "${args[@]}"
 }
 
 setup_run_project_artifact_setup() {
@@ -1019,7 +1019,7 @@ setup_run_project_bootstrap_layer() {
             BASE_PROJECT_VENV_DIR="$project_venv_dir" \
             BASE_SETUP_RECREATE_PROJECT_VENV=true \
             PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
-            "$python_bin" -m base_setup "${args[@]}"
+            "$python_bin" -I "$BASE_HOME/cli/python/base_cli_adapters/module_entrypoint.py" base_setup "${args[@]}"
     else
         env "${project_env_args[@]}" \
             BASE_HOME="$BASE_HOME" \
@@ -1028,7 +1028,7 @@ setup_run_project_bootstrap_layer() {
             BASE_PROJECT_MANIFEST="$manifest_path" \
             BASE_PROJECT_VENV_DIR="$project_venv_dir" \
             PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
-            "$python_bin" -m base_setup "${args[@]}"
+            "$python_bin" -I "$BASE_HOME/cli/python/base_cli_adapters/module_entrypoint.py" base_setup "${args[@]}"
     fi
 }
 

--- a/cli/bash/commands/basectl/subcommands/setup_linux_debian.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_linux_debian.sh
@@ -103,7 +103,7 @@ setup_linux_python_venv_available() {
     local python_bin="$1"
 
     [[ -n "$python_bin" ]] || return 1
-    "$python_bin" -m venv --help >/dev/null 2>&1
+    "$python_bin" -I -m venv --help >/dev/null 2>&1
 }
 
 setup_linux_bash_version_supported() {

--- a/cli/bash/commands/basectl/subcommands/setup_project_artifacts.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_project_artifacts.sh
@@ -111,6 +111,11 @@ setup_project_artifact_build_command() {
         _BASE_SETUP_PROJECT_ARTIFACT_ARGS+=(--remote-network)
         _BASE_SETUP_PROJECT_ARTIFACT_REMOTE_NETWORK=true
     fi
+    if [[ "${BASE_SETUP_VERIFY_PROJECT_RUNTIME:-}" == true &&
+        ( "$_BASE_SETUP_PROJECT_ARTIFACT_ACTION" == check ||
+        "$_BASE_SETUP_PROJECT_ARTIFACT_ACTION" == doctor ) ]]; then
+        _BASE_SETUP_PROJECT_ARTIFACT_ARGS+=(--verify-project-runtime)
+    fi
     if [[ "$_BASE_SETUP_PROJECT_ARTIFACT_ACTION" == setup ]] &&
         setup_project_ide_mutations_allowed; then
         _BASE_SETUP_PROJECT_ARTIFACT_ARGS+=(--allow-project-ide-mutations)
@@ -163,6 +168,11 @@ setup_project_artifact_prepare_bootstrap() {
 setup_project_artifact_handle_unhealthy_venv() {
     local precheck_json
 
+    if [[ ( "$_BASE_SETUP_PROJECT_ARTIFACT_ACTION" == check ||
+        "$_BASE_SETUP_PROJECT_ARTIFACT_ACTION" == doctor ) &&
+        "${BASE_SETUP_VERIFY_PROJECT_RUNTIME:-}" != true ]]; then
+        return 0
+    fi
     if [[ "$_BASE_SETUP_PROJECT_ARTIFACT_ACTION" == setup ]] && setup_is_dry_run; then
         return 0
     fi
@@ -244,7 +254,9 @@ setup_project_artifact_handle_unhealthy_venv() {
 }
 
 setup_project_artifact_execute() {
-    if [[ "$_BASE_SETUP_PROJECT_ARTIFACT_USES_UV_MANAGER" == true ||
+    if [[ "$_BASE_SETUP_PROJECT_ARTIFACT_ACTION" == check ||
+        "$_BASE_SETUP_PROJECT_ARTIFACT_ACTION" == doctor ||
+        "$_BASE_SETUP_PROJECT_ARTIFACT_USES_UV_MANAGER" == true ||
         "$_BASE_SETUP_PROJECT_ARTIFACT_REQUIRES_PYTHON" != true ]] ||
         { [[ "$_BASE_SETUP_PROJECT_ARTIFACT_ACTION" == setup ]] && setup_is_dry_run; }; then
         env "${_BASE_SETUP_PROJECT_ARTIFACT_PROJECT_ENV_ARGS[@]}" \
@@ -255,7 +267,7 @@ setup_project_artifact_execute() {
             BASE_PROJECT_MANIFEST="$_BASE_SETUP_PROJECT_ARTIFACT_MANIFEST_PATH" \
             BASE_PROJECT_VENV_DIR="$_BASE_SETUP_PROJECT_ARTIFACT_PROJECT_VENV_DIR" \
             PYTHONPATH="$_BASE_SETUP_PYTHONPATH_CACHE" \
-            "$_BASE_SETUP_PROJECT_ARTIFACT_PYTHON_BIN" -m base_setup "${_BASE_SETUP_PROJECT_ARTIFACT_ARGS[@]}"
+            "$_BASE_SETUP_PROJECT_ARTIFACT_PYTHON_BIN" -I "$BASE_HOME/cli/python/base_cli_adapters/module_entrypoint.py" base_setup "${_BASE_SETUP_PROJECT_ARTIFACT_ARGS[@]}"
     else
         env "${_BASE_SETUP_PROJECT_ARTIFACT_PROJECT_ENV_ARGS[@]}" \
             BASE_PLATFORM="$_BASE_SETUP_PROJECT_ARTIFACT_PLATFORM" \

--- a/cli/bash/commands/basectl/subcommands/setup_venv.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_venv.sh
@@ -71,7 +71,7 @@ setup_python_machine() {
     local machine python_bin="$1"
 
     [[ -x "$python_bin" ]] || return 1
-    machine="$("$python_bin" -c 'import platform; print(platform.machine() or "unknown")' 2>/dev/null || true)"
+    machine="$("$python_bin" -I -c 'import platform; print(platform.machine() or "unknown")' 2>/dev/null || true)"
     [[ -n "$machine" ]] || return 1
     printf '%s\n' "$machine"
 }
@@ -325,7 +325,7 @@ setup_base_python_package_installed() {
     setup_ensure_cached_paths
     venv_dir="$_BASE_SETUP_VENV_DIR_CACHE"
     python_bin="$(setup_base_venv_python_bin "$venv_dir")" || return 1
-    env -u PYTHONPATH "$python_bin" -m pip show "$package" >/dev/null 2>&1
+    env -u PYTHONPATH "$python_bin" -I -m pip show "$package" >/dev/null 2>&1
 }
 
 setup_install_base_python_package() {

--- a/cli/bash/commands/basectl/subcommands/test.sh
+++ b/cli/bash/commands/basectl/subcommands/test.sh
@@ -169,6 +169,7 @@ base_test_subcommand_main() {
         return 0
     fi
 
+    base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "$trust_required" || return $?
     resolve_output="$($wrapper --project base base_projects "${command_args[@]}" "${args[@]}" --format command-protocol --test-preflight)" || return $?
     base_command_protocol_decode_one project-command "$resolve_output" || {
         base_std_fatal_error "Unable to resolve test command for project '$project'."
@@ -178,7 +179,6 @@ base_test_subcommand_main() {
     command_runner="${command_runner:-}"
     command_to_run="$(base_command_with_runner "$command_runner" "$test_command" "${extra_args[@]}")" || return $?
 
-    base_project_require_manifest_command_trust "$resolved_name" "$manifest_path" "$trust_required" || return $?
     base_project_activate_environment \
         "$resolved_name" "$project_root" "$manifest_path" "$dry_run" "$route_venv_dir" "$uses_uv_manager" >/dev/null
 

--- a/cli/bash/commands/basectl/subcommands/workspace.sh
+++ b/cli/bash/commands/basectl/subcommands/workspace.sh
@@ -17,6 +17,9 @@ Options:
   -v                  Enable DEBUG logging for this subcommand.
   -h, --help          Show this help text.
 
+Check and doctor accept --verify-project-runtime to authorize execution of project
+runtimes and configuration for that invocation. Inspection is static by default.
+
 Show status, check, or doctor output for repositories in the workspace.
 EOF
 }

--- a/cli/bash/commands/basectl/tests/activate.bats
+++ b/cli/bash/commands/basectl/tests/activate.bats
@@ -32,6 +32,8 @@ setup_activate_lifecycle_fixture() {
         "$ACTIVATE_WORKSPACE/demo"
     cat > "$ACTIVATE_BASE_PYTHON" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
@@ -75,6 +77,8 @@ EOF
     mkdir -p "$(dirname "$base_python")" "$(dirname "$project_python")" "$workspace/demo"
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
@@ -202,6 +206,8 @@ EOF
     mkdir -p "$(dirname "$base_python")" "$(dirname "$project_python")" "$workspace/demo"
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
@@ -242,6 +248,8 @@ EOF
     mkdir -p "$(dirname "$base_python")" "$(dirname "$project_python")" "$workspace/demo"
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
@@ -283,6 +291,8 @@ EOF
     mkdir -p "$(dirname "$base_python")" "$workspace/demo/.venv/bin"
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" true false
@@ -324,6 +334,8 @@ EOF
     mkdir -p "$(dirname "$base_python")" "$(dirname "$project_python")" "$workspace/demo/.venv/bin"
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
@@ -364,6 +376,8 @@ EOF
     mkdir -p "$(dirname "$base_python")" "$workspace/demo"
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" true false
@@ -402,6 +416,8 @@ EOF
     mkdir -p "$(dirname "$base_python")" "$workspace/base" "$caller"
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "base" ]]; then
     base_test_protocol_project_route base "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${HOME:?}/.base.d/base/.venv" false false
@@ -448,6 +464,8 @@ EOF
     mkdir -p "$(dirname "$base_python")" "$(dirname "$project_python")" "$workspace/demo" "$caller"
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false
@@ -503,6 +521,8 @@ EOF
     mkdir -p "$(dirname "$base_python")" "$(dirname "$project_python")" "$workspace/demo"
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false

--- a/cli/bash/commands/basectl/tests/build.bats
+++ b/cli/bash/commands/basectl/tests/build.bats
@@ -368,6 +368,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ " $* " == *" -m base_projects build-target-list --project demo --dry-run --format json "* ]]; then
     printf '%s\n' "${BASE_TEST_EXPECTED_JSON:?}"
     exit 0

--- a/cli/bash/commands/basectl/tests/build.bats
+++ b/cli/bash/commands/basectl/tests/build.bats
@@ -64,6 +64,8 @@ load ./basectl_helpers.bash
         "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-targets" && "${4:-}" == "demo" ]]; then
     base_test_protocol_begin build-target 2
     base_test_protocol_build_target_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
@@ -105,6 +107,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo/services/api" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-targets" && "${4:-}" == "demo" ]]; then
     base_test_protocol_begin build-target 1
     base_test_protocol_build_target_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
@@ -149,6 +153,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo/services/api" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-targets" && "${4:-}" == "demo" && "${5:-}" == "api" ]]; then
     base_test_protocol_begin build-target 1
     base_test_protocol_build_target_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
@@ -187,6 +193,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo/services/api"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-targets" && "${4:-}" == "demo" ]]; then
     base_test_protocol_begin build-target 1
     base_test_protocol_build_target_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
@@ -222,6 +230,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo/services/api" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-targets" ]]; then
     base_test_protocol_begin build-target 1
     base_test_protocol_build_target_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
@@ -254,6 +264,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo/services/api"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-target-list" && "${4:-}" == "demo" ]]; then
     base_test_protocol_begin build-target 1
     base_test_protocol_build_target_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
@@ -287,6 +299,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo/services/api"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-target-list" && "${4:-}" == "demo" ]]; then
     base_test_protocol_begin build-target 1
     base_test_protocol_build_target_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
@@ -321,6 +335,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo/docs" "$workspace/demo/services/api"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-targets" && "${4:-}" == "api" ]]; then
     base_test_protocol_begin build-target 1
     base_test_protocol_build_target_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
@@ -376,6 +392,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "build-targets" && "${4:-}" == "demo" ]]; then
     printf "ERROR: Project 'demo' does not declare build targets in '%s/base_manifest.yaml'.\n" "${BASE_TEST_PROJECT_ROOT:?}" >&2
     exit 1

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -162,6 +162,8 @@ load ./setup_helpers.bash
 
     cat > "$TEST_MOCKBIN/python3" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
@@ -409,7 +411,7 @@ EOF
     [ "$status" -eq 0 ]
     [ -f "$TEST_STATE_DIR/project-setup-python" ]
     actual_python="$(cat "$TEST_STATE_DIR/project-setup-python")"
-    [[ "$actual_python" == *"$demo_venv_dir/bin/python"* ]] || {
+    [[ "$actual_python" == *"$base_venv_dir/bin/python"* ]] || {
         printf 'actual project check python: %s\n' "$actual_python" >&3
         false
     }
@@ -548,7 +550,7 @@ EOF
     BASE_SETUP_TEST_WORKSPACE="$workspace" create_project_setup_venv_stub "$venv_dir"
     resolved_demo_root="$(cd "$workspace/demo" && pwd -P)"
 
-    run_base_command BASE_SETUP_TEST_WORKSPACE="$workspace" check demo
+    run_base_command BASE_SETUP_TEST_WORKSPACE="$workspace" check demo --verify-project-runtime
 
     [ "$status" -eq 1 ]
     project_venv_error_line="$(printf '%s\n' "$output" | grep -F "Virtual environment is missing at '$resolved_demo_root/.venv'.")"
@@ -1000,7 +1002,7 @@ EOF
         BASE_SETUP_TEST_PYTHON_PREFIX="$TEST_TMPDIR/python-prefix" \
         BASE_SETUP_TEST_WORKSPACE="$workspace" \
         BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/CommandLineTools" \
-        "$BASE_REPO_ROOT/bin/basectl" check demo --remote-network --format json
+        "$BASE_REPO_ROOT/bin/basectl" check demo --verify-project-runtime --remote-network --format json
 
     [ "$status" -eq 1 ]
     [[ "$output" == *'"schema_version": 1'* ]]

--- a/cli/bash/commands/basectl/tests/clean.bats
+++ b/cli/bash/commands/basectl/tests/clean.bats
@@ -9,6 +9,8 @@ load ./basectl_helpers.bash
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_clean" ]]; then
     printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT"
     printf 'ARGS=%s\n' "${*:3}"
@@ -65,6 +67,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_clean" ]]; then
     shift 2
     printf 'ARGC=%s\n' "$#"

--- a/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash
+++ b/cli/bash/commands/basectl/tests/command_protocol_fixtures.bash
@@ -1,5 +1,16 @@
 # Test-only builders for Base command-protocol fixtures emitted by fake Python commands.
 
+# Fake Python executables are Bash scripts loaded through BASH_ENV. Normalize
+# interpreter isolation and the owned entrypoint into the module arguments
+# those stubs model. Real Python integration tests exercise the actual launcher.
+if [[ "${0##*/}" == python* && "${1:-}" == -I ]]; then
+    shift
+    if [[ "${1:-}" == */base_cli_adapters/module_entrypoint.py ]]; then
+        shift
+        set -- -m "$@"
+    fi
+fi
+
 base_test_protocol_hex() {
     local LC_ALL=C
     local value="$1"

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -9,6 +9,8 @@ load ./setup_helpers.bash
     mkdir -p "$(dirname "$base_python")"
     cat > "$base_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "list" ]]; then
     base_test_protocol_begin project-list-entry 2
     base_test_protocol_project_list_record 0 base /Users/test/base

--- a/cli/bash/commands/basectl/tests/completions.bats
+++ b/cli/bash/commands/basectl/tests/completions.bats
@@ -296,7 +296,7 @@ EOF
     [[ "$output" == *"run_projects=base demo"* ]]
     [[ "$output" == *"export_context_projects=base demo"* ]]
     [[ "$output" == *"update_projects=base demo"* ]]
-    [[ "$output" == *"check_options=--ci --profile --format --manifest --remote-network"* ]]
+    [[ "$output" == *"check_options=--ci --profile --format --manifest --verify-project-runtime --remote-network"* ]]
     [[ "$output" == *"update_options=--dry-run"* ]]
     [[ "$output" == *"check_profiles=dev sre ai linux-lab dev,sre dev,ai dev,linux-lab sre,ai sre,linux-lab ai,linux-lab dev,sre,ai dev,sre,linux-lab dev,ai,linux-lab sre,ai,linux-lab dev,sre,ai,linux-lab"* ]]
     [[ "$output" == *"test_options=--workspace --project --dry-run"* ]]

--- a/cli/bash/commands/basectl/tests/demo.bats
+++ b/cli/bash/commands/basectl/tests/demo.bats
@@ -49,6 +49,8 @@ load ./basectl_helpers.bash
     mkdir -p "$(dirname "$python_bin")" "$(dirname "$script_path")" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "demo" ]]; then
     base_test_protocol_demo demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -103,6 +105,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$(dirname "$script_path")" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "demo" ]]; then
     base_test_protocol_demo demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -146,6 +150,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "--format" ]]; then
     base_test_protocol_demo demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -187,6 +193,8 @@ EOF
     touch "$script_path"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "--project" && "${5:-}" == "other" ]]; then
     base_test_protocol_demo other "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -215,6 +223,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "demo" && "${5:-}" == "--workspace" ]]; then
     base_test_protocol_demo demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -273,6 +283,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "demo" ]]; then
     printf "ERROR: No demo declared for project 'demo'. Add demo.script to '%s/base_manifest.yaml'.\n" "${BASE_TEST_PROJECT_ROOT:?}" >&2
     exit 1
@@ -300,6 +312,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "demo" ]]; then
     printf "ERROR: %s/base_manifest.yaml: demo.script './demo.sh' does not exist.\n" "${BASE_TEST_PROJECT_ROOT:?}" >&2
     exit 1
@@ -363,6 +377,8 @@ EOF
     bash_bin_dir="$(dirname "$(command -v bash)")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "demo-script" && "${4:-}" == "base" ]]; then
     base_test_protocol_demo base "${BASE_REPO_ROOT:?}" \
         "${BASE_REPO_ROOT:?}/base_manifest.yaml" "${HOME:?}/.base.d/base/.venv" false false \

--- a/cli/bash/commands/basectl/tests/devcontainer.bats
+++ b/cli/bash/commands/basectl/tests/devcontainer.bats
@@ -33,6 +33,8 @@ load ./basectl_helpers.bash
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false

--- a/cli/bash/commands/basectl/tests/devenv-report.bats
+++ b/cli/bash/commands/basectl/tests/devenv-report.bats
@@ -33,6 +33,8 @@ load ./basectl_helpers.bash
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false

--- a/cli/bash/commands/basectl/tests/diagnostics_module_fixture.bash
+++ b/cli/bash/commands/basectl/tests/diagnostics_module_fixture.bash
@@ -177,6 +177,10 @@ base_test_diagnostics_module() {
     local result_files=() embedded_keys=() embedded_values=() i
 
     case "$command" in
+        -h|--help)
+            printf 'Base diagnostics fixture\n'
+            return 0
+            ;;
         base-check-metadata)
             local metadata_names=()
             while (($#)); do

--- a/cli/bash/commands/basectl/tests/doctor.bats
+++ b/cli/bash/commands/basectl/tests/doctor.bats
@@ -85,6 +85,8 @@ exit 1
 EOF
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
@@ -109,6 +111,8 @@ create_doctor_linux_success_stubs() {
     mkdir -p "$fake_bin" "$(dirname "$venv_python")"
     cat > "$fake_bin/python3" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
@@ -121,6 +125,8 @@ exit 1
 EOF
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
@@ -205,7 +211,9 @@ EOF
 @test "basectl doctor explain delegates to the local explanation renderer" {
     cat > "$TEST_MOCKBIN/python3" <<'EOF'
 #!/usr/bin/env bash
-if [[ "${1:-}" == "-c" ]]; then
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
+if [[ "${1:-}" == "-c" || ( "${1:-}" == "-m" && "${2:-}" == "base_setup.diagnostics" && "${3:-}" == "--help" ) ]]; then
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_setup.finding_explanations" ]]; then
@@ -360,6 +368,8 @@ printf 'gh version test\n'
 EOF
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
@@ -456,6 +466,8 @@ EOF
     mkdir -p "$fake_bin" "$(dirname "$venv_python")"
     cat > "$fake_bin/python3" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
@@ -467,6 +479,8 @@ exit 1
 EOF
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
@@ -540,6 +554,8 @@ exit 1
 EOF
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
@@ -607,6 +623,8 @@ exit 1
 EOF
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
@@ -732,6 +750,8 @@ exit 1
 EOF
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
@@ -859,6 +879,8 @@ exit 1
 EOF
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
@@ -929,6 +951,8 @@ exit 1
 EOF
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
@@ -991,11 +1015,13 @@ EOF
     cp "$BASE_REPO_ROOT/cli/bash/commands/basectl/tests/fixtures/shell-only/base_manifest.yaml" "$manifest_path"
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
 fi
-if [[ "${1:-}" == "-c" ]]; then
+if [[ "${1:-}" == "-c" || ( "${1:-}" == "-m" && "${2:-}" == "base_setup.diagnostics" && "${3:-}" == "--help" ) ]]; then
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "pip" && "${3:-}" == "show" ]]; then
@@ -1080,6 +1106,8 @@ exit 1
 EOF
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
@@ -1189,6 +1217,8 @@ exit 1
 EOF
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
@@ -1305,6 +1335,8 @@ EOF
     mkdir -p "$(dirname "$venv_python")"
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
@@ -1364,6 +1396,8 @@ exit 1
 EOF
     cat > "$venv_python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
@@ -1424,7 +1458,7 @@ EOF
         BASE_TEST_PROJECT_ROOT="$workspace/demo" \
         BASE_TEST_XCODE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
         BASE_SETUP_XCODE_COMMAND_LINE_TOOLS_DIR="$TEST_TMPDIR/xcode-tools" \
-        "$BASE_REPO_ROOT/bin/basectl" doctor demo --remote-network --format json
+        "$BASE_REPO_ROOT/bin/basectl" doctor demo --verify-project-runtime --remote-network --format json
 
     [ "$status" -eq 1 ]
     [[ "$output" == *'"schema_version": 1'* ]]

--- a/cli/bash/commands/basectl/tests/export-context.bats
+++ b/cli/bash/commands/basectl/tests/export-context.bats
@@ -45,6 +45,8 @@ load ./basectl_helpers.bash
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "current" ]]; then
     base_test_protocol_project_reference \
         demo "${BASE_TEST_PROJECT_ROOT:?}" "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml"
@@ -96,6 +98,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "current" ]]; then
     base_test_protocol_project_reference demo "${BASE_TEST_PROJECT_ROOT:?}" ""
     exit 0
@@ -137,6 +141,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "resolve" && "${4:-}" == "demo" && "${5:-}" == "--workspace" ]]; then
     base_test_protocol_project_route demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false

--- a/cli/bash/commands/basectl/tests/history.bats
+++ b/cli/bash/commands/basectl/tests/history.bats
@@ -9,6 +9,8 @@ load ./basectl_helpers.bash
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_history" ]]; then
     printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT"
     printf 'ARGS=%s\n' "${*:3}"
@@ -32,6 +34,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_history" ]]; then
     printf 'ARGS=%s\n' "${*:3}"
     exit 0
@@ -53,6 +57,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_history" ]]; then
     printf 'ARGS=%s\n' "${*:3}"
     exit 0

--- a/cli/bash/commands/basectl/tests/logs.bats
+++ b/cli/bash/commands/basectl/tests/logs.bats
@@ -9,6 +9,8 @@ load ./basectl_helpers.bash
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_logs" ]]; then
     printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT"
     printf 'DISPLAY=%s\n' "${BASE_CLI_DISPLAY_COMMAND:-}"
@@ -34,6 +36,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_logs" ]]; then
     printf 'ARGS=%s\n' "${*:3}"
     exit 0
@@ -55,6 +59,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_logs" ]]; then
     printf 'ARGS=%s\n' "${*:3}"
     exit 0
@@ -122,6 +128,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_logs" ]]; then
     shift 2
     printf 'ARGC=%s\n' "$#"

--- a/cli/bash/commands/basectl/tests/manifest-command-trust.bats
+++ b/cli/bash/commands/basectl/tests/manifest-command-trust.bats
@@ -8,6 +8,8 @@ write_manifest_trust_python() {
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_trust" && "${3:-}" == "require" && "${4:-}" == "demo" ]]; then
     if [[ "${BASE_TEST_TRUST_ALLOWED:-0}" == "1" ]]; then
         exit 0

--- a/cli/bash/commands/basectl/tests/projects.bats
+++ b/cli/bash/commands/basectl/tests/projects.bats
@@ -10,6 +10,8 @@ load ./basectl_helpers.bash
     mkdir -p "$(dirname "$python_bin")" "$workspace/base" "$workspace/demo" "$workspace/notes"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "list" && "${4:-}" == "--workspace" ]]; then
     printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT" > "${BASE_TEST_PROJECTS_LIST_STATE:?}"
     printf '%s\t%s\n' base "$5/base"
@@ -43,6 +45,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/base"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_history.record" ]]; then
     exit 0
 fi
@@ -78,7 +82,9 @@ EOF
     mkdir -p "$workspace/base" "$workspace/demo"
     cat > "$TEST_MOCKBIN/python3" <<'EOF'
 #!/usr/bin/env bash
-if [[ "${1:-}" == "-c" ]]; then
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
+if [[ "${1:-}" == "-c" || ( "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "--help" ) ]]; then
     exit 0
 fi
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "list" && "${4:-}" == "--workspace" ]]; then
@@ -120,6 +126,8 @@ EOF
     mkdir -p "$workspace/base"
     cat > "$TEST_MOCKBIN/python3" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-c" ]]; then
     exit 1
 fi
@@ -167,6 +175,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "list" ]]; then
     printf 'ERROR: Unsupported output format '\''xml'\''. Expected one of: text, csv, tsv, yaml, json.\n' >&2
     exit 2
@@ -189,6 +199,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "list" ]]; then
     shift 3
     printf 'ARGC=%s\n' "$#"

--- a/cli/bash/commands/basectl/tests/prompt.bats
+++ b/cli/bash/commands/basectl/tests/prompt.bats
@@ -59,6 +59,8 @@ load ./basectl_helpers.bash
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_prompt" ]]; then
     shift 2
     printf '%s\n' "$*" > "${BASE_TEST_PROMPT_STATE:?}"
@@ -88,6 +90,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_prompt" ]]; then
     shift 2
     printf '%s\n' "$*" > "${BASE_TEST_PROMPT_STATE:?}"
@@ -118,6 +122,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_prompt" ]]; then
     shift 2
     printf '%s\n' "$*" > "${BASE_TEST_PROMPT_STATE:?}"
@@ -148,6 +154,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_prompt" ]]; then
     shift 2
     printf '%s\n' "$*" > "${BASE_TEST_PROMPT_STATE:?}"
@@ -176,6 +184,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_prompt" && "${3:-}" == "list" ]]; then
     printf 'product-self-review\tPeriodic Base product self-review\n'
     exit 0

--- a/cli/bash/commands/basectl/tests/release.bats
+++ b/cli/bash/commands/basectl/tests/release.bats
@@ -86,6 +86,8 @@ load ./basectl_helpers.bash
     printf 'project:\n  name: demo\nartifacts: []\n' > "$manifest"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_release" ]]; then
     printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT" > "${BASE_TEST_RELEASE_STATE:?}"
     printf 'DISPLAY=%s\n' "${BASE_CLI_DISPLAY_COMMAND:-}"

--- a/cli/bash/commands/basectl/tests/run.bats
+++ b/cli/bash/commands/basectl/tests/run.bats
@@ -33,6 +33,8 @@ load ./basectl_helpers.bash
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "dev" ]]; then
     base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -71,6 +73,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin" "$TEST_HOME/.local/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "audit" ]]; then
     base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -113,6 +117,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "dev" ]]; then
     base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" true false \
@@ -147,6 +153,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "audit" ]]; then
     base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -178,6 +186,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "dev" ]]; then
     base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -212,6 +222,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "lint" ]]; then
     base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -248,6 +260,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "dev" ]]; then
     base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -284,6 +298,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "demo" && "${5:-}" == "test" ]]; then
     base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -314,6 +330,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-commands" && "${4:-}" == "demo" ]]; then
     base_test_protocol_begin named-command 2
     base_test_protocol_named_command_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
@@ -383,6 +401,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo/docs"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "run-command" && "${4:-}" == "dev" ]]; then
     base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \

--- a/cli/bash/commands/basectl/tests/run.bats
+++ b/cli/bash/commands/basectl/tests/run.bats
@@ -366,6 +366,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ " $* " == *" -m base_projects run-commands --dry-run --format command-protocol "* ]]; then
     base_test_protocol_begin named-command 1
     base_test_protocol_named_command_record 0 demo "${BASE_TEST_PROJECT_ROOT:?}" \
@@ -432,6 +434,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ " $* " == *" -m base_projects run-commands --project demo --dry-run --format json "* ]]; then
     printf '%s\n' "${BASE_TEST_EXPECTED_JSON:?}"
     exit 0

--- a/cli/bash/commands/basectl/tests/runtime-dispatch.bats
+++ b/cli/bash/commands/basectl/tests/runtime-dispatch.bats
@@ -801,6 +801,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 printf 'BASE_HOME=%s\n' "$BASE_HOME"
 printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT"
 printf 'PYTHONPATH=%s\n' "$PYTHONPATH"

--- a/cli/bash/commands/basectl/tests/runtime-shell.bats
+++ b/cli/bash/commands/basectl/tests/runtime-shell.bats
@@ -92,6 +92,8 @@ export VIRTUAL_ENV
 EOF
     cat > "$venv_dir/bin/python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "activation-sources" && "${4:-}" == "demo" ]]; then
     base_test_protocol_begin activation-source 0
     base_test_protocol_end
@@ -135,6 +137,8 @@ export VIRTUAL_ENV
 EOF
     cat > "$venv_dir/bin/python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "activation-sources" && "${4:-}" == "demo" ]]; then
     base_test_protocol_begin activation-source 1
     base_test_protocol_activation_source_record 0 "${BASE_TEST_ACTIVATION_SOURCE:?}"
@@ -191,6 +195,8 @@ export VIRTUAL_ENV
 EOF
     cat > "$venv_dir/bin/python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "activation-sources" && "${4:-}" == "demo" ]]; then
     printf 'startup-run-root=%s\n' "${BASE_CLI_RUN_ROOT:-unset}" >&2
     printf 'startup-primary-log=%s\n' "${BASE_BASH_LIBS_PRIMARY_LOG:-unset}" >&2
@@ -328,6 +334,8 @@ export VIRTUAL_ENV
 EOF
     cat > "$venv_dir/bin/python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "activation-sources" && "${4:-}" == "demo" ]]; then
     printf 'ERROR: %s: activate.source[1] script %q does not exist.\n' "$BASE_PROJECT_MANIFEST" ".base/missing.sh" >&2
     exit 1

--- a/cli/bash/commands/basectl/tests/runtime-shell.bats
+++ b/cli/bash/commands/basectl/tests/runtime-shell.bats
@@ -217,6 +217,8 @@ printf 'unexpected base_projects args: %s\n' "$*" >&2
 exit 1
 EOF
     chmod +x "$venv_dir/bin/python"
+    mkdir -p "$TEST_HOME/.base.d/base/.venv/bin"
+    cp "$venv_dir/bin/python" "$TEST_HOME/.base.d/base/.venv/bin/python"
 
     run env \
         HOME="$TEST_HOME" \

--- a/cli/bash/commands/basectl/tests/setup.bats
+++ b/cli/bash/commands/basectl/tests/setup.bats
@@ -318,6 +318,8 @@ load ./setup_helpers.bash
     printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
     cat > "$venv_dir/bin/python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
 if [[ "${1:-}" == "--version" ]]; then
@@ -415,6 +417,8 @@ executable = $python_executable
 EOF
     cat > "$venv_dir/bin/python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "--version" ]]; then
     printf 'Python 3.13.test\n'
     exit 0
@@ -532,6 +536,8 @@ EOF
     : > "$venv_dir/pyvenv.cfg"
     cat > "$venv_dir/bin/python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ -n "${PYTHONPATH:-}" ]]; then
     printf 'pip subprocess inherited PYTHONPATH: %s\n' "$PYTHONPATH" >&2
     exit 1

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -199,6 +199,8 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "venv" && -n "${3:-}" ]]; then
     printf '#!/usr/bin/env bash\n' > "$3/bin/activate"
     cat > "$3/bin/python" <<'VENVEOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
 if [[ "${1:-}" == "--version" ]]; then
@@ -408,12 +410,16 @@ case "${1:-}" in
             mkdir -p "$python_prefix/bin"
             cat > "$python_prefix/bin/python3" <<'PYEOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "venv" && -n "${3:-}" ]]; then
     mkdir -p "$3/bin"
     printf 'python-home = test\n' > "$3/pyvenv.cfg"
     printf '#!/usr/bin/env bash\n' > "$3/bin/activate"
     cat > "$3/bin/python" <<'VENVEOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
 if [[ "${1:-}" == "--version" ]]; then
@@ -587,12 +593,16 @@ case "${1:-}" in
             mkdir -p "$python_prefix/bin"
             cat > "$python_prefix/bin/python3" <<'PYEOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "venv" && -n "${3:-}" ]]; then
     mkdir -p "$3/bin"
     printf 'python-home = test\n' > "$3/pyvenv.cfg"
     printf '#!/usr/bin/env bash\n' > "$3/bin/activate"
     cat > "$3/bin/python" <<'VENVEOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
 if [[ "${1:-}" == "--version" ]]; then

--- a/cli/bash/commands/basectl/tests/setup_helpers.bash
+++ b/cli/bash/commands/basectl/tests/setup_helpers.bash
@@ -186,6 +186,8 @@ EOF
 create_system_python3_stub() {
     cat > "$TEST_MOCKBIN/python3" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 touch "${BASE_SETUP_TEST_STATE_DIR:?}/system-python-ran"
 if [[ "${1:-}" == "-m" && "${2:-}" == "venv" && "${3:-}" == "--help" ]]; then
     printf 'usage: python3 -m venv ENV_DIR\n'
@@ -799,6 +801,8 @@ create_base_venv_stub() {
     printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
     cat > "$venv_dir/bin/python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
 if [[ "${1:-}" == "--version" ]]; then
@@ -866,6 +870,8 @@ create_project_setup_venv_stub() {
     printf '#!/usr/bin/env bash\n' > "$venv_dir/bin/activate"
     cat > "$venv_dir/bin/python" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 pyyaml_package="${BASE_SETUP_PYYAML_PACKAGE:-PyYAML}"
 click_package="${BASE_SETUP_CLICK_PACKAGE:-click}"
 if [[ "${1:-}" == "--version" ]]; then

--- a/cli/bash/commands/basectl/tests/test.bats
+++ b/cli/bash/commands/basectl/tests/test.bats
@@ -41,6 +41,8 @@ load ./basectl_helpers.bash
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -79,6 +81,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -121,6 +125,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -155,6 +161,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -190,6 +198,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -221,6 +231,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -256,6 +268,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "demo" ]]; then
     base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -289,6 +303,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/demo" "$workspace/demo/.venv/bin"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "--format" ]]; then
     base_test_protocol_project_command demo "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -323,6 +339,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/current"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "--project" && "${5:-}" == "other" ]]; then
     base_test_protocol_project_command other "${BASE_TEST_PROJECT_ROOT:?}" \
         "${BASE_TEST_PROJECT_ROOT:?}/base_manifest.yaml" "${BASE_TEST_PROJECT_ROOT:?}/.venv" false false \
@@ -397,6 +415,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "test-command" && "${4:-}" == "base-dmo" ]]; then
     printf '{"version":1,"bundles":[{"path":"%s","run_id":"stale","status":"running","started_at":1,"size":1,"preserve":false}]}\n' \
         "${BASE_CLI_RUN_ROOT:?}" > "${BASE_CLI_RUN_ROOT%/*}/.base-cli-run-index.json"

--- a/cli/bash/commands/basectl/tests/workspace.bats
+++ b/cli/bash/commands/basectl/tests/workspace.bats
@@ -12,6 +12,8 @@ load ./basectl_helpers.bash
     touch "$manifest"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "status" ]]; then
     printf 'BASE_PROJECT=%s\n' "$BASE_PROJECT" > "${BASE_TEST_WORKSPACE_STATUS_STATE:?}"
     printf 'ARGS=%s\n' "${*:4}"
@@ -43,6 +45,8 @@ EOF
         "$project_root/base_manifest.yaml"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "status" ]]; then
     [[ ! -e "${BASE_TEST_SHELL_PROJECT_ROOT:?}/.venv" ]] || exit 10
     ! grep -Eq '^[[:space:]]*python:' "${BASE_TEST_SHELL_PROJECT_ROOT:?}/base_manifest.yaml" || exit 11
@@ -74,6 +78,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/base"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "check" ]]; then
     printf 'ARGS=%s\n' "${*:4}"
     exit 0
@@ -100,6 +106,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/base"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "doctor" ]]; then
     printf 'ARGS=%s\n' "${*:4}"
     exit 0
@@ -128,6 +136,8 @@ EOF
     touch "$manifest"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "onboarding" ]]; then
     printf 'ARGS=%s\n' "${*:4}"
     exit 0
@@ -156,6 +166,8 @@ EOF
     touch "$manifest"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "agent-brief" ]]; then
     printf 'ARGS=%s\n' "${*:4}"
     exit 0
@@ -184,6 +196,8 @@ EOF
     touch "$manifest"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "clone" ]]; then
     printf 'ARGS=%s\n' "${*:4}"
     exit 0
@@ -212,6 +226,8 @@ EOF
     touch "$source"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "pull" ]]; then
     printf 'ARGS=%s\n' "${*:4}"
     exit 0
@@ -239,6 +255,8 @@ EOF
     touch "$manifest"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "update" ]]; then
     printf 'ARGS=%s\n' "${*:4}"
     exit 0
@@ -268,6 +286,8 @@ EOF
     touch "$manifest"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "configure" ]]; then
     printf 'ARGS=%s\n' "${*:4}"
     exit 0
@@ -296,6 +316,8 @@ EOF
     touch "$manifest"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "setup" ]]; then
     printf 'ARGS=%s\n' "${*:4}"
     exit 0
@@ -325,6 +347,8 @@ EOF
     touch "$manifest"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" && "${2:-}" == "base_projects" && "${3:-}" == "init" ]]; then
     printf 'ARGS=%s\n' "${*:4}"
     exit 0
@@ -352,6 +376,8 @@ EOF
     mkdir -p "$(dirname "$python_bin")" "$workspace/base"
     cat > "$python_bin" <<'EOF'
 #!/usr/bin/env bash
+# Bash 3 reads BASH_ENV before assigning script arguments.
+source "${BASH_ENV:?}"
 if [[ "${1:-}" == "-m" &&
       "${2:-}" == "base_projects" &&
       "${3:-}" == "init" &&

--- a/cli/python/base_cli_adapters/module_entrypoint.py
+++ b/cli/python/base_cli_adapters/module_entrypoint.py
@@ -9,14 +9,18 @@ from __future__ import annotations
 
 import sys
 
+# This bootstrap must validate isolation before importing the CLI provider.
+USAGE_ERROR = 2
+SUCCESS = 0
+
 
 def main() -> int:
     if not sys.flags.isolated:
         print("Base module entrypoint requires Python's -I option.", file=sys.stderr)
-        return 2
+        return USAGE_ERROR
     if len(sys.argv) < 2:
         print("Usage: module_entrypoint.py <module> [arguments...]", file=sys.stderr)
-        return 2
+        return USAGE_ERROR
     import os
     import runpy
     from pathlib import Path
@@ -30,7 +34,7 @@ def main() -> int:
     module = sys.argv[1]
     sys.argv = sys.argv[1:]
     runpy.run_module(module, run_name="__main__", alter_sys=True)
-    return 0
+    return SUCCESS
 
 
 if __name__ == "__main__":

--- a/cli/python/base_cli_adapters/module_entrypoint.py
+++ b/cli/python/base_cli_adapters/module_entrypoint.py
@@ -1,0 +1,37 @@
+"""Run Base-owned modules without adding the caller's directory to imports.
+
+Launch this file by absolute path with Python's isolated (-I) option. The
+selected provider and Base command source roots are the only injected paths;
+the caller's working directory is preserved for project discovery.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> int:
+    if not sys.flags.isolated:
+        print("Base module entrypoint requires Python's -I option.", file=sys.stderr)
+        return 2
+    if len(sys.argv) < 2:
+        print("Usage: module_entrypoint.py <module> [arguments...]", file=sys.stderr)
+        return 2
+    import os
+    import runpy
+    from pathlib import Path
+
+    command_root = Path(__file__).resolve().parents[1]
+    source_roots = [str(command_root)]
+    provider_root = os.environ.get("BASE_CLI_RUNTIME_SOURCE_ROOT")
+    if provider_root:
+        source_roots.insert(0, str(Path(provider_root).resolve()))
+    sys.path[:0] = source_roots
+    module = sys.argv[1]
+    sys.argv = sys.argv[1:]
+    runpy.run_module(module, run_name="__main__", alter_sys=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/python/base_cli_adapters/tests/test_module_entrypoint.py
+++ b/cli/python/base_cli_adapters/tests/test_module_entrypoint.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import base_cli
+import pytest
+
+
+ENTRYPOINT = Path(__file__).resolve().parents[1] / "module_entrypoint.py"
+
+
+@pytest.mark.parametrize("arguments", [["current"], ["manifest", "base_manifest.yaml"]])
+def test_owned_module_loading_preserves_cwd_and_arguments(tmp_path, arguments):
+    manifest = tmp_path / "base_manifest.yaml"
+    manifest.write_text("project:\n  name: demo\nartifacts: []\n", encoding="utf-8")
+    (tmp_path / "base_projects.py").write_text('raise RuntimeError("project module loaded")\n', encoding="utf-8")
+    (tmp_path / "sitecustomize.py").write_text('raise RuntimeError("project startup loaded")\n', encoding="utf-8")
+    environment = {
+        **os.environ,
+        "HOME": str(tmp_path),
+        "BASE_CLI_RUNTIME_SOURCE_ROOT": str(Path(base_cli.__file__).resolve().parents[1]),
+        "PYTHONPATH": str(tmp_path),
+    }
+    completed = subprocess.run(
+        [sys.executable, "-I", str(ENTRYPOINT), "base_projects", *arguments],
+        cwd=tmp_path, env=environment, text=True, capture_output=True, check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.startswith(f"demo\t{tmp_path.resolve()}\t{manifest.resolve()}")
+    assert "project startup loaded" not in completed.stderr
+
+
+def test_entrypoint_refuses_nonisolated_python(tmp_path):
+    completed = subprocess.run(
+        [sys.executable, str(ENTRYPOINT), "base_projects", "--help"],
+        cwd=tmp_path, text=True, capture_output=True, check=False,
+    )
+
+    assert completed.returncode == 2
+    assert "requires Python's -I option" in completed.stderr

--- a/cli/python/base_projects/engine.py
+++ b/cli/python/base_projects/engine.py
@@ -7,6 +7,7 @@ import base_cli
 from base_cli_profile import base_cli_app
 from base_cli_adapters.protocol import dumps_record
 from base_cli_adapters.protocol import dumps_records
+from base_projects.test_preflight import project_test_preflight
 from base_projects.build_targets import build_targets_project_from_args
 from base_projects.build_targets import list_build_targets_from_args
 from base_projects.command_helpers import ProjectUsageError
@@ -73,7 +74,6 @@ from base_setup.demo import resolve_demo_script_path
 from base_setup.errors import ArtifactError
 from base_setup.manifest import read_manifest
 from base_setup.manifest_loader import ManifestError
-from base_setup.test_requirements import check_test_requirements
 
 
 app = base_cli_app(name="base_projects")
@@ -138,6 +138,10 @@ def main(argv: list[str] | None = None) -> int:
     is_flag=True,
     help="Check a project test requirements file before resolving its test command.",
 )
+@base_cli.option(
+    "--verify-project-runtime", is_flag=True,
+    help="Authorize project runtime and configuration execution for workspace check/doctor in this invocation.",
+)
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 def run(
     ctx: base_cli.Context,
@@ -157,6 +161,7 @@ def run(
     workspace_projects: str | None,
     fail_fast: bool,
     test_preflight: bool,
+    verify_project_runtime: bool,
 ) -> int:
     try:
         return dispatch_projects_command(
@@ -178,6 +183,7 @@ def run(
                 workspace_projects=workspace_projects,
                 fail_fast=fail_fast,
                 test_preflight=test_preflight,
+                verify_project_runtime=verify_project_runtime,
             ),
             project_command_actions(),
         )
@@ -350,6 +356,7 @@ def workspace_check_command(
     workspace: str | None,
     output_format: str = "text",
     workspace_manifest: str | None = None,
+    verify_project_runtime: bool = False,
 ) -> int:
     if not validate_report_format(ctx, output_format):
         return base_cli.ExitCode.USAGE_ERROR
@@ -357,7 +364,9 @@ def workspace_check_command(
     try:
         workspace_root = resolve_workspace_root(ctx, workspace)
         manifest = resolve_workspace_manifest(effective_workspace_manifest(ctx, workspace_manifest))
-        results = workspace_project_check_results(ctx, workspace_root, manifest)
+        results = workspace_project_check_results(
+            ctx, workspace_root, manifest, verify_project_runtime=verify_project_runtime,
+        )
     except (ProjectDiscoveryError, ManifestError, WorkspaceManifestError) as exc:
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
@@ -398,6 +407,7 @@ def workspace_doctor_command(
     workspace: str | None,
     output_format: str = "text",
     workspace_manifest: str | None = None,
+    verify_project_runtime: bool = False,
 ) -> int:
     if not validate_report_format(ctx, output_format):
         return base_cli.ExitCode.USAGE_ERROR
@@ -405,7 +415,9 @@ def workspace_doctor_command(
     try:
         workspace_root = resolve_workspace_root(ctx, workspace)
         manifest = resolve_workspace_manifest(effective_workspace_manifest(ctx, workspace_manifest))
-        results = workspace_project_check_results(ctx, workspace_root, manifest)
+        results = workspace_project_check_results(
+            ctx, workspace_root, manifest, verify_project_runtime=verify_project_runtime,
+        )
     except (ProjectDiscoveryError, ManifestError, WorkspaceManifestError) as exc:
         ctx.log.error(str(exc))
         return base_cli.ExitCode.FAILURE
@@ -632,13 +644,8 @@ def test_command_project_command(
         )
         return base_cli.ExitCode.FAILURE
 
-    if test_preflight:
-        check = check_test_requirements(manifest)
-        if check is not None and not check.ok:
-            ctx.log.error(check.message)
-            if check.fix:
-                ctx.log.error("Fix: %s", check.fix)
-            return base_cli.ExitCode.FAILURE
+    if test_preflight and not project_test_preflight(ctx, manifest):
+        return base_cli.ExitCode.FAILURE
 
     command_config = test_command(manifest.test)
     if output_format == "command-protocol":

--- a/cli/python/base_projects/project_dispatch.py
+++ b/cli/python/base_projects/project_dispatch.py
@@ -24,14 +24,15 @@ class WorkspaceCommandOptions:
     yes: bool = False
     fail_fast: bool = False
     test_preflight: bool = False
+    verify_project_runtime: bool = False
 
 
 @dataclass(frozen=True)
 class ProjectCommandActions:
     list_projects: Callable[[base_cli.Context, str | None, str], int]
     workspace_status: Callable[[base_cli.Context, str | None, str, str | None], int]
-    workspace_check: Callable[[base_cli.Context, str | None, str, str | None], int]
-    workspace_doctor: Callable[[base_cli.Context, str | None, str, str | None], int]
+    workspace_check: Callable[[base_cli.Context, str | None, str, str | None, bool], int]
+    workspace_doctor: Callable[[base_cli.Context, str | None, str, str | None, bool], int]
     workspace_onboarding: Callable[[base_cli.Context, str | None, str, str | None], int]
     workspace_agent_brief: Callable[[base_cli.Context, str | None, str, str | None], int]
     workspace_clone: Callable[[base_cli.Context, WorkspaceCommandOptions], int]
@@ -69,6 +70,8 @@ def dispatch_projects_command(
     actions: ProjectCommandActions,
 ) -> int:
     command = arguments[0] if arguments else "list"
+    if options.verify_project_runtime and command not in {"check", "doctor"}:
+        raise ProjectUsageError("--verify-project-runtime is only supported for workspace check and doctor.")
     command_arguments = arguments[1:] if arguments else ()
     handler = PROJECT_COMMAND_HANDLERS.get(command)
     if handler is not None:
@@ -121,7 +124,9 @@ def _handle_check(
     actions: ProjectCommandActions,
 ) -> int:
     require_argument_count("check", arguments, 0, 0)
-    return actions.workspace_check(ctx, options.workspace, options.output_format, options.workspace_manifest)
+    return actions.workspace_check(
+        ctx, options.workspace, options.output_format, options.workspace_manifest, options.verify_project_runtime,
+    )
 
 
 def _handle_doctor(
@@ -131,7 +136,9 @@ def _handle_doctor(
     actions: ProjectCommandActions,
 ) -> int:
     require_argument_count("doctor", arguments, 0, 0)
-    return actions.workspace_doctor(ctx, options.workspace, options.output_format, options.workspace_manifest)
+    return actions.workspace_doctor(
+        ctx, options.workspace, options.output_format, options.workspace_manifest, options.verify_project_runtime,
+    )
 
 
 def _handle_onboarding(

--- a/cli/python/base_projects/test_preflight.py
+++ b/cli/python/base_projects/test_preflight.py
@@ -1,0 +1,24 @@
+"""Approval and dependency checks before executing a project test contract."""
+
+from __future__ import annotations
+
+import base_cli
+
+from base_setup.manifest_model import BaseManifest
+from base_setup.test_requirements import check_test_requirements
+
+
+def project_test_preflight(ctx: base_cli.Context, manifest: BaseManifest) -> bool:
+    # Import at invocation time: the trust command resolves projects through
+    # the project engine, which also owns this preflight's public entry point.
+    from base_trust.engine import require_command
+
+    if require_command(ctx, manifest.project_name, None, str(manifest.path)) != base_cli.ExitCode.SUCCESS:
+        return False
+    check = check_test_requirements(manifest)
+    if check is None or check.ok:
+        return True
+    ctx.log.error(check.message)
+    if check.fix:
+        ctx.log.error("Fix: %s", check.fix)
+    return False

--- a/cli/python/base_projects/test_preflight.py
+++ b/cli/python/base_projects/test_preflight.py
@@ -2,18 +2,25 @@
 
 from __future__ import annotations
 
+import sys
+
 import base_cli
 
 from base_setup.manifest_model import BaseManifest
 from base_setup.test_requirements import check_test_requirements
+from base_trust.guidance import print_blocked_command_text
+from base_trust.trust_store import (
+    ManifestCommandTrustStore, compute_trust_identity, manifest_command_surfaces_from_manifest,
+)
 
 
 def project_test_preflight(ctx: base_cli.Context, manifest: BaseManifest) -> bool:
-    # Import at invocation time: the trust command resolves projects through
-    # the project engine, which also owns this preflight's public entry point.
-    from base_trust.engine import require_command
-
-    if require_command(ctx, manifest.project_name, None, str(manifest.path)) != base_cli.ExitCode.SUCCESS:
+    identity = compute_trust_identity(manifest)
+    trust_status = ManifestCommandTrustStore().status(identity)
+    if not trust_status.is_allowed:
+        print_blocked_command_text(
+            trust_status, manifest_command_surfaces_from_manifest(manifest), stream=sys.stderr,
+        )
         return False
     check = check_test_requirements(manifest)
     if check is None or check.ok:

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -1082,7 +1082,10 @@ class ProjectDiscoveryTests(unittest.TestCase):
             (project_root / ".venv" / "bin" / "python").touch()
 
             with (
-                mock.patch("base_trust.engine.require_command", return_value=0),
+                mock.patch(
+                    "base_projects.test_preflight.ManifestCommandTrustStore.status",
+                    return_value=mock.Mock(is_allowed=True),
+                ),
                 mock.patch("base_setup.test_requirements.python_artifact_installed", return_value=False),
             ):
                 status, stdout, stderr = run_engine(["test-command", "demo", "--test-preflight"], base_home)

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -495,9 +495,9 @@ class ProjectDiscoveryTests(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
         self.assertIn(f"Workspace: {workspace.resolve()} (2 projects)", stdout)
-        self.assertIn("base                 ok     ready          valid    2026-06-17", stdout)
-        self.assertIn("demo                 warn   missing        valid    -", stdout)
-        self.assertIn("1 project(s) need attention", stdout)
+        self.assertIn("base                 warn   present_unverified valid    2026-06-17", stdout)
+        self.assertIn("demo                 warn   missing            valid    -", stdout)
+        self.assertIn("2 project(s) need attention", stdout)
 
     def test_workspace_status_reports_uv_project_venv_ready_without_base_project_venv(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -513,8 +513,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
-        self.assertIn("bankbuddy            ok     ready          valid    -", stdout)
-        self.assertIn("All discovered projects look ok.", stdout)
+        self.assertIn("bankbuddy            warn   present_unverified valid    -", stdout)
+        self.assertIn("1 project(s) need attention", stdout)
 
     def test_workspace_status_reports_shell_only_project_venv_not_applicable(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -633,7 +633,7 @@ class ProjectDiscoveryTests(unittest.TestCase):
             stderr,
         )
 
-    def test_workspace_status_json_reports_uv_project_python_runtime(self) -> None:
+    def test_workspace_status_json_reports_unverified_uv_project_runtime(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             home = root / "home"
@@ -653,13 +653,12 @@ class ProjectDiscoveryTests(unittest.TestCase):
             )
 
         payload = json.loads(stdout)
-        runtime = payload["projects"][0]["python_runtime"]
+        project = payload["projects"][0]
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
-        self.assertEqual(runtime["manager"], "uv")
-        self.assertEqual(runtime["version"], "3.12")
-        self.assertEqual(runtime["python"], str(python_bin.resolve()))
-        self.assertEqual(runtime["venv"], str(python_bin.parent.parent.resolve()))
+        self.assertEqual(project["venv"], "present_unverified")
+        self.assertEqual(project["status"], "warn")
+        self.assertNotIn("python_runtime", project)
 
     def test_workspace_status_reports_invalid_manifest_without_stopping_scan(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -678,8 +677,8 @@ class ProjectDiscoveryTests(unittest.TestCase):
 
         self.assertEqual(status, 1)
         self.assertEqual(stderr, "")
-        self.assertIn("broken               error  unknown        invalid", stdout)
-        self.assertIn("demo                 warn   missing        valid", stdout)
+        self.assertIn("broken               error  unknown            invalid", stdout)
+        self.assertIn("demo                 warn   missing            valid", stdout)
         self.assertIn("2 project(s) need attention", stdout)
 
     def test_workspace_status_json_aggregates_mixed_project_states(self) -> None:
@@ -1082,7 +1081,10 @@ class ProjectDiscoveryTests(unittest.TestCase):
             (project_root / ".venv" / "bin").mkdir(parents=True)
             (project_root / ".venv" / "bin" / "python").touch()
 
-            with mock.patch("base_setup.test_requirements.python_artifact_installed", return_value=False):
+            with (
+                mock.patch("base_trust.engine.require_command", return_value=0),
+                mock.patch("base_setup.test_requirements.python_artifact_installed", return_value=False),
+            ):
                 status, stdout, stderr = run_engine(["test-command", "demo", "--test-preflight"], base_home)
 
         self.assertEqual(status, 1)

--- a/cli/python/base_projects/tests/test_inspection_runtime_consent.py
+++ b/cli/python/base_projects/tests/test_inspection_runtime_consent.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+
+import pytest
+
+from base_projects import engine
+from base_setup import engine as setup_engine
+from base_trust.trust_store import ManifestCommandTrustStore, compute_trust_identity_for_manifest
+
+
+@pytest.fixture(name="runtime_project")
+def runtime_project_fixture(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    base = tmp_path / "base"
+    workspace = tmp_path / "workspace"
+    project = workspace / "demo"
+    home.mkdir()
+    defaults = base / "lib" / "base" / "default_manifest.yaml"
+    defaults.parent.mkdir(parents=True)
+    defaults.write_text("project:\n  name: defaults\nartifacts: []\n", encoding="utf-8")
+    project.mkdir(parents=True)
+    manifest = project / "base_manifest.yaml"
+    manifest.write_text(
+        "project:\n  name: demo\npython: {}\ntest:\n  command: 'true'\n"
+        "  requirements: requirements.txt\nartifacts: []\n",
+        encoding="utf-8",
+    )
+    (project / "requirements.txt").write_text("pip\n", encoding="utf-8")
+    workspace_manifest = tmp_path / "workspace.yaml"
+    workspace_manifest.write_text(
+        "schema_version: 1\nworkspace:\n  name: demo\nrepos:\n  - name: demo\n", encoding="utf-8",
+    )
+    python_bin = project / ".venv" / "bin" / "python"
+    python_bin.parent.mkdir(parents=True)
+    marker = project / "runtime-probed"
+    python_bin.write_text(
+        '#!/bin/sh\nprintf probe >> "$(dirname "$0")/../../runtime-probed"\nprintf "3.13\\n"\n',
+        encoding="utf-8",
+    )
+    python_bin.chmod(0o755)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("BASE_HOME", str(base))
+    for variable in ("BASE_PROJECT", "BASE_PROJECT_ROOT", "BASE_PROJECT_MANIFEST", "BASE_PROJECT_VENV_DIR"):
+        monkeypatch.delenv(variable, raising=False)
+    return workspace, workspace_manifest, manifest, marker
+
+
+def invoke(main, arguments):
+    stdout, stderr = io.StringIO(), io.StringIO()
+    with redirect_stdout(stdout), redirect_stderr(stderr):
+        result = main(arguments)
+    return result, stdout.getvalue(), stderr.getvalue()
+
+
+@pytest.mark.parametrize("command", ["status", "check", "doctor", "onboarding"])
+@pytest.mark.parametrize("approved", [False, True])
+def test_workspace_inspection_does_not_execute_runtime(runtime_project, command, approved):
+    workspace, workspace_manifest, manifest, marker = runtime_project
+    if approved:
+        ManifestCommandTrustStore().allow(compute_trust_identity_for_manifest(manifest), base_version="fixture")
+
+    result, stdout, _stderr = invoke(engine.main, [
+        command, "--workspace", str(workspace), "--manifest", str(workspace_manifest), "--format", "json", "--yes",
+    ])
+
+    assert result == 0
+    assert not marker.exists()
+    document = json.loads(stdout)
+    assert "unverified" in json.dumps(document) or "needs_verification" in json.dumps(document)
+
+
+@pytest.mark.parametrize("action", ["check", "doctor"])
+def test_project_inspection_does_not_execute_runtime(runtime_project, action):
+    _workspace, _workspace_manifest, manifest, marker = runtime_project
+    result, stdout, _stderr = invoke(setup_engine.main, [
+        "--action", action, "--manifest", str(manifest), "--format", "json",
+    ])
+
+    assert result == 0
+    assert not marker.exists()
+    assert "unverified" in stdout
+
+
+def test_test_preflight_requires_approval_before_runtime_probe(runtime_project):
+    workspace, _workspace_manifest, _manifest, marker = runtime_project
+    result, _stdout, stderr = invoke(engine.main, [
+        "test-command", "demo", "--workspace", str(workspace), "--test-preflight",
+    ])
+
+    assert result == 1
+    assert not marker.exists()
+    assert "trust" in stderr.lower()
+
+
+@pytest.mark.parametrize("command", ["check", "doctor"])
+def test_workspace_runtime_verification_requires_explicit_option(runtime_project, command):
+    workspace, workspace_manifest, _manifest, marker = runtime_project
+    result, stdout, _stderr = invoke(engine.main, [
+        command, "--workspace", str(workspace), "--manifest", str(workspace_manifest), "--format", "json",
+        "--verify-project-runtime",
+    ])
+
+    assert result == 0
+    assert marker.is_file()
+    assert "unverified" not in stdout
+
+
+@pytest.mark.parametrize("action", ["check", "doctor"])
+def test_project_runtime_verification_requires_explicit_option(runtime_project, action):
+    _workspace, _workspace_manifest, manifest, marker = runtime_project
+    result, stdout, _stderr = invoke(setup_engine.main, [
+        "--action", action, "--manifest", str(manifest), "--format", "json", "--verify-project-runtime",
+    ])
+
+    assert result == 0
+    assert marker.is_file()
+    assert "unverified" not in stdout
+
+
+def test_approved_test_preflight_can_verify_runtime(runtime_project):
+    workspace, _workspace_manifest, manifest, marker = runtime_project
+    ManifestCommandTrustStore().allow(compute_trust_identity_for_manifest(manifest), base_version="fixture")
+    result, _stdout, _stderr = invoke(engine.main, [
+        "test-command", "demo", "--workspace", str(workspace), "--test-preflight",
+    ])
+
+    assert result == 0
+    assert marker.is_file()
+
+
+def test_status_rejects_runtime_execution_option(runtime_project):
+    workspace, _workspace_manifest, _manifest, marker = runtime_project
+    result, _stdout, stderr = invoke(engine.main, [
+        "status", "--workspace", str(workspace), "--verify-project-runtime",
+    ])
+
+    assert result == 2
+    assert not marker.exists()
+    assert "only supported for workspace check and doctor" in stderr
+
+
+@pytest.mark.parametrize("action", ["check", "doctor"])
+def test_explicit_verification_reports_broken_runtime(runtime_project, action):
+    _workspace, _workspace_manifest, manifest, marker = runtime_project
+    python_bin = manifest.parent / ".venv" / "bin" / "python"
+    python_bin.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+
+    result, stdout, _stderr = invoke(setup_engine.main, [
+        "--action", action, "--manifest", str(manifest), "--format", "json", "--verify-project-runtime",
+    ])
+
+    assert result == 1
+    assert "BASE-P050" in stdout
+    assert "missing or incomplete" in stdout
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize("delegate", ["brew", "mise", "uv"])
+def test_static_inspection_does_not_execute_project_tool_configuration(runtime_project, monkeypatch, delegate):
+    _workspace, _workspace_manifest, manifest, marker = runtime_project
+    project = manifest.parent
+    tools = project / "tools"
+    tools.mkdir()
+    tool = tools / delegate
+    tool.write_text(f'#!/bin/sh\nprintf probe >> "{marker}"\nexit 0\n', encoding="utf-8")
+    tool.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tools), prepend=":")
+    monkeypatch.setenv("BASE_PLATFORM", "macos")
+    if delegate == "brew":
+        (project / "Brewfile").write_text('brew "git"\n', encoding="utf-8")
+        declaration = "brewfile: Brewfile\npython: {}\n"
+        finding = "BASE-P012"
+    elif delegate == "mise":
+        (project / ".mise.toml").write_text('[tools]\npython = "3.13"\n', encoding="utf-8")
+        declaration = "mise: .mise.toml\npython: {}\n"
+        finding = "BASE-P022"
+    else:
+        (project / "pyproject.toml").write_text('[project]\nname = "demo"\nversion = "0.1.0"\n', encoding="utf-8")
+        (project / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+        declaration = "python:\n  manager: uv\n"
+        finding = "BASE-P155"
+    manifest.write_text(f"project:\n  name: demo\n{declaration}artifacts: []\n", encoding="utf-8")
+
+    result, stdout, _stderr = invoke(setup_engine.main, [
+        "--action", "check", "--manifest", str(manifest), "--format", "json",
+    ])
+
+    assert result == 0, (stdout, _stderr)
+    assert not marker.exists()
+    assert finding in stdout
+    assert "unverified" in stdout

--- a/cli/python/base_projects/tests/test_workspace_checks.py
+++ b/cli/python/base_projects/tests/test_workspace_checks.py
@@ -554,7 +554,7 @@ class WorkspaceCheckTests(unittest.TestCase):
                 write_ready_python_bin(python_bin)
 
             status, stdout, stderr = invoke_engine(
-                ["check", "--workspace", str(workspace), "--manifest", str(manifest_path)],
+                ["check", "--verify-project-runtime", "--workspace", str(workspace), "--manifest", str(manifest_path)],
                 base_home,
                 home,
             )
@@ -669,7 +669,10 @@ class WorkspaceCheckTests(unittest.TestCase):
             broken_root.mkdir(parents=True)
             (broken_root / "base_manifest.yaml").write_text("project: [", encoding="utf-8")
 
-            status, stdout, stderr = invoke_engine(["check", "--workspace", str(workspace)], base_home, home)
+            status, stdout, stderr = invoke_engine(
+                ["check", "--verify-project-runtime", "--workspace", str(workspace)],
+                base_home, home,
+            )
 
         self.assertEqual(status, 1)
         self.assertIn(f"Workspace check: {workspace.resolve()} (2 projects)", stdout)
@@ -701,7 +704,10 @@ class WorkspaceCheckTests(unittest.TestCase):
                     ),
                 ),
             ):
-                status, stdout, stderr = invoke_engine(["check", "--workspace", str(workspace)], base_home, home)
+                status, stdout, stderr = invoke_engine(
+                    ["check", "--verify-project-runtime", "--workspace", str(workspace)],
+                    base_home, home,
+                )
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
@@ -731,7 +737,10 @@ class WorkspaceCheckTests(unittest.TestCase):
                     ),
                 ),
             ):
-                status, stdout, stderr = invoke_engine(["doctor", "--workspace", str(workspace)], base_home, home)
+                status, stdout, stderr = invoke_engine(
+                    ["doctor", "--verify-project-runtime", "--workspace", str(workspace)],
+                    base_home, home,
+                )
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")
@@ -814,7 +823,7 @@ class WorkspaceCheckTests(unittest.TestCase):
             python_bin.chmod(0o755)
 
             status, stdout, stderr = invoke_engine(
-                ["check", "--workspace", str(workspace), "--format", "json"],
+                ["check", "--verify-project-runtime", "--workspace", str(workspace), "--format", "json"],
                 base_home,
                 home,
             )
@@ -909,7 +918,10 @@ class WorkspaceCheckTests(unittest.TestCase):
             python_bin = workspace / "demo" / ".venv" / "bin" / "python"
             write_ready_python_bin(python_bin)
 
-            status, stdout, stderr = invoke_engine(["doctor", "--workspace", str(workspace)], base_home, home)
+            status, stdout, stderr = invoke_engine(
+                ["doctor", "--verify-project-runtime", "--workspace", str(workspace)],
+                base_home, home,
+            )
 
         self.assertEqual(status, 0)
         self.assertEqual(stderr, "")

--- a/cli/python/base_projects/tests/test_workspace_onboarding.py
+++ b/cli/python/base_projects/tests/test_workspace_onboarding.py
@@ -176,14 +176,16 @@ class WorkspaceOnboardingTests(unittest.TestCase):
         self.assertEqual(payload["workspace"], str(workspace.resolve()))
         self.assertEqual(payload["workspace_manifest"]["name"], "demo-suite")
         self.assertEqual(payload["repository_count"], 4)
-        self.assertEqual(payload["next_actions"], [])
-        self.assertEqual(repositories["base"]["status"], "ready")
+        self.assertEqual(len(payload["next_actions"]), 1)
+        self.assertEqual(payload["next_actions"][0]["description"], "Review runtimes and verify workspace health")
+        self.assertEqual(repositories["base"]["status"], "needs_verification")
         self.assertEqual(repositories["base"]["discovery_status"], "present")
         self.assertEqual(repositories["base"]["path"], str((workspace / "base").resolve()))
         self.assertEqual(repositories["base"]["setup_command"], f"cd {(workspace / 'base').resolve()} && basectl setup")
         self.assertEqual(
             repositories["base"]["validation_command"],
-            f"cd {(workspace / 'base').resolve()} && basectl check",
+            f"basectl check --manifest {(workspace / 'base' / 'base_manifest.yaml').resolve()} "
+            "--verify-project-runtime",
         )
         self.assertEqual(repositories["base"]["test_command"], "./bin/base-test")
         self.assertIsNone(repositories["base"]["clone_command"])
@@ -213,12 +215,14 @@ class WorkspaceOnboardingTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertIn(f"Workspace onboarding: {workspace.resolve()} (demo-suite)", stdout)
         self.assertIn(f"Workspace manifest: {manifest_path.resolve()}", stdout)
-        self.assertIn("base                 yes      ready", stdout)
+        self.assertIn("base                 yes      needs_verification", stdout)
         self.assertIn("api                  yes      missing_required", stdout)
         self.assertIn("optional-tool        no       missing_optional", stdout)
         self.assertIn(f"clone: git clone git@github.com:example/api.git {(workspace / 'api').resolve()}", stdout)
         self.assertIn("optional repository is missing; clone it only if this role needs it", stdout)
-        self.assertIn(f"validate: cd {(workspace / 'base').resolve()} && basectl check", stdout)
+        self.assertIn(
+            f"validate: basectl check --manifest {(workspace / 'base' / 'base_manifest.yaml').resolve()}", stdout,
+        )
         self.assertIn("test: ./bin/base-test", stdout)
         self.assertIn("Workspace onboarding — next actions (3 steps to ready):", stdout)
         self.assertIn(
@@ -272,11 +276,11 @@ class WorkspaceOnboardingTests(unittest.TestCase):
                 },
                 {
                     "order": 2,
-                    "description": "Verify workspace health",
+                    "description": "Review runtimes and verify workspace health",
                     "commands": [
                         (
                             f"basectl workspace check --workspace {workspace.resolve()} "
-                            f"--manifest {manifest_path.resolve()}"
+                            f"--manifest {manifest_path.resolve()} --verify-project-runtime"
                         )
                     ],
                 },

--- a/cli/python/base_projects/tests/test_workspace_status_manifest.py
+++ b/cli/python/base_projects/tests/test_workspace_status_manifest.py
@@ -170,12 +170,12 @@ class WorkspaceStatusManifestTests(unittest.TestCase):
         self.assertEqual(stderr, "")
         self.assertIn(f"Workspace: {workspace.resolve()} (5 repositories)", stdout)
         self.assertIn(f"Workspace manifest: {manifest_path.resolve()} (demo-suite)", stdout)
-        self.assertIn("base                 ok     yes      present  ready          valid    2026-06-17", stdout)
+        self.assertIn("base                 warn   yes      present  present_unverified valid    2026-06-17", stdout)
         self.assertIn("docs                 ok", stdout)
         self.assertIn("api                  error", stdout)
         self.assertIn("optional-tool        warn", stdout)
         self.assertIn("extra                warn", stdout)
-        self.assertIn("3 repositories need attention", stdout)
+        self.assertIn("4 repositories need attention", stdout)
 
     def test_workspace_status_manifest_supports_json_format(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -217,7 +217,7 @@ class WorkspaceStatusManifestTests(unittest.TestCase):
         self.assertEqual(payload["workspace_manifest"]["path"], str(manifest_path.resolve()))
         self.assertEqual(payload["workspace_manifest"]["name"], "demo-suite")
         self.assertEqual(payload["repository_count"], 4)
-        self.assertEqual(projects_by_repo["base"]["status"], "ok")
+        self.assertEqual(projects_by_repo["base"]["status"], "warn")
         self.assertEqual(projects_by_repo["base"]["required"], True)
         self.assertEqual(projects_by_repo["base"]["repo"], "present")
         self.assertEqual(projects_by_repo["base"]["url"], "git@github.com:codeforester/base.git")

--- a/cli/python/base_projects/workspace_checks.py
+++ b/cli/python/base_projects/workspace_checks.py
@@ -25,13 +25,10 @@ from base_setup.checks import doctor_status
 from base_setup.diagnostics import check_record_warning
 from base_setup.diagnostics import write_check_record
 from base_setup.engine import manifest_checks
-from base_setup.engine import pre_venv_manifest_checks
 from base_setup.engine import read_default_manifest
 from base_setup.manifest import read_manifest
 from base_setup.manifest_loader import ManifestError
 from base_setup.manifest_model import BaseManifest
-from base_setup.project_routing import manifest_requires_project_python
-from base_setup.uv import manifest_uses_uv_project_manager
 
 
 WORKSPACE_CHECK_COMMAND = "basectl workspace check"
@@ -93,20 +90,26 @@ def workspace_project_check_results(
     ctx: base_cli.Context,
     workspace_root: Path,
     workspace_manifest: WorkspaceManifest | None = None,
+    *,
+    verify_project_runtime: bool = False,
 ) -> tuple[WorkspaceProjectCheckResult, ...]:
     default_manifest = read_default_manifest(ctx)
     if workspace_manifest is None:
         return tuple(
-            workspace_project_check_result(entry, default_manifest)
+            workspace_project_check_result(entry, default_manifest, verify_project_runtime=verify_project_runtime)
             for entry in workspace_manifest_entries(workspace_root, include_outside=False)
         )
-    return workspace_manifest_project_check_results(workspace_root, workspace_manifest, default_manifest)
+    return workspace_manifest_project_check_results(
+        workspace_root, workspace_manifest, default_manifest, verify_project_runtime=verify_project_runtime,
+    )
 
 
 def workspace_manifest_project_check_results(
     workspace_root: Path,
     workspace_manifest: WorkspaceManifest,
     default_manifest: BaseManifest,
+    *,
+    verify_project_runtime: bool = False,
 ) -> tuple[WorkspaceProjectCheckResult, ...]:
     entries_by_repo = {
         entry.path.parent.name: entry
@@ -118,10 +121,14 @@ def workspace_manifest_project_check_results(
     for repo in workspace_manifest.repos:
         entry = entries_by_repo.pop(repo.name, None)
         repository_paths_by_name.pop(repo.name, None)
-        results.append(workspace_expected_repo_check_result(workspace_root, repo, entry, default_manifest))
+        results.append(workspace_expected_repo_check_result(
+            workspace_root, repo, entry, default_manifest, verify_project_runtime=verify_project_runtime,
+        ))
 
     for repo_name in sorted(entries_by_repo):
-        results.append(workspace_extra_project_check_result(entries_by_repo[repo_name], default_manifest))
+        results.append(workspace_extra_project_check_result(
+            entries_by_repo[repo_name], default_manifest, verify_project_runtime=verify_project_runtime,
+        ))
     for repo_name in sorted(repository_paths_by_name):
         results.append(workspace_undeclared_repo_check_result(repository_paths_by_name[repo_name]))
 
@@ -133,10 +140,12 @@ def workspace_expected_repo_check_result(
     repo: WorkspaceManifestRepo,
     entry: ManifestEntry | None,
     default_manifest: BaseManifest,
+    *,
+    verify_project_runtime: bool = False,
 ) -> WorkspaceProjectCheckResult:
     root = (workspace_root / repo.name).resolve()
     if entry is not None:
-        result = workspace_project_check_result(entry, default_manifest)
+        result = workspace_project_check_result(entry, default_manifest, verify_project_runtime=verify_project_runtime)
         checks = (workspace_repo_presence_check(repo, root, present=True),) + result.checks
         return attach_check_result_repo_metadata(
             result,
@@ -200,8 +209,10 @@ def attach_check_result_repo_metadata(
 def workspace_extra_project_check_result(
     entry: ManifestEntry,
     default_manifest: BaseManifest,
+    *,
+    verify_project_runtime: bool = False,
 ) -> WorkspaceProjectCheckResult:
-    result = workspace_project_check_result(entry, default_manifest)
+    result = workspace_project_check_result(entry, default_manifest, verify_project_runtime=verify_project_runtime)
     checks = (workspace_extra_project_check(result),) + result.checks
     return replace(
         result,
@@ -217,6 +228,8 @@ def workspace_extra_project_check_result(
 def workspace_project_check_result(
     entry: ManifestEntry,
     default_manifest: BaseManifest,
+    *,
+    verify_project_runtime: bool = False,
 ) -> WorkspaceProjectCheckResult:
     root = entry.path.parent.resolve()
     manifest_path = entry.path.resolve()
@@ -233,14 +246,7 @@ def workspace_project_check_result(
             checks=checks,
         )
 
-    if not manifest_requires_project_python(manifest) or manifest_uses_uv_project_manager(manifest):
-        checks = manifest_checks(default_manifest, manifest)
-    else:
-        venv_check = project_venv_check(manifest)
-        if venv_check.ok:
-            checks = (venv_check,) + manifest_checks(default_manifest, manifest)
-        else:
-            checks = pre_venv_manifest_checks(manifest) + (venv_check,)
+    checks = manifest_checks(default_manifest, manifest, verify_project_runtime=verify_project_runtime)
 
     return WorkspaceProjectCheckResult(
         name=manifest.project_name,

--- a/cli/python/base_projects/workspace_onboarding.py
+++ b/cli/python/base_projects/workspace_onboarding.py
@@ -14,6 +14,7 @@ from base_projects.workspace_statuses import WorkspaceProjectStatus
 from base_projects.workspace_statuses import workspace_manifest_project_statuses
 from base_setup.manifest import read_manifest
 from base_setup.manifest_loader import ManifestError
+from base_setup.runtime_inspection import runtime_verification_command
 
 
 @dataclass(frozen=True)
@@ -122,11 +123,11 @@ def workspace_onboarding_next_actions(
             )
         )
 
-    if actions:
+    if actions or any(repository.status == "needs_verification" for repository in summary.repositories):
         actions.append(
             WorkspaceNextAction(
                 order=len(actions) + 1,
-                description="Verify workspace health",
+                description="Review runtimes and verify workspace health",
                 commands=(workspace_check_command(summary),),
             )
         )
@@ -158,6 +159,7 @@ def workspace_check_command(summary: WorkspaceOnboardingSummary) -> str:
             str(summary.workspace_root),
             "--manifest",
             str(summary.workspace_manifest.path),
+            "--verify-project-runtime",
         ]
     )
 
@@ -198,6 +200,8 @@ def onboarding_status(status: WorkspaceProjectStatus) -> str:
         return "present_without_manifest"
     if status.manifest == "invalid":
         return "invalid_manifest"
+    if status.venv == "present_unverified":
+        return "needs_verification"
     if status.venv in ("ready", "not_applicable"):
         return "ready"
     return "needs_setup"
@@ -212,6 +216,8 @@ def setup_command_for_status(status: WorkspaceProjectStatus) -> str | None:
 def validation_command_for_status(status: WorkspaceProjectStatus) -> str | None:
     if status.manifest != "valid":
         return None
+    if status.venv == "present_unverified" and status.manifest_path is not None:
+        return runtime_verification_command(status.manifest_path)
     return f"cd {shlex.quote(str(status.root))} && basectl check"
 
 
@@ -257,8 +263,11 @@ def next_action_for_status(status: WorkspaceProjectStatus, status_name: str) -> 
         return f"Add or verify {(status.root / 'base_manifest.yaml').resolve()} before Base setup."
     if status_name == "invalid_manifest":
         return f"Fix {status.manifest_path} before Base setup."
-    if status_name == "ready":
-        return "Run validation command."
+    if status_name in {"needs_verification", "ready"}:
+        return (
+            "Review the project runtime and configuration, then run the validation command."
+            if status_name == "needs_verification" else "Run validation command."
+        )
     return "Run setup command, then validation command."
 
 

--- a/cli/python/base_projects/workspace_report_text.py
+++ b/cli/python/base_projects/workspace_report_text.py
@@ -36,12 +36,12 @@ def print_workspace_status(
         print("No Base-managed projects discovered.")
         return
 
-    print(f"{'PROJECT':<20} {'STATUS':<6} {'VENV':<14} {'MANIFEST':<8} {'LAST CHECK':<10} PATH")
+    print(f"{'PROJECT':<20} {'STATUS':<6} {'VENV':<18} {'MANIFEST':<8} {'LAST CHECK':<10} PATH")
     for status in statuses:
         print(
             f"{status.name:<20} "
             f"{status.status:<6} "
-            f"{status.venv:<14} "
+            f"{status.venv:<18} "
             f"{status.manifest:<8} "
             f"{last_check_display(status.last_check):<10} "
             f"{status.root}"
@@ -68,7 +68,7 @@ def print_manifest_workspace_status(
 
     print(
         f"{'REPOSITORY':<20} {'STATUS':<6} {'REQUIRED':<8} {'REPO':<8} "
-        f"{'VENV':<14} {'MANIFEST':<8} {'LAST CHECK':<10} PATH"
+        f"{'VENV':<18} {'MANIFEST':<8} {'LAST CHECK':<10} PATH"
     )
     for status in statuses:
         print(
@@ -76,7 +76,7 @@ def print_manifest_workspace_status(
             f"{status.status:<6} "
             f"{yes_no(status.required):<8} "
             f"{status.repo:<8} "
-            f"{status.venv:<14} "
+            f"{status.venv:<18} "
             f"{status.manifest:<8} "
             f"{last_check_display(status.last_check):<10} "
             f"{status.root}"

--- a/cli/python/base_projects/workspace_statuses.py
+++ b/cli/python/base_projects/workspace_statuses.py
@@ -58,7 +58,7 @@ def workspace_manifest_project_statuses(
     workspace_root: Path,
     workspace_manifest: WorkspaceManifest,
     *,
-    probe_venv: bool = True,
+    probe_venv: bool = False,
 ) -> tuple[WorkspaceProjectStatus, ...]:
     entries_by_repo = {
         entry.path.parent.name: entry
@@ -81,7 +81,7 @@ def workspace_expected_repo_status(
     repo: WorkspaceManifestRepo,
     entry: ManifestEntry | None,
     *,
-    probe_venv: bool = True,
+    probe_venv: bool = False,
 ) -> WorkspaceProjectStatus:
     root = (workspace_root / repo.name).resolve()
     if entry is not None:
@@ -139,7 +139,7 @@ def attach_status_repo_metadata(
     )
 
 
-def workspace_extra_project_status(entry: ManifestEntry, *, probe_venv: bool = True) -> WorkspaceProjectStatus:
+def workspace_extra_project_status(entry: ManifestEntry, *, probe_venv: bool = False) -> WorkspaceProjectStatus:
     status = workspace_project_status(entry, probe_venv=probe_venv)
     return replace(
         status,
@@ -152,7 +152,7 @@ def workspace_extra_project_status(entry: ManifestEntry, *, probe_venv: bool = T
     )
 
 
-def workspace_project_status(entry: ManifestEntry, *, probe_venv: bool = True) -> WorkspaceProjectStatus:
+def workspace_project_status(entry: ManifestEntry, *, probe_venv: bool = False) -> WorkspaceProjectStatus:
     root = entry.path.parent.resolve()
     try:
         manifest = read_manifest(entry.path)
@@ -193,7 +193,7 @@ def workspace_project_status(entry: ManifestEntry, *, probe_venv: bool = True) -
             name=manifest.project_name,
             root=root,
             manifest_path=entry.path.resolve(),
-            status="ok",
+            status="ok" if probe_venv else "warn",
             venv=ready_label,
             manifest="valid",
             issues=(),

--- a/cli/python/base_setup/brewfile_delegate.py
+++ b/cli/python/base_setup/brewfile_delegate.py
@@ -11,9 +11,10 @@ from .checks import ArtifactCheck
 from .errors import ArtifactError
 from .manifest import BaseManifest
 from .platform_policy import brewfile_delegates_supported, platform_label
+from .runtime_inspection import unverified_runtime_check
 
 
-def check_brewfile(manifest: BaseManifest) -> ArtifactCheck:
+def check_brewfile(manifest: BaseManifest, *, verify_project_runtime: bool = True) -> ArtifactCheck:
     try:
         brewfile_path = resolve_brewfile_path(manifest)
     except ArtifactError as exc:
@@ -47,6 +48,9 @@ def check_brewfile(manifest: BaseManifest) -> ArtifactCheck:
             finding_id="BASE-P011",
         )
 
+    if not verify_project_runtime:
+        return unverified_runtime_check(manifest, "brewfile", "BASE-P012")
+
     try:
         ok = process.run_check(
             ["brew", "bundle", "check", f"--file={brewfile_path}"],
@@ -65,19 +69,11 @@ def check_brewfile(manifest: BaseManifest) -> ArtifactCheck:
             status="warn",
             finding_id="BASE-P012",
         )
-    if ok:
-        return ArtifactCheck(
-            name="brewfile",
-            ok=True,
-            message=f"Brewfile dependencies are satisfied for '{brewfile_path}'.",
-            fix="",
-            finding_id="BASE-P012",
-        )
     return ArtifactCheck(
         name="brewfile",
-        ok=False,
-        message=f"Brewfile dependencies are not satisfied for '{brewfile_path}'.",
-        fix=f"basectl setup {manifest.project_name}",
+        ok=ok,
+        message=f"Brewfile dependencies are {'satisfied' if ok else 'not satisfied'} for '{brewfile_path}'.",
+        fix="" if ok else f"basectl setup {manifest.project_name}",
         finding_id="BASE-P012",
     )
 
@@ -139,4 +135,3 @@ def homebrew_no_auto_update_env() -> dict[str, str]:
     env = os.environ.copy()
     env["HOMEBREW_NO_AUTO_UPDATE"] = "1"
     return env
-

--- a/cli/python/base_setup/engine.py
+++ b/cli/python/base_setup/engine.py
@@ -51,6 +51,7 @@ class ManifestAction:
     write: bool = False
     remote_network: bool = False
     allow_project_ide_mutations: bool = False
+    verify_project_runtime: bool = False
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -79,6 +80,10 @@ def main(argv: list[str] | None = None) -> int:
     is_flag=True,
     help="Approve project-originated IDE app, extension, and user-setting mutations for setup.",
 )
+@base_cli.option(
+    "--verify-project-runtime", is_flag=True,
+    help="Authorize execution of project runtimes and configuration for check/doctor in this invocation.",
+)
 # pylint: disable=too-many-arguments,too-many-positional-arguments
 def run(
     ctx: base_cli.Context,
@@ -91,6 +96,7 @@ def run(
     output_format: str,
     remote_network: bool,
     allow_project_ide_mutations: bool,
+    verify_project_runtime: bool,
 ) -> int:
     manifest_path = Path(manifest).resolve() if manifest else discover_manifest(Path(start_dir))
     if manifest_path is not None:
@@ -106,6 +112,9 @@ def run(
         base_manifest = read_manifest(manifest_path)
         ctx.bind_project(base_manifest.project_name, manifest_path.parent, manifest_path)
         validate_project_name(base_manifest, project)
+        if verify_project_runtime and action not in {"check", "doctor", "precheck", "predoctor"}:
+            ctx.log.error("--verify-project-runtime is only supported for check and doctor.")
+            return base_cli.ExitCode.USAGE_ERROR
         manifest_action = ManifestAction(
             action,
             dry_run,
@@ -113,6 +122,7 @@ def run(
             write,
             remote_network,
             allow_project_ide_mutations,
+            verify_project_runtime,
         )
         if action == "route":
             status = route_manifest(ctx, manifest_action, base_manifest)
@@ -169,6 +179,7 @@ def run_manifest_action(
             base_manifest,
             output_format=manifest_action.output_format,
             remote_network=manifest_action.remote_network,
+            verify_project_runtime=manifest_action.verify_project_runtime,
         )
     elif action == "doctor":
         status = doctor_manifest(
@@ -177,6 +188,7 @@ def run_manifest_action(
             output_format=manifest_action.output_format,
             remote_network=manifest_action.remote_network,
             user_config=ctx.user_config,
+            verify_project_runtime=manifest_action.verify_project_runtime,
         )
     elif action == "precheck":
         status = check_pre_venv_manifest(
@@ -286,18 +298,22 @@ def log_check_text_result(ctx: base_cli.Context, check: ArtifactCheck) -> None:
         log_result("Fix: %s", check.fix)
 
 
+# pylint: disable=too-many-arguments
 def check_manifest(
     ctx: base_cli.Context,
     default_manifest: BaseManifest,
     manifest: BaseManifest,
     output_format: str,
     remote_network: bool = False,
+    *,
+    verify_project_runtime: bool = False,
 ) -> int:
     checks = manifest_checks(
         default_manifest,
         manifest,
         remote_network=remote_network,
         user_config=ctx.user_config,
+        verify_project_runtime=verify_project_runtime,
     )
     if output_format == "json":
         print(json.dumps(checks_payload_to_json(checks, project=manifest.project_name), indent=2))
@@ -335,6 +351,7 @@ def check_pre_venv_manifest(
     return base_cli.ExitCode.FAILURE
 
 
+# pylint: disable=too-many-arguments
 def doctor_manifest(
     default_manifest: BaseManifest,
     manifest: BaseManifest,
@@ -342,6 +359,7 @@ def doctor_manifest(
     remote_network: bool = False,
     *,
     user_config: UserConfig | None = None,
+    verify_project_runtime: bool = False,
 ) -> int:
     if output_format not in {"json", "text"}:
         print(f"Unsupported doctor output format '{output_format}'. Expected text or json.", file=sys.stderr)
@@ -352,6 +370,7 @@ def doctor_manifest(
         manifest,
         remote_network=remote_network,
         user_config=user_config,
+        verify_project_runtime=verify_project_runtime,
     )
     if output_format == "json":
         print(json.dumps([check_to_json(check) for check in checks], indent=2))

--- a/cli/python/base_setup/finding_explanations.py
+++ b/cli/python/base_setup/finding_explanations.py
@@ -143,11 +143,13 @@ CATALOG = catalog_by_id(
                 "reliable project setup and command execution."
             ),
             likely_causes=(
+                "Static inspection has not executed the project interpreter; readiness remains unverified.",
                 "The project virtual environment has not been created yet.",
                 "The environment exists but its Python executable is missing or broken.",
                 "The project changed Python versions and the old virtual environment was not recreated.",
             ),
             fix_steps=(
+                "Review the runtime, then run `basectl check <project> --verify-project-runtime` to verify it.",
                 "Run `basectl setup <project> --dry-run` to preview project environment actions.",
                 "Run `basectl setup <project>` to create missing project artifacts.",
                 "Use `--recreate-venv` when Base reports that the existing venv must be replaced.",
@@ -300,7 +302,7 @@ CATALOG = catalog_by_id(
         FindingExplanation(
             finding_id="BASE-P181",
             title="Project test requirements environment",
-            summary="The project virtual environment does not satisfy the requirements declared for its test command.",
+            summary="Project test requirements are unverified or are not satisfied by the project environment.",
             why_it_matters=(
                 "Running a test command before its declared environment is ready produces late import or tool "
                 "errors. Base reports the missing packages before executing the command."
@@ -312,7 +314,8 @@ CATALOG = catalog_by_id(
             ),
             fix_steps=(
                 "Run `basectl setup <project>` to install the declared test requirements.",
-                "Run `basectl check <project>` and confirm `BASE-P181` reports `ok`.",
+                "Review the runtime, then run `basectl check <project> --verify-project-runtime` "
+                "and confirm readiness.",
                 "Rerun the test command only after the environment check passes."
             ),
             related_commands=("basectl setup <project>", "basectl check <project>", "basectl test <project>"),

--- a/cli/python/base_setup/manifest_checks.py
+++ b/cli/python/base_setup/manifest_checks.py
@@ -5,6 +5,7 @@ import os
 from base_cli_adapters.config import UserConfig, UserIdeConfig
 
 from .artifacts import check_artifact
+from .artifacts import artifact_details
 from .artifacts import resolve_artifact_definitions
 from .build import check_build
 from .checks import ArtifactCheck
@@ -22,7 +23,10 @@ from .ide_settings import check_ide_settings
 from .manifest import BaseManifest
 from .pyproject import check_pyproject
 from .python_policy import python_requirement_checks
+from .python_policy import python_requirement_policy_check
 from .python_runtime import project_python_runtime_check
+from .project_routing import manifest_requires_project_python, route_for_manifest
+from .runtime_inspection import project_environment_check, unverified_runtime_check
 from .setup_reconcile import effective_manifest_with_user_config
 from .setup_reconcile import project_runtime_argument
 from .setup_reconcile import setup_artifacts
@@ -32,9 +36,18 @@ from .uv import check_uv
 IDE_EXTENSION_PROFILE = "dev"
 
 
-def pre_venv_manifest_checks(manifest: BaseManifest, remote_network: bool = False) -> tuple[ArtifactCheck, ...]:
+def pre_venv_manifest_checks(
+    manifest: BaseManifest, remote_network: bool = False, *, verify_project_runtime: bool = False,
+) -> tuple[ArtifactCheck, ...]:
     checks: list[ArtifactCheck] = []
-    checks.extend(python_requirement_checks(manifest))
+    if verify_project_runtime:
+        checks.extend(python_requirement_checks(manifest))
+    else:
+        policy = python_requirement_policy_check(manifest)
+        if policy is not None:
+            checks.append(policy)
+            if policy.ok:
+                checks.append(unverified_runtime_check(manifest, "python.interpreter", "BASE-P171"))
     checks.extend(check_git_remote(manifest, check_network=remote_network))
     return tuple(checks)
 
@@ -45,6 +58,7 @@ def manifest_checks(
     remote_network: bool = False,
     *,
     user_config: UserConfig | None = None,
+    verify_project_runtime: bool = False,
 ) -> tuple[ArtifactCheck, ...]:
     pre_venv_checks: list[ArtifactCheck] = []
     checks: list[ArtifactCheck] = []
@@ -53,13 +67,24 @@ def manifest_checks(
     artifacts = setup_artifacts(default_manifest, effective_manifest)
     definitions = resolve_artifact_definitions(artifacts)
 
-    pre_venv_checks.extend(pre_venv_manifest_checks(effective_manifest, remote_network=remote_network))
+    pre_venv_checks.extend(pre_venv_manifest_checks(
+        effective_manifest, remote_network=remote_network, verify_project_runtime=verify_project_runtime,
+    ))
     checks.extend(ide_preference_warning_checks(manifest, active_user_config))
 
+    runtime_verified = verify_project_runtime
+    if manifest_requires_project_python(effective_manifest):
+        environment = project_environment_check(
+            effective_manifest, route_for_manifest(effective_manifest).project_venv_dir,
+            verify_project_runtime=verify_project_runtime,
+        )
+        checks.append(environment)
+        runtime_verified = verify_project_runtime and environment.ok
+
     if effective_manifest.brewfile is not None:
-        checks.append(check_brewfile(effective_manifest))
+        checks.append(check_brewfile(effective_manifest, verify_project_runtime=verify_project_runtime))
     if effective_manifest.mise is not None:
-        checks.append(check_mise(effective_manifest))
+        checks.append(check_mise(effective_manifest, verify_project_runtime=verify_project_runtime))
 
     checks.extend(check_required_env(effective_manifest))
     checks.extend(check_required_ports(effective_manifest))
@@ -70,16 +95,25 @@ def manifest_checks(
     if setup_profile_enabled(IDE_EXTENSION_PROFILE):
         checks.extend(check_ide_extensions(effective_manifest))
     checks.extend(check_ide_settings(effective_manifest))
-    checks.extend(check_uv(effective_manifest))
+    checks.extend(
+        check for check in check_uv(effective_manifest, verify_project_runtime=verify_project_runtime)
+        if check.finding_id != "BASE-P154"  # Runtime presence/verification is reported above.
+    )
     checks.extend(check_pyproject(effective_manifest))
-    checks.extend(project_python_runtime_check(effective_manifest))
-    test_requirements_check = check_test_requirements(effective_manifest)
+    if runtime_verified:
+        checks.extend(project_python_runtime_check(effective_manifest))
+    test_requirements_check = check_test_requirements(effective_manifest, verify_project_runtime=runtime_verified)
     if test_requirements_check is not None:
         checks.append(test_requirements_check)
 
     runtime_config = project_runtime_argument(effective_manifest)
     for artifact, definition in zip(artifacts, definitions, strict=True):
-        checks.append(check_artifact(runtime_config, artifact, definition))
+        if definition.manager == "pip" and not runtime_verified:
+            checks.append(unverified_runtime_check(
+                effective_manifest, artifact.name, "BASE-P040", details=artifact_details(definition),
+            ))
+        else:
+            checks.append(check_artifact(runtime_config, artifact, definition))
 
     if not pre_venv_checks and not checks:
         checks.append(

--- a/cli/python/base_setup/mise_delegate.py
+++ b/cli/python/base_setup/mise_delegate.py
@@ -15,10 +15,11 @@ from .checks import ArtifactCheck
 from .errors import ArtifactError
 from .manifest import BaseManifest
 from .platform_policy import current_base_platform
+from .runtime_inspection import unverified_runtime_check
 from .user_paths import prepend_user_local_bin_to_path
 from .user_paths import user_local_bin
 
-def check_mise(manifest: BaseManifest) -> ArtifactCheck:
+def check_mise(manifest: BaseManifest, *, verify_project_runtime: bool = True) -> ArtifactCheck:
     try:
         mise_path = resolve_mise_path(manifest)
     except ArtifactError as exc:
@@ -43,6 +44,9 @@ def check_mise(manifest: BaseManifest) -> ArtifactCheck:
             finding_id="BASE-P021",
             status="warn",
         )
+
+    if not verify_project_runtime:
+        return unverified_runtime_check(manifest, "mise", "BASE-P022")
 
     project_root = manifest.path.parent.resolve()
     details = mise_details(project_root, mise_path)

--- a/cli/python/base_setup/runtime_inspection.py
+++ b/cli/python/base_setup/runtime_inspection.py
@@ -1,0 +1,85 @@
+"""Static evidence and explicit execution consent for project inspection."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+from .checks import ArtifactCheck
+from .manifest_model import BaseManifest
+
+
+def runtime_verification_command(manifest_path: Path) -> str:
+    return shlex.join([
+        "basectl", "check", "--manifest", str(manifest_path.resolve()), "--verify-project-runtime",
+    ])
+
+
+def unverified_runtime_check(
+    manifest: BaseManifest, name: str, finding_id: str, *, details: dict[str, object] | None = None,
+) -> ArtifactCheck:
+    return ArtifactCheck(
+        name=name,
+        ok=False,
+        status="warn",
+        message=f"{name} is unverified; static inspection does not execute project runtimes or configuration.",
+        fix=f"Review the project runtime and configuration, then run '{runtime_verification_command(manifest.path)}'.",
+        finding_id=finding_id,
+        details={**(details or {}), "verification": "unverified"},
+    )
+
+
+def executable_interpreter_present(python_bin: Path) -> bool:
+    return python_bin.is_file() and os.access(python_bin, os.X_OK)
+
+
+def project_venv_ready(venv_dir: Path) -> bool:
+    python_bin = venv_dir / "bin" / "python"
+    if not executable_interpreter_present(python_bin):
+        return False
+    try:
+        completed = subprocess.run(
+            [str(python_bin), "-c", "import sys"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0
+
+
+def project_environment_check(
+    manifest: BaseManifest, venv_dir: Path, *, verify_project_runtime: bool = False,
+) -> ArtifactCheck:
+    uses_uv = manifest.python.manager == "uv"
+    name = "uv project virtualenv" if uses_uv else "project_virtualenv"
+    finding_id = "BASE-P154" if uses_uv else "BASE-P050"
+    present = executable_interpreter_present(venv_dir / "bin" / "python")
+    ready = present and (not verify_project_runtime or project_venv_ready(venv_dir))
+    if not ready:
+        return ArtifactCheck(
+            name=name,
+            ok=False,
+            message=f"Project virtual environment is missing or incomplete at '{venv_dir}'.",
+            fix=(
+                f"Run 'uv sync' from '{manifest.path.parent}'." if uses_uv else
+                f"Run 'basectl setup {manifest.project_name} --recreate-venv' "
+                "to recreate the project virtual environment."
+            ),
+            finding_id=finding_id,
+            status="warn" if uses_uv and not present else "error",
+        )
+    if not verify_project_runtime:
+        return unverified_runtime_check(manifest, name, finding_id, details={"venv": str(venv_dir)})
+    return ArtifactCheck(
+        name=name,
+        ok=True,
+        message=f"Project virtual environment is ready at '{venv_dir}'.",
+        fix="",
+        finding_id=finding_id,
+        details={"verification": "verified"},
+    )

--- a/cli/python/base_setup/test_requirements.py
+++ b/cli/python/base_setup/test_requirements.py
@@ -15,6 +15,7 @@ from .python_artifacts import create_project_virtualenv
 from .python_artifacts import project_venv_recreate_enabled
 from .python_artifacts import python_artifact_installed
 from .project_routing import route_for_manifest
+from .runtime_inspection import unverified_runtime_check
 from .uv import manifest_uses_uv_project_manager
 
 
@@ -110,7 +111,7 @@ def read_test_requirements(manifest: BaseManifest) -> tuple[Path, tuple[Requirem
     return path, tuple(requirements)
 
 
-def check_test_requirements(manifest: BaseManifest) -> ArtifactCheck | None:
+def check_test_requirements(manifest: BaseManifest, *, verify_project_runtime: bool = True) -> ArtifactCheck | None:
     if manifest.test is None or manifest.test.requirements is None:
         return None
 
@@ -127,6 +128,12 @@ def check_test_requirements(manifest: BaseManifest) -> ArtifactCheck | None:
     if parsed is None:
         return None
     path, requirements = parsed
+    return check_requirements_environment(manifest, path, requirements, verify_project_runtime=verify_project_runtime)
+
+
+def check_requirements_environment(
+    manifest: BaseManifest, path: Path, requirements: tuple[RequirementSpec, ...], *, verify_project_runtime: bool,
+) -> ArtifactCheck:
     route = route_for_manifest(manifest)
     python_bin = route.project_venv_dir / "bin" / "python"
     if not python_bin.is_file():
@@ -139,6 +146,12 @@ def check_test_requirements(manifest: BaseManifest) -> ArtifactCheck | None:
             ),
             fix=f"Run 'basectl setup {manifest.project_name}' before running its tests.",
             finding_id=TEST_REQUIREMENTS_ENVIRONMENT_FINDING_ID,
+        )
+
+    if not verify_project_runtime:
+        return unverified_runtime_check(
+            manifest, "test requirements environment", TEST_REQUIREMENTS_ENVIRONMENT_FINDING_ID,
+            details={"requirements": str(path), "sha256": requirements_file_digest(manifest) or ""},
         )
 
     missing = [

--- a/cli/python/base_setup/tests/test_diagnostics.py
+++ b/cli/python/base_setup/tests/test_diagnostics.py
@@ -58,9 +58,9 @@ class ProjectCheckTests(unittest.TestCase):
         self.assertEqual(payload["project"], "demo")
         request_checks = [check for check in checks if check["name"] == "requests"]
         self.assertEqual(len(request_checks), 1)
-        self.assertEqual(request_checks[0]["status"], "error")
+        self.assertEqual(request_checks[0]["status"], "warn")
         self.assertNotIn("ok", request_checks[0])
-        self.assertEqual(request_checks[0]["fix"], "basectl setup demo")
+        self.assertIn("--verify-project-runtime", request_checks[0]["fix"])
         self.assertEqual(request_checks[0]["details"]["artifact_type"], "python-package")
         self.assertEqual(request_checks[0]["details"]["manager"], "pip")
         self.assertEqual(request_checks[0]["details"]["package"], "requests")
@@ -130,7 +130,7 @@ class ProjectCheckTests(unittest.TestCase):
         self.assertEqual(status, 1)
         self.assertEqual(stdout.getvalue(), "")
         self.assertNotIn("Project doctor: demo", stderr.getvalue())
-        self.assertIn("Fix: basectl setup demo", stderr.getvalue())
+        self.assertIn("basectl setup demo --recreate-venv", stderr.getvalue())
 
 
 
@@ -154,9 +154,9 @@ class ProjectCheckTests(unittest.TestCase):
         findings = json.loads(stdout.getvalue())
         self.assertEqual(stderr.getvalue(), "")
         self.assertEqual(status, 1)
-        self.assertEqual(findings[0]["id"], "BASE-P040")
+        self.assertEqual(findings[0]["id"], "BASE-P050")
         self.assertEqual(findings[0]["status"], "error")
-        self.assertEqual(findings[0]["fix"], "basectl setup demo")
+        self.assertIn("basectl setup demo --recreate-venv", findings[0]["fix"])
 
     def test_doctor_stream_contract_separates_output_from_usage_errors(self) -> None:
         default_manifest = BaseManifest(
@@ -581,7 +581,9 @@ class ProjectCheckTests(unittest.TestCase):
         with mock.patch("base_setup.python_policy.resolve_python_interpreter", return_value=None), redirect_stdout(
             io.StringIO()
         ) as stdout:
-            status = engine.check_manifest(fake_context(), default_manifest, manifest, output_format="json")
+            status = engine.check_manifest(
+                    fake_context(), default_manifest, manifest, output_format="json", verify_project_runtime=True,
+                )
 
         payload = json.loads(stdout.getvalue())
         self.assertEqual(status, 1)
@@ -617,7 +619,9 @@ class ProjectCheckTests(unittest.TestCase):
                 "base_setup.python_policy.resolve_python_interpreter",
                 return_value=PythonInterpreter(path=python_bin, version=(3, 12)),
             ), redirect_stdout(io.StringIO()) as stdout:
-                status = engine.check_manifest(fake_context(), default_manifest, manifest, output_format="json")
+                status = engine.check_manifest(
+                    fake_context(), default_manifest, manifest, output_format="json", verify_project_runtime=True,
+                )
 
         payload = json.loads(stdout.getvalue())
         runtime_check = next(check for check in payload["checks"] if check["id"] == "BASE-P172")

--- a/cli/python/base_setup/tests/test_mise.py
+++ b/cli/python/base_setup/tests/test_mise.py
@@ -448,7 +448,7 @@ class MiseTests(unittest.TestCase):
             write_fake_mise(bin_dir, log_path, f"{project_root.resolve()}: trusted", "{}")
 
             with mock.patch.dict(os.environ, {"PATH": f"{bin_dir}:{os.environ['PATH']}"}):
-                checks = engine.manifest_checks(default_manifest, manifest)
+                checks = engine.manifest_checks(default_manifest, manifest, verify_project_runtime=True)
 
         self.assertIn("mise", [check.name for check in checks])
         mise_check = next(check for check in checks if check.name == "mise")

--- a/cli/python/base_setup/uv.py
+++ b/cli/python/base_setup/uv.py
@@ -15,6 +15,7 @@ from .checks import ArtifactCheck
 from .errors import ArtifactError
 from .manifest import BaseManifest
 from .platform_policy import current_base_platform
+from .runtime_inspection import unverified_runtime_check
 from .user_paths import prepend_user_local_bin_to_path
 from .user_paths import user_local_bin
 
@@ -58,7 +59,7 @@ def reconcile_uv_project(ctx: base_cli.Context, manifest: BaseManifest, dry_run:
     process.run_command(ctx, command, cwd=project_root)
 
 
-def check_uv(manifest: BaseManifest) -> tuple[ArtifactCheck, ...]:
+def check_uv(manifest: BaseManifest, *, verify_project_runtime: bool = True) -> tuple[ArtifactCheck, ...]:
     uses_uv_manager = manifest_uses_uv_project_manager(manifest)
     uses_uv_runner = manifest_declares_uv_runner(manifest)
     if not uses_uv_manager and not uses_uv_runner:
@@ -83,7 +84,11 @@ def check_uv(manifest: BaseManifest) -> tuple[ArtifactCheck, ...]:
             and lock_path.is_file()
             and uv_project_venv_ready(venv_path)
         ):
-            checks.append(uv_project_environment_check(project_root, uv_bin))
+            checks.append(
+                uv_project_environment_check(project_root, uv_bin)
+                if verify_project_runtime
+                else unverified_runtime_check(manifest, "uv project environment", "BASE-P155")
+            )
         stale_check = stale_base_venv_check(manifest)
         if stale_check is not None:
             checks.append(stale_check)

--- a/cli/python/base_trust/engine.py
+++ b/cli/python/base_trust/engine.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import shlex
 import sys
 from pathlib import Path
 from typing import Any
@@ -17,11 +16,17 @@ from base_projects.workspace_context import resolve_workspace_root
 from base_projects.workspace_scanner import ProjectDiscoveryError
 from base_setup.manifest import read_manifest
 from base_setup.manifest_loader import ManifestError
+from .guidance import allow_command_text
+from .guidance import print_blocked_command_text
+from .guidance import print_identity
+from .guidance import print_status_text
+from .guidance import print_trust_scope_warning
+from .guidance import print_review_guidance  # pylint: disable=unused-import
 from .trust_store import ALLOWED_COMMANDS  # pylint: disable=unused-import
 from .trust_store import SCHEMA_VERSION
 from .trust_store import TRUST_RELATIVE_ROOT  # pylint: disable=unused-import
 from .trust_store import TRUST_SCOPE  # pylint: disable=unused-import
-from .trust_store import TRUST_SCOPE_WARNING
+from .trust_store import TRUST_SCOPE_WARNING  # pylint: disable=unused-import
 from .trust_store import ManifestCommandTrustIdentity
 from .trust_store import ManifestCommandTrustStore
 from .trust_store import TrustStatus
@@ -321,153 +326,6 @@ def trust_output_record(payload: dict[str, Any]) -> dict[str, Any]:
     return {"project": project_name, "status": payload.get("status", "-"), "reason": payload.get("reason", "-")}
 
 
-def allow_command_text(identity: ManifestCommandTrustIdentity) -> str:
-    return shlex.join(
-        [
-            "basectl",
-            "trust",
-            "allow",
-            identity.project_name,
-            "--manifest-sha256",
-            identity.manifest_sha256,
-            "--workspace",
-            str(identity.project_root.parent),
-        ]
-    )
-
-
-def print_status_text(trust_status: TrustStatus, surfaces: tuple[str, ...]) -> None:
-    identity = trust_status.identity
-    if not surfaces:
-        print(
-            f"Manifest command trust is not required for project '{identity.project_name}': "
-            "the manifest declares no executable command surfaces."
-        )
-        return
-
-    if trust_status.is_allowed:
-        print(f"Manifest command trust is allowed for project '{identity.project_name}'.")
-        print_identity("Trusted identity", identity)
-        print()
-        print_trust_scope_warning()
-        return
-
-    if trust_status.reason in {"manifest_changed", "test_requirements_changed"}:
-        print(
-            f"Manifest command trust is blocked for project '{identity.project_name}': "
-            "manifest or declared test requirements changed."
-        )
-        if trust_status.reason == "test_requirements_changed":
-            print("Declared test requirements changed; review the requirements file before allowing commands.")
-        changed_project = (trust_status.changed_record or {}).get("project", {})
-        if isinstance(changed_project, dict) and changed_project.get("manifest_sha256"):
-            print(f"Recorded Manifest SHA-256: {changed_project['manifest_sha256']}")
-    else:
-        print(f"Manifest command trust is blocked for project '{identity.project_name}'.")
-    print_identity("Current identity", identity)
-    print()
-    print_trust_scope_warning()
-    print()
-    print_review_guidance(identity, surfaces, stream=sys.stdout)
-    print()
-    print("Allow after review:")
-    print(f"  {allow_command_text(identity)}")
-
-
-def print_blocked_command_text(
-    trust_status: TrustStatus,
-    surfaces: tuple[str, ...],
-    *,
-    stream: Any,
-) -> None:
-    identity = trust_status.identity
-    if trust_status.reason in {"manifest_changed", "test_requirements_changed"}:
-        print(
-            f"ERROR: Manifest command trust is blocked for project '{identity.project_name}': "
-            "manifest command or declared test requirements contract changed.",
-            file=stream,
-        )
-    else:
-        print(
-            f"ERROR: Manifest-declared commands are not allowed for project "
-            f"'{identity.project_name}' on this machine.",
-            file=stream,
-        )
-    print(f"Project root: {identity.project_root}", file=stream)
-    print(f"Manifest: {identity.manifest_path}", file=stream)
-    if trust_status.reason in {"manifest_changed", "test_requirements_changed"}:
-        changed_project = (trust_status.changed_record or {}).get("project", {})
-        if isinstance(changed_project, dict) and changed_project.get("manifest_sha256"):
-            print(f"Recorded Manifest SHA-256: {changed_project['manifest_sha256']}", file=stream)
-    print(f"Manifest SHA-256: {identity.manifest_sha256}", file=stream)
-    if identity.test_requirements_sha256 is not None:
-        print(f"Test requirements SHA-256: {identity.test_requirements_sha256}", file=stream)
-    if identity.origin is not None:
-        print(f"Origin: {identity.origin}", file=stream)
-    print(file=stream)
-    print_trust_scope_warning(stream=stream)
-    print(file=stream)
-    print_review_guidance(identity, surfaces, stream=stream)
-    print(file=stream)
-    print("Allow after review:", file=stream)
-    print(f"  {allow_command_text(identity)}", file=stream)
-
-
-def print_review_guidance(
-    identity: ManifestCommandTrustIdentity,
-    surfaces: tuple[str, ...],
-    *,
-    stream: Any,
-) -> None:
-    workspace = str(identity.project_root.parent)
-    print("Review first:", file=stream)
-    if "run" in surfaces:
-        print(
-            f"  {shlex.join(['basectl', 'run', identity.project_name, '--list', '--workspace', workspace])}",
-            file=stream,
-        )
-    if "build" in surfaces:
-        print(
-            f"  {shlex.join(['basectl', 'build', identity.project_name, '--list', '--workspace', workspace])}",
-            file=stream,
-        )
-    if "test" in surfaces:
-        print(
-            f"  {shlex.join(['basectl', 'test', identity.project_name, '--dry-run', '--workspace', workspace])}",
-            file=stream,
-        )
-    if "demo" in surfaces:
-        print(
-            f"  {shlex.join(['basectl', 'demo', identity.project_name, '--dry-run', '--workspace', workspace])}",
-            file=stream,
-        )
-    if "activate" in surfaces:
-        print(
-            f"  Inspect activate.source entries in {identity.manifest_path} before running "
-            f"'basectl activate {identity.project_name}'.",
-            file=stream,
-        )
-
-
-def print_identity(title: str, identity: ManifestCommandTrustIdentity) -> None:
-    print(f"{title}:")
-    print(f"  Project: {identity.project_name}")
-    print(f"  Project root: {identity.project_root}")
-    print(f"  Manifest: {identity.manifest_path}")
-    print(f"  Manifest SHA-256: {identity.manifest_sha256}")
-    if identity.test_requirements_sha256 is not None:
-        print(f"  Test requirements SHA-256: {identity.test_requirements_sha256}")
-    if identity.origin is not None:
-        print(f"  Origin: {identity.origin}")
-    if identity.head is not None:
-        print(f"  HEAD: {identity.head}")
-
-
-def print_trust_scope_warning(*, stream: Any | None = None) -> None:
-    if stream is None:
-        stream = sys.stdout
-    print("Trust scope:", file=stream)
-    print(f"  {TRUST_SCOPE_WARNING}", file=stream)
 
 
 if __name__ == "__main__":

--- a/cli/python/base_trust/guidance.py
+++ b/cli/python/base_trust/guidance.py
@@ -1,0 +1,159 @@
+"""Trust review guidance shared by CLI commands and execution preflight."""
+
+from __future__ import annotations
+
+import shlex
+import sys
+from typing import Any
+
+from .trust_store import TRUST_SCOPE_WARNING, ManifestCommandTrustIdentity, TrustStatus
+
+
+def allow_command_text(identity: ManifestCommandTrustIdentity) -> str:
+    return shlex.join(
+        [
+            "basectl",
+            "trust",
+            "allow",
+            identity.project_name,
+            "--manifest-sha256",
+            identity.manifest_sha256,
+            "--workspace",
+            str(identity.project_root.parent),
+        ]
+    )
+
+
+def print_status_text(trust_status: TrustStatus, surfaces: tuple[str, ...]) -> None:
+    identity = trust_status.identity
+    if not surfaces:
+        print(
+            f"Manifest command trust is not required for project '{identity.project_name}': "
+            "the manifest declares no executable command surfaces."
+        )
+        return
+
+    if trust_status.is_allowed:
+        print(f"Manifest command trust is allowed for project '{identity.project_name}'.")
+        print_identity("Trusted identity", identity)
+        print()
+        print_trust_scope_warning()
+        return
+
+    if trust_status.reason in {"manifest_changed", "test_requirements_changed"}:
+        print(
+            f"Manifest command trust is blocked for project '{identity.project_name}': "
+            "manifest or declared test requirements changed."
+        )
+        if trust_status.reason == "test_requirements_changed":
+            print("Declared test requirements changed; review the requirements file before allowing commands.")
+        changed_project = (trust_status.changed_record or {}).get("project", {})
+        if isinstance(changed_project, dict) and changed_project.get("manifest_sha256"):
+            print(f"Recorded Manifest SHA-256: {changed_project['manifest_sha256']}")
+    else:
+        print(f"Manifest command trust is blocked for project '{identity.project_name}'.")
+    print_identity("Current identity", identity)
+    print()
+    print_trust_scope_warning()
+    print()
+    print_review_guidance(identity, surfaces, stream=sys.stdout)
+    print()
+    print("Allow after review:")
+    print(f"  {allow_command_text(identity)}")
+
+
+def print_blocked_command_text(
+    trust_status: TrustStatus,
+    surfaces: tuple[str, ...],
+    *,
+    stream: Any,
+) -> None:
+    identity = trust_status.identity
+    if trust_status.reason in {"manifest_changed", "test_requirements_changed"}:
+        print(
+            f"ERROR: Manifest command trust is blocked for project '{identity.project_name}': "
+            "manifest command or declared test requirements contract changed.",
+            file=stream,
+        )
+    else:
+        print(
+            f"ERROR: Manifest-declared commands are not allowed for project "
+            f"'{identity.project_name}' on this machine.",
+            file=stream,
+        )
+    print(f"Project root: {identity.project_root}", file=stream)
+    print(f"Manifest: {identity.manifest_path}", file=stream)
+    if trust_status.reason in {"manifest_changed", "test_requirements_changed"}:
+        changed_project = (trust_status.changed_record or {}).get("project", {})
+        if isinstance(changed_project, dict) and changed_project.get("manifest_sha256"):
+            print(f"Recorded Manifest SHA-256: {changed_project['manifest_sha256']}", file=stream)
+    print(f"Manifest SHA-256: {identity.manifest_sha256}", file=stream)
+    if identity.test_requirements_sha256 is not None:
+        print(f"Test requirements SHA-256: {identity.test_requirements_sha256}", file=stream)
+    if identity.origin is not None:
+        print(f"Origin: {identity.origin}", file=stream)
+    print(file=stream)
+    print_trust_scope_warning(stream=stream)
+    print(file=stream)
+    print_review_guidance(identity, surfaces, stream=stream)
+    print(file=stream)
+    print("Allow after review:", file=stream)
+    print(f"  {allow_command_text(identity)}", file=stream)
+
+
+def print_review_guidance(
+    identity: ManifestCommandTrustIdentity,
+    surfaces: tuple[str, ...],
+    *,
+    stream: Any,
+) -> None:
+    workspace = str(identity.project_root.parent)
+    print("Review first:", file=stream)
+    if "run" in surfaces:
+        print(
+            f"  {shlex.join(['basectl', 'run', identity.project_name, '--list', '--workspace', workspace])}",
+            file=stream,
+        )
+    if "build" in surfaces:
+        print(
+            f"  {shlex.join(['basectl', 'build', identity.project_name, '--list', '--workspace', workspace])}",
+            file=stream,
+        )
+    if "test" in surfaces:
+        print(
+            f"  {shlex.join(['basectl', 'test', identity.project_name, '--dry-run', '--workspace', workspace])}",
+            file=stream,
+        )
+    if "demo" in surfaces:
+        print(
+            f"  {shlex.join(['basectl', 'demo', identity.project_name, '--dry-run', '--workspace', workspace])}",
+            file=stream,
+        )
+    if "activate" in surfaces:
+        print(
+            f"  Inspect activate.source entries in {identity.manifest_path} before running "
+            f"'basectl activate {identity.project_name}'.",
+            file=stream,
+        )
+
+
+def print_identity(title: str, identity: ManifestCommandTrustIdentity) -> None:
+    print(f"{title}:")
+    print(f"  Project: {identity.project_name}")
+    print(f"  Project root: {identity.project_root}")
+    print(f"  Manifest: {identity.manifest_path}")
+    print(f"  Manifest SHA-256: {identity.manifest_sha256}")
+    if identity.test_requirements_sha256 is not None:
+        print(f"  Test requirements SHA-256: {identity.test_requirements_sha256}")
+    if identity.origin is not None:
+        print(f"  Origin: {identity.origin}")
+    if identity.head is not None:
+        print(f"  HEAD: {identity.head}")
+
+
+def print_trust_scope_warning(*, stream: Any | None = None) -> None:
+    if stream is None:
+        stream = sys.stdout
+    print("Trust scope:", file=stream)
+    print(f"  {TRUST_SCOPE_WARNING}", file=stream)
+

--- a/docs/manifest-command-trust.md
+++ b/docs/manifest-command-trust.md
@@ -35,7 +35,7 @@ project code:
 - `basectl activate <project>` when it will source `activate.source` entries
 
 These paths remain allowed before approval because they inspect or report
-without executing project-owned shell code:
+without executing project runtimes or delegated tool configuration:
 
 - `basectl projects list`
 - `basectl workspace status`, `check`, and `doctor`
@@ -54,6 +54,36 @@ approval boundary: `basectl setup --dry-run` shows the complete app, extension,
 and user-settings plan, and applying that plan requires
 `--allow-project-ide-mutations`. `--yes` never supplies this approval. This
 keeps command execution trust and machine-wide IDE mutation consent separate.
+
+## Runtime verification consent
+
+Project `check` and `doctor`, workspace `check` and `doctor`, and workspace
+status/onboarding inspect manifests, files, and environment presence by default.
+An executable file is reported as `present_unverified`, not proof of a working
+runtime. Package inventories and Brewfile, mise, or uv configuration checks
+remain unverified when they would execute project-controlled inputs.
+
+After reviewing the project interpreter and tool configuration, opt in for one
+invocation:
+
+```bash
+basectl check --manifest /absolute/project/base_manifest.yaml --verify-project-runtime
+basectl workspace doctor --workspace /absolute/workspace --verify-project-runtime
+```
+
+`--verify-project-runtime` permits those probes to execute code. It is supported
+only by project and workspace check/doctor. `--yes` and a saved manifest command
+approval never enable it implicitly. Manifest approval records only the manifest
+identity described below; it does not verify the integrity of interpreters,
+installed packages, referenced scripts, or tool configuration. Test execution
+requires manifest command approval before its executable requirements preflight.
+
+Base-owned inspection modules run with Python's isolated import mode and the
+selected Base/base-cli source roots. They preserve the current directory for
+project discovery without importing modules from that directory or inherited
+`PYTHONPATH`. Base uses its own interpreter even in an active project environment;
+`BASE_SETUP_VENV_DIR` can select that Base environment. The selected Base runtime
+and explicit provider source overrides remain trusted inputs.
 
 ## Trust Identity
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,7 +44,10 @@ basectl test <project>
 
 `basectl check` and `basectl doctor` are non-mutating diagnostics. They should
 not install dependencies, rewrite shell profiles, change manifests, or mutate
-repositories.
+repositories. By default they inspect static project state and report executable
+runtime checks as unverified. After reviewing the runtime and tool configuration,
+use `--verify-project-runtime` to run those checks. See
+[Runtime verification consent](manifest-command-trust.md#runtime-verification-consent).
 
 Map each symptom to its likely ownership before changing code:
 
@@ -172,9 +175,11 @@ test:
 Base supports direct package names with optional exact `==` versions in this
 file. `basectl setup <project>` installs the file into the routed project
 virtual environment. `basectl check <project>` and `basectl doctor <project>`
-report missing packages as `BASE-P181`, while `basectl test <project>` performs
-the same read-only preflight and does not execute the test command until the
-environment is ready. Paths outside the project root, unsupported requirement
+validate the requirements file statically and report package readiness as
+unverified (`BASE-P181`). Add `--verify-project-runtime` after reviewing the
+project runtime to probe installed packages. `basectl test <project>` requires
+manifest command approval before running that executable preflight and starts
+the test command only when the environment is ready. Paths outside the project root, unsupported requirement
 syntax, and uv-managed projects using this field fail closed; uv projects
 should declare test dependencies in `pyproject.toml` and use `uv sync`.
 

--- a/lib/base/base_cli_runtime.sh
+++ b/lib/base/base_cli_runtime.sh
@@ -56,8 +56,10 @@ base_cli_runtime_source_kind() {
 }
 
 base_cli_runtime_prepare() {
-    local source_kind
+    local source_kind source_root
 
     source_kind="$(base_cli_runtime_source_kind "$@")" || return 1
+    source_root="$(base_cli_runtime_source_root "$@")" || return 1
     export BASE_CLI_SOURCE="$source_kind"
+    export BASE_CLI_RUNTIME_SOURCE_ROOT="$source_root"
 }

--- a/lib/shell/completions/basectl_completion.sh
+++ b/lib/shell/completions/basectl_completion.sh
@@ -601,8 +601,8 @@ _base_basectl_completion() {
     local command cur
     local commands="activate setup check test export-context devcontainer devenv-report build demo run repo ci release prompt docs clean logs history config trust doctor gh onboard update-profile update projects workspace version help"
     local setup_options="--ci --format --profile --dry-run --manifest --notify --no-notify --recreate-venv --upgrade-pip --yes --allow-project-ide-mutations -v -h --help"
-    local check_options="--ci --profile --format --manifest --remote-network -v -h --help"
-    local doctor_options="--ci --profile --format --manifest --remote-network --no-color -v -h --help"
+    local check_options="--ci --profile --format --manifest --verify-project-runtime --remote-network -v -h --help"
+    local doctor_options="--ci --profile --format --manifest --verify-project-runtime --remote-network --no-color -v -h --help"
 
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]:-}"
@@ -655,7 +655,10 @@ _base_basectl_completion() {
                 _base_basectl_completion_compgen "status check doctor onboarding agent-brief clone pull update init configure setup test" "$cur"
             else
                 case "${COMP_WORDS[2]:-}" in
-                    status|check|doctor)
+                    check|doctor)
+                        _base_basectl_completion_compgen "--workspace --manifest --format --verify-project-runtime -v -h --help" "$cur"
+                        ;;
+                    status)
                         _base_basectl_completion_compgen "--workspace --manifest --format -v -h --help" "$cur"
                         ;;
                     onboarding|agent-brief)

--- a/lib/shell/completions/basectl_completion.zsh
+++ b/lib/shell/completions/basectl_completion.zsh
@@ -540,7 +540,15 @@ _base_basectl_completion() {
             ;;
         workspace)
             case "${words[3]:-}" in
-                status|check|doctor|onboarding|agent-brief)
+                check|doctor)
+                    _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull update init configure setup test)' \
+                        '--workspace[Workspace directory to scan]:path:_files' \
+                        '--manifest[Local workspace manifest]:path:_files' \
+                        '--format[Output format]:format:(text csv tsv yaml json)' \
+                        '--verify-project-runtime[Allow execution of reviewed project runtimes and tool configuration]' \
+                        '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]'
+                    ;;
+                status|onboarding|agent-brief)
                     _arguments '2:workspace command:(status check doctor onboarding agent-brief clone pull update init configure setup test)' \
                         '--workspace[Workspace directory to scan]:path:_files' \
                         '--manifest[Local workspace manifest]:path:_files' \
@@ -636,6 +644,7 @@ _base_basectl_completion() {
                 '--profile[Include prerequisite profiles]:profile:(dev sre ai linux-lab dev,sre dev,ai dev,linux-lab sre,ai sre,linux-lab ai,linux-lab dev,sre,ai dev,sre,linux-lab dev,ai,linux-lab sre,ai,linux-lab dev,sre,ai,linux-lab)' \
                 '--format[Output format]:format:(text json)' \
                 '--manifest[Use a specific manifest]:path:_files' \
+                '--verify-project-runtime[Allow execution of reviewed project runtimes and tool configuration]' \
                 '--remote-network[Opt in to bounded project Git origin reachability checks]' \
                 '-v[Enable DEBUG logging]' '(-h --help)'{-h,--help}'[Show help text]' \
                 '2:Base project:->projects'
@@ -854,6 +863,7 @@ _base_basectl_completion() {
                         '--ci[Run check with CI-safe defaults]' \
                         '--format[Output format]:format:(text json)' \
                         '--manifest[Use a specific manifest]:path:_files' \
+                        '--verify-project-runtime[Allow execution of reviewed project runtimes and tool configuration]' \
                         '--remote-network[Opt in to bounded project Git origin reachability diagnostics]' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
@@ -862,6 +872,7 @@ _base_basectl_completion() {
                         '--ci[Run doctor with CI-safe defaults]' \
                         '--format[Output format]:format:(text json)' \
                         '--manifest[Use a specific manifest]:path:_files' \
+                        '--verify-project-runtime[Allow execution of reviewed project runtimes and tool configuration]' \
                         '--remote-network[Opt in to bounded project Git origin reachability diagnostics]' \
                         '(-h --help)'{-h,--help}'[Show help text]'
                     ;;
@@ -970,6 +981,7 @@ _base_basectl_completion() {
                         '--profile[Include prerequisite profiles]:profile:(dev sre ai linux-lab dev,sre dev,ai dev,linux-lab sre,ai sre,linux-lab ai,linux-lab dev,sre,ai dev,sre,linux-lab dev,ai,linux-lab sre,ai,linux-lab dev,sre,ai,linux-lab)' \
                         '--format[Output format]:format:(text json)' \
                         '--manifest[Use a specific manifest]:path:_files' \
+                        '--verify-project-runtime[Allow execution of reviewed project runtimes and tool configuration]' \
                         '--remote-network[Opt in to bounded project Git origin reachability diagnostics]' \
                         '--no-color[Disable doctor status colors and symbols in text output]' \
                         '-v[Enable DEBUG logging]' \

--- a/tests/integration/base_workflows.bats
+++ b/tests/integration/base_workflows.bats
@@ -303,6 +303,85 @@ YAML
     grep -Fqx "args=<tests/><-k><focused case>" "$TEST_STATE_DIR/fake-test.out"
 }
 
+@test "public inspection keeps the project runtime unverified until explicitly requested" {
+    local command
+    cat > "$TEST_PROJECT_ROOT/base_manifest.yaml" <<'EOF'
+project:
+  name: demo
+python: {}
+test:
+  command: fake-test tests/
+  requirements: requirements.txt
+artifacts: []
+EOF
+    printf 'pip\n' > "$TEST_PROJECT_ROOT/requirements.txt"
+    cat > "$TEST_PROJECT_ROOT/.venv/bin/python" <<EOF
+#!/usr/bin/env bash
+printf probe >> "$TEST_STATE_DIR/project-runtime-probed"
+exec "$TEST_INTEGRATION_PYTHON" "\$@"
+EOF
+    chmod +x "$TEST_PROJECT_ROOT/.venv/bin/python"
+    for command in check doctor; do
+        run_basectl "$command" --ci --manifest "$TEST_PROJECT_ROOT/base_manifest.yaml" --format json
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"unverified"* ]]
+        [ ! -e "$TEST_STATE_DIR/project-runtime-probed" ]
+    done
+    run_basectl test demo
+    [ "$status" -eq 1 ]
+    [ ! -e "$TEST_STATE_DIR/project-runtime-probed" ]
+    [ ! -e "$TEST_STATE_DIR/fake-test.out" ]
+
+    run_basectl check --ci --manifest "$TEST_PROJECT_ROOT/base_manifest.yaml" --verify-project-runtime --format json
+    [ "$status" -eq 0 ]
+    [ -e "$TEST_STATE_DIR/project-runtime-probed" ]
+}
+
+@test "inspection uses Base imports and runtime from an active project directory" {
+    local module command
+    local workspace="$TEST_TMPDIR/inspection-workspace"
+    local workspace_manifest="$TEST_TMPDIR/inspection-workspace.yaml"
+    mkdir -p "$workspace"
+    mv "$TEST_PROJECT_ROOT" "$workspace/demo"
+    TEST_PROJECT_ROOT="$workspace/demo"
+    cat > "$TEST_PROJECT_ROOT/base_manifest.yaml" <<'EOF'
+project:
+  name: demo
+python: {}
+test:
+  command: fake-test tests/
+artifacts: []
+EOF
+    printf 'schema_version: 1\nworkspace:\n  name: demo\nrepos:\n  - name: demo\n' > "$workspace_manifest"
+    for module in base_projects base_setup base_cli_adapters platform pip; do
+        printf 'open("%s", "w").close()\nraise RuntimeError("unexpected project import")\n' \
+            "$TEST_STATE_DIR/project-imported" > "$TEST_PROJECT_ROOT/$module.py"
+    done
+    cat > "$TEST_PROJECT_ROOT/.venv/bin/python" <<EOF
+#!/usr/bin/env bash
+printf probe >> "$TEST_STATE_DIR/project-runtime-probed"
+exec "$TEST_INTEGRATION_PYTHON" "\$@"
+EOF
+    chmod +x "$TEST_PROJECT_ROOT/.venv/bin/python"
+    export BASE_PROJECT=demo BASE_PROJECT_VENV_DIR="$TEST_PROJECT_ROOT/.venv"
+    cd "$TEST_PROJECT_ROOT"
+
+    run_basectl projects list --workspace "$workspace"
+    [ "$status" -eq 0 ]
+    for command in check doctor; do
+        run_basectl "$command" --ci --manifest ./base_manifest.yaml --format json
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"unverified"* ]]
+    done
+    for command in status check doctor onboarding; do
+        run_basectl workspace "$command" --workspace "$workspace" --manifest "$workspace_manifest" --format json
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"unverified"* || "$output" == *"needs_verification"* ]]
+    done
+    [ ! -e "$TEST_STATE_DIR/project-runtime-probed" ]
+    [ ! -e "$TEST_STATE_DIR/project-imported" ]
+}
+
 @test "basectl update-profile dry-run does not write real shell startup files" {
     run_basectl update-profile --dry-run
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

Project and workspace inspection previously executed project interpreters and delegated tool configuration before command approval. Inspection now reports runtime presence and static findings, with executable checks clearly marked unverified. `--verify-project-runtime` authorizes those probes for one check/doctor invocation; neither `--yes` nor saved manifest approval enables them implicitly.

Base-owned Python modules use an isolated entry point and Base's interpreter while preserving the caller's directory for project discovery. Test requirements preflight now follows manifest command approval. Documentation, completion, onboarding guidance, and shell interpreter fixtures reflect the boundary.

## Issue

Fixes #2222

## Validation

- Reproduced pre-approval execution with benign fixtures. Consent regressions cover static inspection, saved approval, `--yes`, explicit verification, broken runtimes, Brewfile/mise/uv delegates, and test preflight.
- Full Python suite passed: 1292 tests and 351 subtests. Full repository Pylint passed after extracting shared trust guidance from the command engine.
- All 12 public integration tests passed, including inspection from an active project containing local module names and a marked interpreter.
- 109 focused Bash tests passed. Subsequent broad-suite fixture findings were corrected and verified: build/run JSON, runtime-shell Base interpreter routing, and Bash/Zsh completion-help contracts.
- ShellCheck on changed production Bash passed. Final local source suite passed: 1292 Python tests and 941 BATS/integration tests.
- All 20 hosted checks passed on `6a817ff36766567682b232648055c4b2f5fafee8`, including the Ubuntu full suite and macOS smoke tests.

## Demo Impact

Existing project and workspace check/doctor commands can report warning/unverified runtime findings by default. After reviewing project runtimes and configuration, add `--verify-project-runtime` to execute readiness probes. Status and onboarding remain static.

## Notes

This is an execution-consent boundary, not a sandbox or repository-integrity approval. The selected Base interpreter and provider sources remain trusted inputs. Manifest command approval remains bound to the manifest identity, not all referenced repository content.
