### PR TITLE
fix(manifest): report malformed keys and encoding as domain errors

### DIFF
--- a/cli/python/base_projects/workspace_manifest.py
+++ b/cli/python/base_projects/workspace_manifest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from base_projects.workspace_repository_url import repository_url_problem
+from base_setup.manifest_loader import ManifestError, validate_mapping_keys
 
 try:
     import yaml
@@ -48,6 +49,8 @@ def read_workspace_manifest(path: Path) -> WorkspaceManifest:
     resolved_path = path.expanduser().resolve()
     try:
         data = yaml.safe_load(resolved_path.read_text(encoding="utf-8"))
+    except UnicodeError as exc:
+        raise WorkspaceManifestError(f"{resolved_path}: workspace manifest must use UTF-8 encoding: {exc}") from exc
     except OSError as exc:
         raise WorkspaceManifestError(f"{resolved_path}: unable to read workspace manifest: {exc}") from exc
     except yaml.YAMLError as exc:
@@ -55,6 +58,11 @@ def read_workspace_manifest(path: Path) -> WorkspaceManifest:
 
     if not isinstance(data, dict):
         raise WorkspaceManifestError(f"{resolved_path}: workspace manifest must be a YAML mapping.")
+
+    try:
+        validate_mapping_keys(data, resolved_path)
+    except ManifestError as exc:
+        raise WorkspaceManifestError(str(exc)) from exc
 
     allowed_top_level = {"schema_version", "workspace", "repos"}
     unknown_top_level = sorted(set(data) - allowed_top_level)

--- a/cli/python/base_setup/manifest_loader.py
+++ b/cli/python/base_setup/manifest_loader.py
@@ -44,6 +44,8 @@ def read_manifest_mapping(path: Path) -> dict[Any, Any]:
 
     try:
         data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except UnicodeError as exc:
+        raise ManifestError(f"{path}: manifest must use UTF-8 encoding: {exc}") from exc
     except OSError as exc:
         raise ManifestError(f"{path}: unable to read manifest: {exc}") from exc
     except yaml.YAMLError as exc:
@@ -54,8 +56,34 @@ def read_manifest_mapping(path: Path) -> dict[Any, Any]:
     if not isinstance(data, dict):
         raise ManifestError(f"{path}: manifest must be a YAML mapping.")
 
+    validate_mapping_keys(data, path)
+
     unknown_top_level = sorted(set(data) - MANIFEST_TOP_LEVEL_KEYS)
     if unknown_top_level:
         raise ManifestError(f"{path}: unsupported top-level keys: {', '.join(unknown_top_level)}.")
 
     return data
+
+
+def validate_mapping_keys(data: Any, path: Path) -> None:
+    """Validate nested keys before schema readers sort or join them.
+
+    YAML aliases can share or cycle through containers. Visit each container
+    once so key validation neither recurses forever nor repeats shared work.
+    """
+    pending = [(data, "manifest")]
+    visited: set[int] = set()
+    while pending:
+        value, location = pending.pop()
+        if not isinstance(value, (dict, list)) or id(value) in visited:
+            continue
+        visited.add(id(value))
+        if isinstance(value, dict):
+            for key, child in value.items():
+                if not isinstance(key, str):
+                    raise ManifestError(
+                        f"{path}: {location} mapping keys must be strings; got {type(key).__name__}."
+                    )
+                pending.append((child, f"{location}.{key}"))
+        else:
+            pending.extend((child, f"{location}[{index}]") for index, child in enumerate(value))

