### PR TITLE
fix(workspace): bind latest checks to checkout and manifest identity

### DIFF
--- a/cli/bash/commands/basectl/subcommands/setup_common.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_common.sh
@@ -741,6 +741,7 @@ setup_project_check_record_path() {
 
 setup_record_project_check_result() {
     local checked_at path project="$1" status="$2"
+    local context_args=()
 
     [[ -n "$project" ]] || return 0
     case "$status" in
@@ -755,11 +756,16 @@ setup_record_project_check_result() {
     # Keep external date -u here so persisted JSON records carry explicit UTC
     # without mutating shell TZ; Bash printf time formatting follows local time.
     checked_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" || return 0
+    if [[ -n "${_BASE_SETUP_PROJECT_ARTIFACT_RESOLVED_ROOT:-}" &&
+        -n "${_BASE_SETUP_PROJECT_ARTIFACT_MANIFEST_PATH:-}" ]]; then
+        context_args+=(--project-root "$_BASE_SETUP_PROJECT_ARTIFACT_RESOLVED_ROOT"
+            --manifest-path "$_BASE_SETUP_PROJECT_ARTIFACT_MANIFEST_PATH")
+    fi
     if ! setup_run_diagnostics_json record-check \
         --project "$project" \
         --status "$status" \
         --checked-at "$checked_at" \
-        --output-path "$path" >/dev/null; then
+        --output-path "$path" "${context_args[@]}" >/dev/null; then
         base_std_log_warn \
             "Unable to persist latest check record at '$path'. Ensure the Base state directory is writable and rerun the check."
     fi
@@ -1277,6 +1283,11 @@ setup_run_check_json() {
     if [[ -n "$project" ]]; then
         args+=(--embedded-payload "project_checks" "$project_json")
         args+=(--record-path "$(setup_project_check_record_path "$project")" --checked-at "$checked_at")
+        if [[ -n "${_BASE_SETUP_PROJECT_ARTIFACT_RESOLVED_ROOT:-}" &&
+            -n "${_BASE_SETUP_PROJECT_ARTIFACT_MANIFEST_PATH:-}" ]]; then
+            args+=(--project-root "$_BASE_SETUP_PROJECT_ARTIFACT_RESOLVED_ROOT"
+                --manifest-path "$_BASE_SETUP_PROJECT_ARTIFACT_MANIFEST_PATH")
+        fi
     fi
     setup_run_diagnostics_json "${args[@]}"
 }

--- a/cli/bash/commands/basectl/subcommands/setup_diagnostics_fallback.sh
+++ b/cli/bash/commands/basectl/subcommands/setup_diagnostics_fallback.sh
@@ -78,6 +78,8 @@ setup_diagnostics_fallback_record_warning() {
     printf '}'
 }
 
+# Without the Python identity writer, preserve the legacy optional record format.
+# Workspace readers treat these unbound records as unavailable evidence.
 setup_diagnostics_fallback_record_check() {
     local checked_at="" path="" project="" status="" tmp_path
     # shellcheck disable=SC2034 # base_arg_parse receives caller-owned arrays by name.
@@ -85,6 +87,8 @@ setup_diagnostics_fallback_record_check() {
         "project|value|--project"
         "status|value|--status"
         "checked_at|value|--checked-at"
+        "project_root|value|--project-root"
+        "manifest_path|value|--manifest-path"
         "path|value|--output-path"
     )
     local -a positionals=()
@@ -195,6 +199,8 @@ setup_diagnostics_fallback_json() {
                 "embedded_values|repeatable|--embedded-value"
                 "record_path|value|--record-path"
                 "checked_at|value|--checked-at"
+                "project_root|value|--project-root"
+                "manifest_path|value|--manifest-path"
             )
             local -A parsed_options=()
             local i
@@ -202,7 +208,7 @@ setup_diagnostics_fallback_json() {
             [[ "$command" == doctor-json ]] && item_key="findings"
             while (($#)); do
                 case "$1" in
-                    --project|--record-path|--checked-at)
+                    --project|--record-path|--checked-at|--project-root|--manifest-path)
                         [[ $# -ge 2 ]] || base_std_fatal_error "Option '$1' requires an argument."
                         parser_args+=("$1" "$2")
                         shift 2

--- a/cli/bash/commands/basectl/tests/check.bats
+++ b/cli/bash/commands/basectl/tests/check.bats
@@ -436,7 +436,7 @@ EOF
 
     [ "$status" -eq 0 ]
     [ -f "$record_path" ]
-    grep -Fq '"schema_version": 1' "$record_path"
+    grep -Fq '"schema_version": 2' "$record_path"
     grep -Fq '"project": "demo"' "$record_path"
     grep -Fq '"command": "basectl check"' "$record_path"
     grep -Fq '"status": "ok"' "$record_path"

--- a/cli/bash/commands/basectl/tests/diagnostics_module_fixture.bash
+++ b/cli/bash/commands/basectl/tests/diagnostics_module_fixture.bash
@@ -125,6 +125,7 @@ base_test_diagnostics_merge_status() {
 
 base_test_diagnostics_record_check() {
     local checked_at="" path="" project="" status="" tmp_path
+    local project_root="" manifest_path="" digest="" schema_version=1
 
     while (($#)); do
         case "$1" in
@@ -132,18 +133,38 @@ base_test_diagnostics_record_check() {
             --status) status="${2:-}"; shift 2 ;;
             --checked-at) checked_at="${2:-}"; shift 2 ;;
             --output-path) path="${2:-}"; shift 2 ;;
+            --project-root) project_root="${2:-}"; shift 2 ;;
+            --manifest-path) manifest_path="${2:-}"; shift 2 ;;
             *) return 2 ;;
         esac
     done
+    if [[ -n "$project_root" && -n "$manifest_path" ]]; then
+        if command -v sha256sum >/dev/null 2>&1; then
+            digest="$(sha256sum "$manifest_path")" || return 1
+        else
+            digest="$(shasum -a 256 "$manifest_path")" || return 1
+        fi
+        digest="${digest%% *}"
+        schema_version=2
+    fi
     mkdir -p -- "$(dirname -- "$path")" 2>/dev/null || return 1
     tmp_path="${path}.tmp.$$"
     if ! {
-        printf '{"schema_version":1,"project":'
+        printf '{"schema_version": %s,"project":' "$schema_version"
         base_test_diagnostics_json_string "$project"
         printf ',"command":"basectl check","status":'
         base_test_diagnostics_json_string "$status"
         printf ',"checked_at":'
         base_test_diagnostics_json_string "$checked_at"
+        if [[ "$schema_version" == 2 ]]; then
+            printf ',"identity":{"project_root":'
+            base_test_diagnostics_json_string "$project_root"
+            printf ',"manifest_path":'
+            base_test_diagnostics_json_string "$manifest_path"
+            printf ',"manifest_sha256":'
+            base_test_diagnostics_json_string "$digest"
+            printf '}'
+        fi
         printf '}\n'
     } >"$tmp_path" 2>/dev/null; then
         rm -f -- "$tmp_path"
@@ -225,6 +246,7 @@ base_test_diagnostics_module() {
             return $?
             ;;
         check-json|doctor-json)
+            local context_args=()
             [[ "$command" == doctor-json ]] && item_key="findings"
             while (($#)); do
                 case "$1" in
@@ -245,6 +267,7 @@ base_test_diagnostics_module() {
                         embedded_values+=("${3:-}")
                         shift 3
                         ;;
+                    --project-root|--manifest-path) context_args+=("$1" "$2"); shift 2 ;;
                     --record-path) record_path="${2:-}"; shift 2 ;;
                     --checked-at) checked_at="${2:-}"; shift 2 ;;
                     *) return 2 ;;
@@ -283,7 +306,7 @@ base_test_diagnostics_module() {
             done
             if [[ -n "$record_path" && -n "$project" && -n "$checked_at" && "$command" == check-json ]]; then
                 if ! base_test_diagnostics_record_check \
-                    --project "$project" --status "$status" --checked-at "$checked_at" --output-path "$record_path"; then
+                    --project "$project" --status "$status" --checked-at "$checked_at" --output-path "$record_path" "${context_args[@]}"; then
                     printf ', "record": '
                     base_test_diagnostics_record_warning "$record_path"
                 fi

--- a/cli/python/base_projects/project_discovery.py
+++ b/cli/python/base_projects/project_discovery.py
@@ -16,6 +16,7 @@ from base_projects.workspace_scanner import ProjectNotFoundError
 from base_projects.workspace_scanner import workspace_manifest_entries
 from base_setup.manifest import read_manifest
 from base_setup.manifest_loader import ManifestError
+from base_setup.manifest_schema import COMMAND_NAME_RE
 
 
 @dataclass(frozen=True, order=True)
@@ -92,26 +93,45 @@ def read_project_cache(workspace_root: Path, entries: tuple[ManifestEntry, ...])
     cache_path = project_cache_path(workspace_root)
     try:
         data = json.loads(cache_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeError, json.JSONDecodeError):
         return None
 
-    if data.get("version") != 1 or data.get("workspace") != str(workspace_root):
+    if (
+        not isinstance(data, dict)
+        or not isinstance(data.get("version"), int) or isinstance(data.get("version"), bool)
+    ):
         return None
-    if data.get("manifests") != [manifest_entry_to_json(entry) for entry in entries]:
+    if (
+        data.get("version") != 1 or data.get("workspace") != str(workspace_root)
+        or data.get("manifests") != [manifest_entry_to_json(entry) for entry in entries]
+    ):
         return None
 
+    records = data.get("projects")
+    if not isinstance(records, list) or len(records) != len(entries):
+        return None
     try:
-        projects = tuple(
-            Project(
-                name=project["name"],
-                root=Path(project["root"]),
-                manifest_path=Path(project["manifest_path"]),
-            )
-            for project in data["projects"]
-        )
-    except (KeyError, TypeError):
+        projects = tuple(project_from_cache_record(record) for record in records)
+        expected_paths = {entry.path.resolve() for entry in entries}
+        if {project.manifest_path for project in projects} != expected_paths:
+            raise ValueError("Cached projects do not match discovered manifests.")
+        return validate_unique_project_names(tuple(sorted(projects)))
+    except (KeyError, TypeError, ValueError, ProjectDiscoveryError, OSError):
         return None
-    return validate_unique_project_names(tuple(sorted(projects)))
+
+
+def project_from_cache_record(record: Any) -> Project:
+    if not isinstance(record, dict):
+        raise ValueError("Cached project must be an object.")
+    name, root, manifest_path = (record.get(key) for key in ("name", "root", "manifest_path"))
+    if not isinstance(name, str) or not COMMAND_NAME_RE.fullmatch(name):
+        raise ValueError("Cached project name is invalid.")
+    if not all(isinstance(value, str) and value and "\0" not in value for value in (root, manifest_path)):
+        raise ValueError("Cached project paths are invalid.")
+    root_path, manifest = Path(root), Path(manifest_path)
+    if not root_path.is_absolute() or not manifest.is_absolute() or manifest.parent != root_path:
+        raise ValueError("Cached project paths do not describe a project root and manifest.")
+    return Project(name=name, root=root_path, manifest_path=manifest)
 
 
 def write_project_cache(

--- a/cli/python/base_projects/tests/test_check_record_identity.py
+++ b/cli/python/base_projects/tests/test_check_record_identity.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from base_projects.workspace_checks import WorkspaceProjectCheckResult, persist_workspace_check_records
+from base_projects.workspace_scanner import workspace_manifest_entries
+from base_projects.workspace_statuses import workspace_project_status
+
+
+@pytest.fixture(name="check_projects")
+def check_projects_fixture(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    roots = (tmp_path / "first" / "shared", tmp_path / "second" / "shared")
+    for root in roots:
+        root.mkdir(parents=True)
+        (root / "base_manifest.yaml").write_text("project:\n  name: shared\nartifacts: []\n", encoding="utf-8")
+    entries = tuple(workspace_manifest_entries(root.parent)[0] for root in roots)
+    record = tmp_path / "home" / ".base.d" / "shared" / "checks" / "last.json"
+    return roots, entries, record
+
+
+def persist_result(root):
+    result = WorkspaceProjectCheckResult(
+        name="shared", root=root.resolve(), manifest_path=(root / "base_manifest.yaml").resolve(),
+        manifest="valid", status="ok", checks=(),
+    )
+    assert not persist_workspace_check_records((result,))
+
+
+def test_saved_check_is_only_available_for_its_checkout(check_projects):
+    roots, entries, _record = check_projects
+    persist_result(roots[0])
+
+    assert workspace_project_status(entries[0]).last_check is not None
+    assert workspace_project_status(entries[1]).last_check is None
+
+
+def test_manifest_change_invalidates_saved_check(check_projects):
+    roots, entries, _record = check_projects
+    persist_result(roots[0])
+    with (roots[0] / "base_manifest.yaml").open("a", encoding="utf-8") as stream:
+        stream.write("# A changed manifest needs a new check.\n")
+
+    assert workspace_project_status(entries[0]).last_check is None
+
+
+def test_legacy_check_is_unavailable_until_a_new_check(check_projects):
+    roots, entries, record = check_projects
+    record.parent.mkdir(parents=True)
+    record.write_text(json.dumps({
+        "schema_version": 1, "project": "shared", "status": "ok", "checked_at": "2026-09-12T10:00:00Z",
+    }), encoding="utf-8")
+
+    assert workspace_project_status(entries[0]).last_check is None
+    persist_result(roots[0])
+    assert workspace_project_status(entries[0]).last_check is not None
+
+
+def test_canonical_checkout_alias_matches_saved_check(check_projects, tmp_path):
+    roots, entries, record = check_projects
+    alias = tmp_path / "alias"
+    alias.symlink_to(roots[0], target_is_directory=True)
+    persist_result(alias)
+
+    assert workspace_project_status(entries[0]).last_check is not None
+    identity = json.loads(record.read_text(encoding="utf-8"))["identity"]
+    assert identity["project_root"] == str(roots[0].resolve())
+    assert identity["manifest_path"] == str(entries[0].path.resolve())
+
+
+@pytest.mark.parametrize("identity", [None, [], {}, {"project_root": []}, {"manifest_sha256": "invalid"}])
+def test_malformed_check_identity_is_unavailable(check_projects, identity):
+    roots, entries, record = check_projects
+    persist_result(roots[0])
+    payload = json.loads(record.read_text(encoding="utf-8"))
+    payload["identity"] = identity
+    record.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert workspace_project_status(entries[0]).last_check is None

--- a/cli/python/base_projects/tests/test_engine.py
+++ b/cli/python/base_projects/tests/test_engine.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 from unittest import mock
 
+from base_setup.check_records import CheckRecordContext
 from base_cli_adapters.history import build_finished_record
 from base_cli_adapters.protocol import loads_records
 from base_projects import engine, project_discovery
@@ -69,7 +70,11 @@ def write_last_check(home: Path, project: str, checked_at: str, status: str = "o
     record_path.write_text(
         json.dumps(
             {
-                "schema_version": 1,
+                "schema_version": 2,
+                "identity": CheckRecordContext(
+                    home.parent / "workspace" / project,
+                    home.parent / "workspace" / project / "base_manifest.yaml",
+                ).identity(),
                 "project": project,
                 "command": "basectl check",
                 "status": status,

--- a/cli/python/base_projects/tests/test_optional_json_state.py
+++ b/cli/python/base_projects/tests/test_optional_json_state.py
@@ -9,6 +9,7 @@ from base_projects import project_discovery as discovery
 from base_projects.workspace_report_common import project_last_check
 from base_projects.workspace_scanner import workspace_manifest_entries, ProjectDiscoveryError
 from base_projects.tests.test_workspace_checks import invoke_engine, write_default_manifest
+from base_setup.check_records import CheckRecordContext
 from base_setup.tests.helpers import fake_context
 
 
@@ -33,7 +34,8 @@ def local_state_fixture(tmp_path, monkeypatch):
     record = home / ".base.d" / "demo" / "checks" / "last.json"
     record.parent.mkdir(parents=True)
     record.write_text(json.dumps({
-        "schema_version": 1, "project": "demo", "checked_at": "2026-09-12T10:00:00Z", "status": "ok",
+        "schema_version": 2, "identity": CheckRecordContext(project, project / "base_manifest.yaml").identity(),
+        "project": "demo", "checked_at": "2026-09-12T10:00:00Z", "status": "ok",
     }), encoding="utf-8")
     return home, base, workspace, entries, cache, record
 
@@ -45,7 +47,7 @@ def test_optional_nonobject_and_unreadable_json_is_unavailable(local_state, raw)
     record.write_bytes(raw)
 
     assert discovery.read_project_cache(workspace, entries) is None
-    assert project_last_check("demo") is None
+    assert project_last_check("demo", context=CheckRecordContext(workspace / "demo", entries[0].path)) is None
 
 
 @pytest.mark.parametrize("field,value", [
@@ -81,12 +83,12 @@ def test_invalid_cached_project_fields_fall_back(local_state, field, value):
     ("status", []), ("status", ""), ("status", "success"),
 ])
 def test_invalid_latest_check_members_are_unavailable(local_state, field, value):
-    _home, _base, _workspace, _entries, _cache, record = local_state
+    _home, _base, workspace, entries, _cache, record = local_state
     payload = json.loads(record.read_text(encoding="utf-8"))
     payload[field] = value
     record.write_text(json.dumps(payload), encoding="utf-8")
 
-    assert project_last_check("demo") is None
+    assert project_last_check("demo", context=CheckRecordContext(workspace / "demo", entries[0].path)) is None
 
 
 def test_duplicate_cache_records_trigger_fresh_discovery(local_state):
@@ -133,7 +135,7 @@ def test_valid_optional_records_retain_existing_behavior(local_state):
     projects = discovery.read_project_cache(workspace, entries)
     assert projects is not None
     assert [project.name for project in projects] == ["demo"]
-    last_check = project_last_check("demo")
+    last_check = project_last_check("demo", context=CheckRecordContext(workspace / "demo", entries[0].path))
     assert last_check is not None
     assert last_check.status == "ok"
     assert last_check.checked_at == "2026-09-12T10:00:00Z"

--- a/cli/python/base_projects/tests/test_optional_json_state.py
+++ b/cli/python/base_projects/tests/test_optional_json_state.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from base_projects import project_discovery as discovery
+from base_projects.workspace_report_common import project_last_check
+from base_projects.workspace_scanner import workspace_manifest_entries, ProjectDiscoveryError
+from base_projects.tests.test_workspace_checks import invoke_engine, write_default_manifest
+from base_setup.tests.helpers import fake_context
+
+
+INVALID_JSON = [b"[]", b"null", b"42", b'"value"', b"false", b"{", b"\xff"]
+
+
+@pytest.fixture(name="local_state")
+def local_state_fixture(tmp_path, monkeypatch):
+    home, base, workspace = tmp_path / "home", tmp_path / "base", tmp_path / "workspace"
+    home.mkdir()
+    write_default_manifest(base)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("BASE_CACHE_DIR", str(tmp_path / "cache"))
+    project = workspace / "demo"
+    project.mkdir(parents=True)
+    (project / "base_manifest.yaml").write_text("project:\n  name: demo\nartifacts: []\n", encoding="utf-8")
+    entries = workspace_manifest_entries(workspace)
+    ctx = fake_context()
+    projects = (discovery.read_project(entries[0].path),)
+    discovery.write_project_cache(workspace, entries, projects, ctx)
+    cache = discovery.project_cache_path(workspace)
+    record = home / ".base.d" / "demo" / "checks" / "last.json"
+    record.parent.mkdir(parents=True)
+    record.write_text(json.dumps({
+        "schema_version": 1, "project": "demo", "checked_at": "2026-09-12T10:00:00Z", "status": "ok",
+    }), encoding="utf-8")
+    return home, base, workspace, entries, cache, record
+
+
+@pytest.mark.parametrize("raw", INVALID_JSON)
+def test_optional_nonobject_and_unreadable_json_is_unavailable(local_state, raw):
+    _home, _base, workspace, entries, cache, record = local_state
+    cache.write_bytes(raw)
+    record.write_bytes(raw)
+
+    assert discovery.read_project_cache(workspace, entries) is None
+    assert project_last_check("demo") is None
+
+
+@pytest.mark.parametrize("field,value", [
+    ("projects", None), ("projects", {}), ("projects", []), ("projects", [None]),
+    ("projects", [{"name": [], "root": "/tmp", "manifest_path": "/tmp/base_manifest.yaml"}]),
+    ("version", True),
+])
+def test_invalid_cache_members_fall_back(local_state, field, value):
+    _home, _base, workspace, entries, cache, _record = local_state
+    payload = json.loads(cache.read_text(encoding="utf-8"))
+    payload[field] = value
+    cache.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert discovery.read_project_cache(workspace, entries) is None
+
+
+@pytest.mark.parametrize("field,value", [
+    ("name", {}), ("name", ""), ("name", "../demo"), ("root", 42),
+    ("root", ""), ("manifest_path", ""), ("manifest_path", "\0"),
+])
+def test_invalid_cached_project_fields_fall_back(local_state, field, value):
+    _home, _base, workspace, entries, cache, _record = local_state
+    payload = json.loads(cache.read_text(encoding="utf-8"))
+    payload["projects"][0][field] = value
+    cache.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert discovery.read_project_cache(workspace, entries) is None
+
+
+@pytest.mark.parametrize("field,value", [
+    ("schema_version", True), ("project", []), ("checked_at", []), ("checked_at", ""),
+    ("checked_at", "not-a-date"), ("checked_at", "2026-09-12"),
+    ("status", []), ("status", ""), ("status", "success"),
+])
+def test_invalid_latest_check_members_are_unavailable(local_state, field, value):
+    _home, _base, _workspace, _entries, _cache, record = local_state
+    payload = json.loads(record.read_text(encoding="utf-8"))
+    payload[field] = value
+    record.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert project_last_check("demo") is None
+
+
+def test_duplicate_cache_records_trigger_fresh_discovery(local_state):
+    _home, _base, workspace, _entries, cache, _record = local_state
+    payload = json.loads(cache.read_text(encoding="utf-8"))
+    payload["projects"].append(copy.deepcopy(payload["projects"][0]))
+    cache.write_text(json.dumps(payload), encoding="utf-8")
+
+    projects = discovery.discover_projects_cached(fake_context(), workspace)
+
+    assert [project.name for project in projects] == ["demo"]
+
+
+@pytest.mark.parametrize("raw", INVALID_JSON)
+def test_public_listing_and_status_survive_invalid_optional_state(local_state, raw):
+    home, base, workspace, _entries, cache, record = local_state
+    cache.write_bytes(raw)
+    record.write_bytes(raw)
+
+    result, stdout, stderr = invoke_engine(["list", "--workspace", str(workspace), "--format", "json"], base, home)
+    assert result == 0
+    assert json.loads(stdout)[0]["name"] == "demo"
+    assert "Traceback" not in stderr
+    result, stdout, stderr = invoke_engine(["status", "--workspace", str(workspace), "--format", "json"], base, home)
+    assert result == 0
+    report = json.loads(stdout)
+    assert report["projects"][0]["status"] == "ok"
+    assert report["projects"][0]["last_check"] is None
+    assert "Traceback" not in stderr
+
+
+def test_invalid_cache_does_not_hide_manifest_errors(local_state):
+    _home, _base, workspace, entries, cache, _record = local_state
+    cache.write_text("[]", encoding="utf-8")
+    entries[0].path.write_text("project: {}\n", encoding="utf-8")
+
+    with pytest.raises(ProjectDiscoveryError, match="project.name"):
+        discovery.discover_projects_cached(fake_context(), workspace)
+
+
+def test_valid_optional_records_retain_existing_behavior(local_state):
+    _home, _base, workspace, entries, _cache, _record = local_state
+
+    projects = discovery.read_project_cache(workspace, entries)
+    assert projects is not None
+    assert [project.name for project in projects] == ["demo"]
+    last_check = project_last_check("demo")
+    assert last_check is not None
+    assert last_check.status == "ok"
+    assert last_check.checked_at == "2026-09-12T10:00:00Z"

--- a/cli/python/base_projects/tests/test_workspace_checks.py
+++ b/cli/python/base_projects/tests/test_workspace_checks.py
@@ -492,6 +492,7 @@ class WorkspaceCheckTests(unittest.TestCase):
             write_shell_manifest(workspace / "beta", "beta")
             write_record = workspace_checks.write_check_record
 
+            # pylint: disable-next=too-many-arguments
             def write_partially(
                 path: Path,
                 project: str,
@@ -499,6 +500,7 @@ class WorkspaceCheckTests(unittest.TestCase):
                 checked_at: str,
                 *,
                 command: str,
+                context,
             ) -> bool:
                 if project == "beta":
                     return False
@@ -508,6 +510,7 @@ class WorkspaceCheckTests(unittest.TestCase):
                     result_status,
                     checked_at,
                     command=command,
+                    context=context,
                 )
 
             with mock.patch.object(

--- a/cli/python/base_projects/tests/test_workspace_status_manifest.py
+++ b/cli/python/base_projects/tests/test_workspace_status_manifest.py
@@ -9,6 +9,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest import mock
 
+from base_setup.check_records import CheckRecordContext
 from base_projects import engine
 
 
@@ -31,7 +32,11 @@ def write_last_check(home: Path, project: str, checked_at: str, status: str = "o
     record_path.write_text(
         json.dumps(
             {
-                "schema_version": 1,
+                "schema_version": 2,
+                "identity": CheckRecordContext(
+                    home.parent / "workspace" / project,
+                    home.parent / "workspace" / project / "base_manifest.yaml",
+                ).identity(),
                 "project": project,
                 "command": "basectl check",
                 "status": status,

--- a/cli/python/base_projects/workspace_checks.py
+++ b/cli/python/base_projects/workspace_checks.py
@@ -19,6 +19,7 @@ from base_projects.workspace_repository_url import redact_repository_url
 from base_projects.workspace_scanner import ManifestEntry
 from base_projects.workspace_scanner import workspace_manifest_entries
 from base_projects.workspace_scanner import workspace_repository_paths
+from base_setup.check_records import CheckRecordContext
 from base_setup.checks import ArtifactCheck
 from base_setup.checks import checks_status
 from base_setup.checks import doctor_status
@@ -77,6 +78,7 @@ def persist_workspace_check_records(
                 result.status,
                 checked_at,
                 command=WORKSPACE_CHECK_COMMAND,
+                context=CheckRecordContext(result.root, result.manifest_path) if result.manifest_path else None,
             )
         except OSError:
             written = False

--- a/cli/python/base_projects/workspace_report_common.py
+++ b/cli/python/base_projects/workspace_report_common.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import subprocess
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -44,19 +45,25 @@ def project_last_check(project_name: str) -> ProjectLastCheck | None:
     record_path = base_state_root() / project_name / "checks" / "last.json"
     try:
         payload = json.loads(record_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeError, json.JSONDecodeError):
         return None
 
-    if payload.get("schema_version") != 1:
-        return None
-    if payload.get("project") != project_name:
+    if (
+        not isinstance(payload, dict)
+        or not isinstance(payload.get("schema_version"), int) or isinstance(payload.get("schema_version"), bool)
+        or payload.get("schema_version") != 1 or payload.get("project") != project_name
+    ):
         return None
 
     checked_at = payload.get("checked_at")
     status = payload.get("status")
-    if not isinstance(checked_at, str) or not isinstance(status, str):
+    if not isinstance(checked_at, str) or not isinstance(status, str) or status not in {"ok", "warn", "error"}:
         return None
-    return ProjectLastCheck(checked_at=checked_at, status=status)
+    try:
+        timestamp = datetime.fromisoformat(checked_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return ProjectLastCheck(checked_at=checked_at, status=status) if timestamp.tzinfo is not None else None
 
 
 def workspace_repo_check_details(repo: WorkspaceManifestRepo, root: Path, present: bool) -> dict[str, Any]:

--- a/cli/python/base_projects/workspace_report_common.py
+++ b/cli/python/base_projects/workspace_report_common.py
@@ -10,6 +10,7 @@ from typing import Any
 from base_cli_adapters.paths import base_state_root
 from base_projects.workspace_manifest import WorkspaceManifestRepo
 from base_projects.workspace_repository_url import redact_repository_url
+from base_setup.check_records import CHECK_RECORD_SCHEMA_VERSION, CheckRecordContext
 from base_setup.manifest_model import BaseManifest
 from base_setup.project_routing import route_for_manifest
 
@@ -41,18 +42,22 @@ def project_venv_ready(venv_dir: Path) -> bool:
     return completed.returncode == 0
 
 
-def project_last_check(project_name: str) -> ProjectLastCheck | None:
+def project_last_check(project_name: str, *, context: CheckRecordContext | None = None) -> ProjectLastCheck | None:
     record_path = base_state_root() / project_name / "checks" / "last.json"
     try:
         payload = json.loads(record_path.read_text(encoding="utf-8"))
+        identity = context.identity() if context is not None else None
     except (OSError, UnicodeError, json.JSONDecodeError):
         return None
 
     if (
         not isinstance(payload, dict)
         or not isinstance(payload.get("schema_version"), int) or isinstance(payload.get("schema_version"), bool)
-        or payload.get("schema_version") != 1 or payload.get("project") != project_name
+        or payload.get("schema_version") != CHECK_RECORD_SCHEMA_VERSION or payload.get("project") != project_name
     ):
+        return None
+
+    if identity is None or payload.get("identity") != identity:
         return None
 
     checked_at = payload.get("checked_at")

--- a/cli/python/base_projects/workspace_statuses.py
+++ b/cli/python/base_projects/workspace_statuses.py
@@ -16,6 +16,7 @@ from base_projects.workspace_report_common import project_venv_ready
 from base_projects.workspace_repository_url import redact_repository_url
 from base_projects.workspace_scanner import ManifestEntry
 from base_projects.workspace_scanner import workspace_manifest_entries
+from base_setup.check_records import CheckRecordContext
 from base_setup.manifest import read_manifest
 from base_setup.manifest_loader import ManifestError
 from base_setup.python_runtime import ProjectPythonRuntime
@@ -87,7 +88,7 @@ def workspace_expected_repo_status(
     if entry is not None:
         status = workspace_project_status(entry, probe_venv=probe_venv)
         return attach_status_repo_metadata(status, repo)
-    last_check = project_last_check(repo.name)
+    last_check = None
     if root.exists():
         return WorkspaceProjectStatus(
             name=repo.name,
@@ -165,10 +166,10 @@ def workspace_project_status(entry: ManifestEntry, *, probe_venv: bool = True) -
             venv="unknown",
             manifest="invalid",
             issues=(str(exc),),
-            last_check=project_last_check(root.name),
+            last_check=project_last_check(root.name, context=CheckRecordContext(root, entry.path)),
         )
 
-    last_check = project_last_check(manifest.project_name)
+    last_check = project_last_check(manifest.project_name, context=CheckRecordContext(root, entry.path))
     if not manifest_requires_project_python(manifest):
         return WorkspaceProjectStatus(
             name=manifest.project_name,

--- a/cli/python/base_setup/check_records.py
+++ b/cli/python/base_setup/check_records.py
@@ -1,0 +1,24 @@
+"""Checkout and manifest identity for optional saved check evidence."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CHECK_RECORD_SCHEMA_VERSION = 2
+
+
+@dataclass(frozen=True)
+class CheckRecordContext:
+    project_root: Path
+    manifest_path: Path
+
+    def identity(self) -> dict[str, str]:
+        manifest = self.manifest_path.resolve()
+        return {
+            "project_root": str(self.project_root.resolve()),
+            "manifest_path": str(manifest),
+            "manifest_sha256": hashlib.sha256(manifest.read_bytes()).hexdigest(),
+        }

--- a/cli/python/base_setup/diagnostics.py
+++ b/cli/python/base_setup/diagnostics.py
@@ -20,6 +20,7 @@ from typing import Any, Iterable
 
 import base_cli
 
+from .check_records import CHECK_RECORD_SCHEMA_VERSION, CheckRecordContext
 from .checks import DIAGNOSTIC_JSON_SCHEMA_VERSION
 
 
@@ -255,7 +256,10 @@ def render_project_venv_doctor_payload(
     return compact_json([*checks, project_venv_check_item(status, message, fix)]) + "\n"
 
 
-def render_check_record(project: str, status: str, checked_at: str, *, command: str = "basectl check") -> str:
+def render_check_record(
+    project: str, status: str, checked_at: str, *, command: str = "basectl check",
+    identity: dict[str, str] | None = None,
+) -> str:
     payload = {
         "schema_version": DIAGNOSTIC_JSON_SCHEMA_VERSION,
         "project": project,
@@ -263,9 +267,13 @@ def render_check_record(project: str, status: str, checked_at: str, *, command: 
         "status": validate_status(status),
         "checked_at": checked_at,
     }
+    if identity is not None:
+        payload["schema_version"] = CHECK_RECORD_SCHEMA_VERSION
+        payload["identity"] = identity
     return json.dumps(payload, ensure_ascii=True, indent=2) + "\n"
 
 
+# pylint: disable-next=too-many-arguments
 def write_check_record(
     path: Path,
     project: str,
@@ -273,11 +281,14 @@ def write_check_record(
     checked_at: str,
     *,
     command: str = "basectl check",
+    context: CheckRecordContext | None = None,
 ) -> bool:
     temp_path: Path | None = None
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        if command == "basectl check":
+        if context is not None:
+            record = render_check_record(project, status, checked_at, command=command, identity=context.identity())
+        elif command == "basectl check":
             record = render_check_record(project, status, checked_at)
         else:
             record = render_check_record(project, status, checked_at, command=command)
@@ -371,6 +382,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     check_json = subparsers.add_parser("check-json")
     check_json.add_argument("--project")
+    check_json.add_argument("--project-root", type=Path)
+    check_json.add_argument("--manifest-path", type=Path)
     check_json.add_argument(
         "--check",
         action="append",
@@ -397,6 +410,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     record_check = subparsers.add_parser("record-check")
     record_check.add_argument("--project", required=True)
+    record_check.add_argument("--project-root", type=Path)
+    record_check.add_argument("--manifest-path", type=Path)
     record_check.add_argument("--status", required=True)
     record_check.add_argument("--checked-at", required=True)
     record_check.add_argument("--output-path", required=True)
@@ -419,10 +434,21 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def record_context_from_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> CheckRecordContext | None:
+    if args.command not in {"check-json", "record-check"}:
+        return None
+    if bool(args.project_root) != bool(args.manifest_path):
+        parser.error("--project-root and --manifest-path must be supplied together")
+    if args.project_root is not None:
+        return CheckRecordContext(args.project_root, args.manifest_path)
+    return None
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     exit_code = base_cli.ExitCode.SUCCESS
+    record_context = record_context_from_args(args, parser)
 
     if args.command == "check-json":
         checks = load_diagnostic_checks(args.check, args.check_result_file)
@@ -432,7 +458,7 @@ def main(argv: list[str] | None = None) -> int:
         status = payload_status(payload_object)
         if args.record_path and args.project and args.checked_at:
             record_path = Path(args.record_path)
-            if not write_check_record(record_path, args.project, status, args.checked_at):
+            if not write_check_record(record_path, args.project, status, args.checked_at, context=record_context):
                 payload_object["record"] = check_record_warning(record_path)
                 payload = render_top_level_payload(payload_object)
         print(payload, end="")
@@ -445,7 +471,9 @@ def main(argv: list[str] | None = None) -> int:
         status = payload_status(json.loads(payload))
         exit_code = base_cli.ExitCode.SUCCESS if status != "error" else base_cli.ExitCode.FAILURE
     elif args.command == "record-check":
-        if not write_check_record(Path(args.output_path), args.project, args.status, args.checked_at):
+        if not write_check_record(
+            Path(args.output_path), args.project, args.status, args.checked_at, context=record_context,
+        ):
             exit_code = base_cli.ExitCode.FAILURE
     elif args.command == "base-check-metadata":
         print(render_base_check_metadata(args.name), end="")

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -106,6 +106,21 @@ invalid object, member, timestamp, status, or encoding makes that evidence
 unavailable. Base rescans manifests after an invalid discovery cache, and an
 unavailable latest check does not change current workspace health.
 
+Saved project checks use record schema version `2` and include the canonical
+project root, canonical manifest path, and SHA-256 of the manifest bytes when
+the result is saved. Readers display the record only when all three still
+match. Same-named checkouts therefore cannot display each other's result, and
+any manifest edit makes the previous record unavailable. The per-project-name
+`last.json` path retains only the latest saved result; checking another checkout
+with that name replaces it without transferring its evidence to the first.
+
+Legacy name-only records (including the minimal Bash fallback when Python is
+unavailable) are not verified evidence and appear as an unavailable latest
+check. Run `basectl check --manifest /absolute/project/base_manifest.yaml` or
+`basectl workspace check --workspace /absolute/workspace` to write a new bound
+record. The saved result is historical: it does not verify referenced scripts,
+installed tools, or other files that may have changed since the check.
+
 JSON status output includes a top-level `status` aggregate in addition to each
 project's status. It uses the same status vocabulary and precedence as workspace
 reports: `error` takes precedence over `warn`, which takes precedence over `ok`.

--- a/docs/workspace-manifest.md
+++ b/docs/workspace-manifest.md
@@ -101,6 +101,11 @@ check date in the `LAST CHECK` column, while JSON output includes the full
 timestamp and check status. Projects without a recorded check show `-` in text
 output and `null` in JSON output.
 
+Discovery caches and saved latest-check records are optional local state. An
+invalid object, member, timestamp, status, or encoding makes that evidence
+unavailable. Base rescans manifests after an invalid discovery cache, and an
+unavailable latest check does not change current workspace health.
+
 JSON status output includes a top-level `status` aggregate in addition to each
 project's status. It uses the same status vocabulary and precedence as workspace
 reports: `error` takes precedence over `warn`, which takes precedence over `ok`.

--- a/tests/integration/base_workflows.bats
+++ b/tests/integration/base_workflows.bats
@@ -400,3 +400,24 @@ EOF
     [[ "$output" == *"Workspace setup plan complete: setup=1 skipped=2 failed=0."* ]]
     [[ "$output" == *"[DRY-RUN] No repositories were modified."* ]]
 }
+
+@test "public listing and workspace status recover from malformed optional JSON" {
+    local cache
+    export BASE_CACHE_DIR="$TEST_TMPDIR/optional-cache"
+    run_basectl projects list --workspace "$TEST_WORKSPACE"
+    [ "$status" -eq 0 ]
+    for cache in "$BASE_CACHE_DIR/base/cache/discovery/"*.json; do
+        [ -f "$cache" ]
+        printf '[]\n' > "$cache"
+    done
+    mkdir -p "$TEST_HOME/.base.d/demo/checks"
+    printf '\377' > "$TEST_HOME/.base.d/demo/checks/last.json"
+
+    run_basectl projects list --workspace "$TEST_WORKSPACE" --format json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"name": "demo"'* || "$output" == *'"name":"demo"'* ]]
+    run_basectl workspace status --workspace "$TEST_WORKSPACE" --format json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"last_check": null'* ]]
+    [[ "$output" != *"Traceback"* ]]
+}

--- a/tests/integration/base_workflows.bats
+++ b/tests/integration/base_workflows.bats
@@ -421,3 +421,38 @@ EOF
     [[ "$output" == *'"last_check": null'* ]]
     [[ "$output" != *"Traceback"* ]]
 }
+
+@test "saved check evidence follows the exact checkout and current manifest" {
+    local mode root
+    local first="$TEST_TMPDIR/first/shared"
+    local second="$TEST_TMPDIR/second/shared"
+    for root in "$first" "$second"; do
+        mkdir -p "$root"
+        printf 'project:\n  name: shared\nartifacts: []\n' > "$root/base_manifest.yaml"
+    done
+    for mode in text json; do
+        run_basectl check --ci --manifest "$first/base_manifest.yaml" --format "$mode"
+        [ "$status" -eq 0 ]
+        run "$TEST_INTEGRATION_PYTHON" -c '
+import hashlib, json, pathlib, sys
+record = json.loads(pathlib.Path(sys.argv[1]).read_text())
+root = pathlib.Path(sys.argv[2]).resolve()
+manifest = root / "base_manifest.yaml"
+assert record["schema_version"] == 2
+assert record["identity"] == {"project_root": str(root), "manifest_path": str(manifest),
+    "manifest_sha256": hashlib.sha256(manifest.read_bytes()).hexdigest()}
+' "$TEST_HOME/.base.d/shared/checks/last.json" "$first"
+        [ "$status" -eq 0 ]
+
+        run_basectl workspace status --workspace "$TEST_TMPDIR/first" --format json
+        [ "$status" -eq 0 ]
+        [[ "$output" == *'"checked_at":'* ]]
+        run_basectl workspace status --workspace "$TEST_TMPDIR/second" --format json
+        [ "$status" -eq 0 ]
+        [[ "$output" == *'"last_check": null'* ]]
+    done
+    printf '# Changed since the saved check.\n' >> "$first/base_manifest.yaml"
+    run_basectl workspace status --workspace "$TEST_TMPDIR/first" --format json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"last_check": null'* ]]
+}


### PR DESCRIPTION
## Summary

Saved project checks now include the canonical checkout root, manifest path, and manifest SHA-256. Workspace reports show that historical result only when all three match, preventing a same-named checkout from inheriting another checkout's evidence. A manifest edit invalidates the saved result.

Record schema version 2 carries the identity. Legacy records remain unavailable until a new check writes a bound record. The existing per-project-name latest-record location and optional-persistence behavior are preserved; checking a second checkout replaces the stored record without transferring evidence to the first.

## Issue

Fixes #2227

Includes the optional-state validation merged through #2238 and is integrated with main.

## Validation

- Reproduced cross-checkout aliasing, stale evidence after manifest changes, and legacy-record reuse before the fix.
- 175 focused Python tests and 6 subtests passed, including canonical aliases, malformed identity, optional state, workspace reports, and persistence failure behavior.
- Public text/JSON check regression passed with two same-named checkouts, exact persisted identity, and a subsequent manifest edit.
- Focused check-record Bash fixtures, Pylint, ShellCheck, and `git diff --check` passed. Full local source suite passed: 1,315 Python and 941 BATS/integration tests.
- After integrating preceding fixes, 347 Python tests and 65 subtests plus three public regressions passed. All 20 hosted checks passed on the final head, including the full Ubuntu source suite and macOS validation.

## Demo Impact

Legacy latest-check dates disappear until a new check runs. Current workspace health and check exit codes retain their existing behavior.

## Notes

The manifest digest describes the bytes present when the result is saved. This is historical check evidence, not a claim that every referenced file or installed tool remains unchanged. The minimal Bash fallback retains the legacy unbound format when Python is unavailable.
