### PR TITLE
fix(workspace): recover from malformed optional JSON state

### DIFF
--- a/cli/python/base_projects/project_discovery.py
+++ b/cli/python/base_projects/project_discovery.py
@@ -16,6 +16,7 @@ from base_projects.workspace_scanner import ProjectNotFoundError
 from base_projects.workspace_scanner import workspace_manifest_entries
 from base_setup.manifest import read_manifest
 from base_setup.manifest_loader import ManifestError
+from base_setup.manifest_schema import COMMAND_NAME_RE
 
 
 @dataclass(frozen=True, order=True)
@@ -92,26 +93,45 @@ def read_project_cache(workspace_root: Path, entries: tuple[ManifestEntry, ...])
     cache_path = project_cache_path(workspace_root)
     try:
         data = json.loads(cache_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeError, json.JSONDecodeError):
         return None
 
-    if data.get("version") != 1 or data.get("workspace") != str(workspace_root):
+    if (
+        not isinstance(data, dict)
+        or not isinstance(data.get("version"), int) or isinstance(data.get("version"), bool)
+    ):
         return None
-    if data.get("manifests") != [manifest_entry_to_json(entry) for entry in entries]:
+    if (
+        data.get("version") != 1 or data.get("workspace") != str(workspace_root)
+        or data.get("manifests") != [manifest_entry_to_json(entry) for entry in entries]
+    ):
         return None
 
+    records = data.get("projects")
+    if not isinstance(records, list) or len(records) != len(entries):
+        return None
     try:
-        projects = tuple(
-            Project(
-                name=project["name"],
-                root=Path(project["root"]),
-                manifest_path=Path(project["manifest_path"]),
-            )
-            for project in data["projects"]
-        )
-    except (KeyError, TypeError):
+        projects = tuple(project_from_cache_record(record) for record in records)
+        expected_paths = {entry.path.resolve() for entry in entries}
+        if {project.manifest_path for project in projects} != expected_paths:
+            raise ValueError("Cached projects do not match discovered manifests.")
+        return validate_unique_project_names(tuple(sorted(projects)))
+    except (KeyError, TypeError, ValueError, ProjectDiscoveryError, OSError):
         return None