--- a/cli/python/base_setup/tests/test_manifest_input_errors.py
+++ b/cli/python/base_setup/tests/test_manifest_input_errors.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from base_projects.workspace_manifest import WorkspaceManifestError, read_workspace_manifest
+from base_projects.tests.test_workspace_checks import invoke_engine, write_default_manifest
+from base_setup.manifest import read_manifest
+from base_setup.manifest_loader import ManifestError, read_manifest_mapping
+
+
+PROJECT = "project:\n  name: demo\nartifacts: []\n"
+WORKSPACE = "schema_version: 1\nworkspace:\n  name: demo\nrepos: []\n"
+
+
+@pytest.mark.parametrize("content,location", [
+    (PROJECT + "42: true\n", "manifest"),
+    (PROJECT + "false: true\n", "manifest"),
+    (PROJECT + "unknown: true\n42: true\n", "manifest"),
+    ("project:\n  name: demo\n  42: value\n", "manifest.project"),
+    (PROJECT + "commands:\n  false:\n    command: 'true'\n", "manifest.commands"),
+    (PROJECT + "health:\n  ports:\n    - 42: value\n", "manifest.health.ports[0]"),
+])
+def test_project_non_string_keys_raise_domain_error(tmp_path, content, location):
+    manifest = tmp_path / "base_manifest.yaml"
+    manifest.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ManifestError, match="mapping keys must be strings") as error:
+        read_manifest(manifest)
+
+    assert str(manifest) in str(error.value)
+    assert location in str(error.value)
+
+
+@pytest.mark.parametrize("content,location", [
+    (WORKSPACE + "42: true\n", "manifest"),
+    (WORKSPACE + "false: true\n", "manifest"),
+    (WORKSPACE + "unknown: true\n42: true\n", "manifest"),
+    ("schema_version: 1\nworkspace:\n  name: demo\n  42: true\nrepos: []\n", "manifest.workspace"),
+    ("schema_version: 1\nworkspace:\n  name: demo\nrepos:\n  - name: demo\n    42: true\n", "manifest.repos[0]"),
+])
+def test_workspace_non_string_keys_raise_domain_error(tmp_path, content, location):
+    manifest = tmp_path / "workspace.yaml"
+    manifest.write_text(content, encoding="utf-8")
+
+    with pytest.raises(WorkspaceManifestError, match="mapping keys must be strings") as error:
+        read_workspace_manifest(manifest)
+
+    assert str(manifest) in str(error.value)
+    assert location in str(error.value)
+
+
+@pytest.mark.parametrize("loader,error_type", [
+    (read_manifest, ManifestError), (read_workspace_manifest, WorkspaceManifestError),
+])
+def test_invalid_utf8_raises_domain_error(tmp_path, loader, error_type):
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_bytes(b"name: \xff\n")
+
+    with pytest.raises(error_type, match="UTF-8") as error:
+        loader(manifest)
+
+    assert str(manifest) in str(error.value)
+
+
+@pytest.mark.parametrize("bad_content", [b"42: true\n", b"name: \xff\n"])
+@pytest.mark.parametrize("command", ["status", "check", "doctor"])
+def test_workspace_reports_bad_member_and_continues(tmp_path, bad_content, command):
+    home = tmp_path / "home"
+    base = tmp_path / "base"
+    workspace = tmp_path / "workspace"
+    home.mkdir()
+    write_default_manifest(base)
+    for name, content in (("bad", bad_content), ("good", PROJECT.replace("demo", "good").encode())):
+        project = workspace / name
+        project.mkdir(parents=True)
+        (project / "base_manifest.yaml").write_bytes(content)
+
+    result, stdout, stderr = invoke_engine([command, "--workspace", str(workspace), "--format", "json"], base, home)
+
+    assert result == 1
+    assert "Traceback" not in stderr
+    report = json.loads(stdout)
+    assert '"good"' in json.dumps(report)
+    assert '"bad"' in json.dumps(report)
+    assert "mapping keys" in stdout or "UTF-8" in stdout
+
+
+def test_workspace_cli_returns_controlled_error_for_bad_encoding(tmp_path):
+    manifest = tmp_path / "workspace.yaml"
+    manifest.write_bytes(b"\xff")
+    home, base = tmp_path / "home", tmp_path / "base"
+    home.mkdir()
+    write_default_manifest(base)
+
+    result, _stdout, stderr = invoke_engine(
+        ["status", "--manifest", str(manifest), "--workspace", str(tmp_path)], base, home,
+    )
+
+    assert result == 1
+    assert "UTF-8" in stderr
+    assert "Traceback" not in stderr
+
+
+def test_mapping_key_validation_handles_shared_and_cyclic_yaml_aliases(tmp_path):
+    manifest = tmp_path / "base_manifest.yaml"
+    manifest.write_text("project: &project\n  name: demo\n  self: *project\n", encoding="utf-8")
+
+    mapping = read_manifest_mapping(manifest)
+
+    assert mapping["project"]["self"] is mapping["project"]
+    manifest.write_text("project: &project\n  name: demo\n  self: *project\n  42: true\n", encoding="utf-8")
+    with pytest.raises(ManifestError, match="manifest.project mapping keys"):
+        read_manifest_mapping(manifest)

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -4,6 +4,11 @@ Base uses "workspace" in a precise way: a workspace is a local directory that
 contains sibling repositories. A workspace manifest is an optional local file
 that describes which repositories are expected to belong to that workspace.
 
+Project and workspace manifests must use UTF-8 encoding and string mapping
+keys, including nested mappings. Invalid input reports the manifest path and
+field location. Workspace reports identify invalid project members while
+continuing to inspect the other members.
+
 Workspace status, check, doctor, and clone commands can use a manifest when the
 user configures `workspace.manifest` in `~/.base.d/config.yaml` or supplies
 `--manifest <path>`. The command-line flag takes precedence over the configured

--- a/tests/integration/base_workflows.bats
+++ b/tests/integration/base_workflows.bats
@@ -400,3 +400,20 @@ EOF
     [[ "$output" == *"Workspace setup plan complete: setup=1 skipped=2 failed=0."* ]]
     [[ "$output" == *"[DRY-RUN] No repositories were modified."* ]]
 }
+
+
+@test "public diagnostics report invalid manifest encoding without a traceback" {
+    local command
+    printf 'project: \377\n' > "$TEST_PROJECT_ROOT/base_manifest.yaml"
+    for command in check doctor; do
+        run_basectl "$command" --manifest "$TEST_PROJECT_ROOT/base_manifest.yaml" --format json
+        [ "$status" -eq 1 ]
+        [[ "$output" == *"UTF-8"* ]]
+        [[ "$output" != *"Traceback"* ]]
+    done
+    run_basectl workspace status --workspace "$TEST_WORKSPACE" --format json
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"manifest": "invalid"'* ]]
+    [[ "$output" == *'"name": "base"'* ]]
+    [[ "$output" != *"Traceback"* ]]
+}


### PR DESCRIPTION
## Summary

Malformed project and workspace manifests now report controlled errors with the file path and field location. Both loaders reject non-string mapping keys before schema readers sort or join them, and invalid UTF-8 is translated into an actionable encoding diagnostic. Workspace reports continue past an invalid project member.

## Issue

Fixes #2225

## Validation

- Reproduced the malformed-key and invalid-encoding failures before changing the loaders.
- 115 focused manifest/workspace tests and 122 subtests passed; the added alias regression brings the new input-error suite to 21 passing tests.
- Public check, doctor, and workspace-status regression passed with an invalid-encoding fixture and no traceback.
- Changed-file Pylint and `git diff --check` passed. Full local source suite passed: 1,288 Python and 940 BATS/integration tests.
- Integrated preceding train changes; 43 manifest/consent tests passed afterward. All 20 hosted checks passed on the integrated head, including the full Ubuntu source suite and macOS validation.

## Demo Impact

None. Valid manifest syntax is unchanged.

## Notes

The key walk handles shared and cyclic YAML aliases without repeated traversal. Optional local JSON state and check-evidence identity are separate issues in the train.