-    return validate_unique_project_names(tuple(sorted(projects)))
+
+
+def project_from_cache_record(record: Any) -> Project:
+    if not isinstance(record, dict):
+        raise ValueError("Cached project must be an object.")
+    name, root, manifest_path = (record.get(key) for key in ("name", "root", "manifest_path"))
+    if not isinstance(name, str) or not COMMAND_NAME_RE.fullmatch(name):
+        raise ValueError("Cached project name is invalid.")
+    if not all(isinstance(value, str) and value and "\0" not in value for value in (root, manifest_path)):
+        raise ValueError("Cached project paths are invalid.")
+    root_path, manifest = Path(root), Path(manifest_path)
+    if not root_path.is_absolute() or not manifest.is_absolute() or manifest.parent != root_path:
+        raise ValueError("Cached project paths do not describe a project root and manifest.")
+    return Project(name=name, root=root_path, manifest_path=manifest)
 
 
 def write_project_cache(

--- a/cli/python/base_projects/tests/test_optional_json_state.py
+++ b/cli/python/base_projects/tests/test_optional_json_state.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from base_projects import project_discovery as discovery
+from base_projects.workspace_report_common import project_last_check
+from base_projects.workspace_scanner import workspace_manifest_entries, ProjectDiscoveryError
+from base_projects.tests.test_workspace_checks import invoke_engine, write_default_manifest
+from base_setup.tests.helpers import fake_context
+
+
+INVALID_JSON = [b"[]", b"null", b"42", b'"value"', b"false", b"{", b"\xff"]
+
+
+@pytest.fixture(name="local_state")
+def local_state_fixture(tmp_path, monkeypatch):
+    home, base, workspace = tmp_path / "home", tmp_path / "base", tmp_path / "workspace"
+    home.mkdir()
+    write_default_manifest(base)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("BASE_CACHE_DIR", str(tmp_path / "cache"))
+    project = workspace / "demo"
+    project.mkdir(parents=True)
+    (project / "base_manifest.yaml").write_text("project:\n  name: demo\nartifacts: []\n", encoding="utf-8")
+    entries = workspace_manifest_entries(workspace)
+    ctx = fake_context()
+    projects = (discovery.read_project(entries[0].path),)
+    discovery.write_project_cache(workspace, entries, projects, ctx)
+    cache = discovery.project_cache_path(workspace)
+    record = home / ".base.d" / "demo" / "checks" / "last.json"
+    record.parent.mkdir(parents=True)
+    record.write_text(json.dumps({
+        "schema_version": 1, "project": "demo", "checked_at": "2026-09-12T10:00:00Z", "status": "ok",
+    }), encoding="utf-8")
+    return home, base, workspace, entries, cache, record
+
+
+@pytest.mark.parametrize("raw", INVALID_JSON)
+def test_optional_nonobject_and_unreadable_json_is_unavailable(local_state, raw):
+    _home, _base, workspace, entries, cache, record = local_state
+    cache.write_bytes(raw)
+    record.write_bytes(raw)
+
+    assert discovery.read_project_cache(workspace, entries) is None
+    assert project_last_check("demo") is None
+
+
+@pytest.mark.parametrize("field,value", [
+    ("projects", None), ("projects", {}), ("projects", []), ("projects", [None]),
+    ("projects", [{"name": [], "root": "/tmp", "manifest_path": "/tmp/base_manifest.yaml"}]),
+    ("version", True),
+])
+def test_invalid_cache_members_fall_back(local_state, field, value):
+    _home, _base, workspace, entries, cache, _record = local_state
+    payload = json.loads(cache.read_text(encoding="utf-8"))
+    payload[field] = value
+    cache.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert discovery.read_project_cache(workspace, entries) is None
+
+
+@pytest.mark.parametrize("field,value", [
+    ("name", {}), ("name", ""), ("name", "../demo"), ("root", 42),
+    ("root", ""), ("manifest_path", ""), ("manifest_path", "\0"),
+])
+def test_invalid_cached_project_fields_fall_back(local_state, field, value):
+    _home, _base, workspace, entries, cache, _record = local_state
+    payload = json.loads(cache.read_text(encoding="utf-8"))
+    payload["projects"][0][field] = value
+    cache.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert discovery.read_project_cache(workspace, entries) is None
+
+
+@pytest.mark.parametrize("field,value", [
+    ("schema_version", True), ("project", []), ("checked_at", []), ("checked_at", ""),
+    ("checked_at", "not-a-date"), ("checked_at", "2026-09-12"),
+    ("status", []), ("status", ""), ("status", "success"),
+])
+def test_invalid_latest_check_members_are_unavailable(local_state, field, value):
+    _home, _base, _workspace, _entries, _cache, record = local_state
+    payload = json.loads(record.read_text(encoding="utf-8"))
+    payload[field] = value
+    record.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert project_last_check("demo") is None
+
+
+def test_duplicate_cache_records_trigger_fresh_discovery(local_state):
+    _home, _base, workspace, _entries, cache, _record = local_state
+    payload = json.loads(cache.read_text(encoding="utf-8"))
+    payload["projects"].append(copy.deepcopy(payload["projects"][0]))
+    cache.write_text(json.dumps(payload), encoding="utf-8")
+
+    projects = discovery.discover_projects_cached(fake_context(), workspace)
+
+    assert [project.name for project in projects] == ["demo"]
+
+
+@pytest.mark.parametrize("raw", INVALID_JSON)
+def test_public_listing_and_status_survive_invalid_optional_state(local_state, raw):
+    home, base, workspace, _entries, cache, record = local_state
+    cache.write_bytes(raw)
+    record.write_bytes(raw)
+
+    result, stdout, stderr = invoke_engine(["list", "--workspace", str(workspace), "--format", "json"], base, home)
+    assert result == 0
+    assert json.loads(stdout)[0]["name"] == "demo"
+    assert "Traceback" not in stderr
+    result, stdout, stderr = invoke_engine(["status", "--workspace", str(workspace), "--format", "json"], base, home)
+    assert result == 0
+    report = json.loads(stdout)
+    assert report["projects"][0]["status"] == "ok"
+    assert report["projects"][0]["last_check"] is None
+    assert "Traceback" not in stderr
+
+
+def test_invalid_cache_does_not_hide_manifest_errors(local_state):
+    _home, _base, workspace, entries, cache, _record = local_state
+    cache.write_text("[]", encoding="utf-8")
+    entries[0].path.write_text("project: {}\n", encoding="utf-8")
+
+    with pytest.raises(ProjectDiscoveryError, match="project.name"):
+        discovery.discover_projects_cached(fake_context(), workspace)
+
+
+def test_valid_optional_records_retain_existing_behavior(local_state):
+    _home, _base, workspace, entries, _cache, _record = local_state
+
+    projects = discovery.read_project_cache(workspace, entries)
+    assert projects is not None
+    assert [project.name for project in projects] == ["demo"]
+    last_check = project_last_check("demo")
+    assert last_check is not None
+    assert last_check.status == "ok"
+    assert last_check.checked_at == "2026-09-12T10:00:00Z"

--- a/cli/python/base_projects/workspace_report_common.py
+++ b/cli/python/base_projects/workspace_report_common.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import subprocess
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -44,19 +45,25 @@ def project_last_check(project_name: str) -> ProjectLastCheck | None:
     record_path = base_state_root() / project_name / "checks" / "last.json"
     try:
         payload = json.loads(record_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeError, json.JSONDecodeError):
         return None
 
-    if payload.get("schema_version") != 1:
-        return None
-    if payload.get("project") != project_name:
+    if (
+        not isinstance(payload, dict)
+        or not isinstance(payload.get("schema_version"), int) or isinstance(payload.get("schema_version"), bool)
+        or payload.get("schema_version") != 1 or payload.get("project") != project_name
+    ):
         return None
 
     checked_at = payload.get("checked_at")
     status = payload.get("status")
-    if not isinstance(checked_at, str) or not isinstance(status, str):
+    if not isinstance(checked_at, str) or not isinstance(status, str) or status not in {"ok", "warn", "error"}:
         return None
-    return ProjectLastCheck(checked_at=checked_at, status=status)
+    try:
+        timestamp = datetime.fromisoformat(checked_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return ProjectLastCheck(checked_at=checked_at, status=status) if timestamp.tzinfo is not None else None
 
 
 def workspace_repo_check_details(repo: WorkspaceManifestRepo, root: Path, present: bool) -> dict[str, Any]:

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -101,6 +101,11 @@ check date in the `LAST CHECK` column, while JSON output includes the full
 timestamp and check status. Projects without a recorded check show `-` in text
 output and `null` in JSON output.
 
+Discovery caches and saved latest-check records are optional local state. An
+invalid object, member, timestamp, status, or encoding makes that evidence
+unavailable. Base rescans manifests after an invalid discovery cache, and an
+unavailable latest check does not change current workspace health.
+
 JSON status output includes a top-level `status` aggregate in addition to each
 project's status. It uses the same status vocabulary and precedence as workspace
 reports: `error` takes precedence over `warn`, which takes precedence over `ok`.

--- a/tests/integration/base_workflows.bats
+++ b/tests/integration/base_workflows.bats
@@ -400,3 +400,24 @@ EOF
     [[ "$output" == *"Workspace setup plan complete: setup=1 skipped=2 failed=0."* ]]
     [[ "$output" == *"[DRY-RUN] No repositories were modified."* ]]
 }
+
+@test "public listing and workspace status recover from malformed optional JSON" {
+    local cache
+    export BASE_CACHE_DIR="$TEST_TMPDIR/optional-cache"
+    run_basectl projects list --workspace "$TEST_WORKSPACE"
+    [ "$status" -eq 0 ]
+    for cache in "$BASE_CACHE_DIR/base/cache/discovery/"*.json; do
+        [ -f "$cache" ]
+        printf '[]\n' > "$cache"
+    done
+    mkdir -p "$TEST_HOME/.base.d/demo/checks"
+    printf '\377' > "$TEST_HOME/.base.d/demo/checks/last.json"
+
+    run_basectl projects list --workspace "$TEST_WORKSPACE" --format json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"name": "demo"'* || "$output" == *'"name":"demo"'* ]]
+    run_basectl workspace status --workspace "$TEST_WORKSPACE" --format json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"last_check": null'* ]]
+    [[ "$output" != *"Traceback"* ]]
+}


### PR DESCRIPTION
## Summary

Malformed optional discovery-cache and latest-check JSON now become unavailable state instead of raising exceptions or inventing valid history. Discovery validates cached project fields and membership before reuse, then falls back to normal manifest discovery when invalid. Latest-check readers require a supported status and a timestamp with a time zone.

## Issue

Fixes #2226

## Validation

- Reproduced failures with non-object JSON, invalid members, duplicate cached projects, truncated JSON, and invalid UTF-8.
- 123 focused discovery/status tests and 4 subtests passed; the 39-case optional-state suite includes valid-record reuse and preservation of real manifest errors.
- Public project-list/workspace-status regression passed with corrupt cache and history files.
- Changed-file Pylint and `git diff --check` passed. Full local source suite passed: 1,306 Python and 940 BATS/integration tests.
- After integrating preceding fixes, all 39 optional-state cases and both public malformed-input regressions passed. All 20 hosted checks passed on the integrated head, including the full Ubuntu source suite and macOS smoke tests.

## Demo Impact

None. Current project health is independent of unavailable optional history.

## Notes

This change validates optional state structure. Binding check evidence to a particular checkout and manifest remains the next issue in the train (#2227).
